### PR TITLE
Cli update

### DIFF
--- a/src/http/controllers/health.rs
+++ b/src/http/controllers/health.rs
@@ -30,10 +30,10 @@ impl Controller for HealthController {
 }
 
 fn health(controller: &ControllerData, _req: &SyncRequest, res: &mut SyncResponse) {
-    build_health_response(res, &controller.config.jet_instance);
+    build_health_response(res, &controller.config.hostname);
 }
 
-pub fn build_health_response(res: &mut SyncResponse, jet_instance: &str) {
+pub fn build_health_response(res: &mut SyncResponse, hostname: &str) {
     res.status(StatusCode::OK)
-        .body(format!("Jet instance \"{}\" is alive and healthy.", jet_instance));
+        .body(format!("Devolutions Gateway \"{}\" is alive and healthy.", hostname));
 }

--- a/src/http/controllers/jet.rs
+++ b/src/http/controllers/jet.rs
@@ -211,7 +211,7 @@ impl ControllerData {
     }
 
     fn health(&self, _req: &SyncRequest, res: &mut SyncResponse) {
-        build_health_response(res, &self.config.jet_instance);
+        build_health_response(res, &self.config.hostname);
     }
 }
 

--- a/src/http/http_server.rs
+++ b/src/http/http_server.rs
@@ -46,8 +46,8 @@ impl HttpServer {
                 info!("Configuring HTTP router");
                 router.add(health).add(jet).add(session)
             })
-            .configure_listener(|list_config| {
-                let listener_config = list_config.set_uri(&config.http_listener_url.to_string());
+            .configure_listener(|listener| {
+                let listener_config = listener.set_uri(&config.api_listener.to_string());
 
                 let cert_config_opt = if let Some(cert_path) = &config.certificate.certificate_file {
                     Some(SslConfig::FilePath(cert_path.into()))

--- a/src/jet_client.rs
+++ b/src/jet_client.rs
@@ -267,7 +267,7 @@ impl HandleAcceptJetMsg {
                 status_code,
                 version: request.version,
                 association,
-                instance: self.config.jet_instance.clone(),
+                instance: self.config.hostname.clone(),
                 timeout: ACCEPT_REQUEST_TIMEOUT_SEC,
             });
             let mut response_msg_buffer = Vec::with_capacity(512);

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -70,7 +70,7 @@ impl Proxy {
         let (mut jet_stream_server, jet_sink_server) = server_transport.split_transport(server_writer, server_reader);
         let (mut jet_stream_client, jet_sink_client) = client_transport.split_transport(client_writer, client_reader);
 
-        if let (Some(pcap_files_path), Some(message_reader)) = (self.config.pcap_files_path.as_ref(), message_reader) {
+        if let (Some(capture_path), Some(message_reader)) = (self.config.capture_path.as_ref(), message_reader) {
             let filename = format!(
                 "{}({})-to-{}({})-at-{}.pcap",
                 client_peer_addr.ip(),
@@ -79,7 +79,7 @@ impl Proxy {
                 server_peer_addr.port(),
                 chrono::Local::now().format("%Y-%m-%d_%H-%M-%S")
             );
-            let mut path = PathBuf::from(pcap_files_path);
+            let mut path = PathBuf::from(capture_path);
             path.push(filename);
 
             let mut interceptor = PcapInterceptor::new(

--- a/src/service.rs
+++ b/src/service.rs
@@ -360,7 +360,7 @@ fn start_tcp_server(
                 "rdp" => RdpClient::new(config.clone(), tls_public_key.clone(), tls_acceptor.clone()).serve(conn),
                 scheme => panic!("Unsupported routing URL scheme {}", scheme),
             }
-        } else if config.rdp {
+        } else if config.is_rdp_supported() {
             RdpClient::new(config.clone(), tls_public_key.clone(), tls_acceptor.clone()).serve(conn)
         } else {
             JetClient::new(config.clone(), jet_associations.clone(), executor_handle.clone())

--- a/src/service.rs
+++ b/src/service.rs
@@ -149,8 +149,8 @@ pub fn create_context(
         .listeners
         .iter()
         .filter_map(|listener| {
-            if listener.url.scheme() == "tcp" {
-                Some(listener.url.clone())
+            if listener.internal_url.scheme() == "tcp" {
+                Some(listener.internal_url.clone())
             } else {
                 None
             }
@@ -161,8 +161,8 @@ pub fn create_context(
         .listeners
         .iter()
         .filter_map(|listener| {
-            if listener.url.scheme() == "ws" || listener.url.scheme() == "wss" {
-                Some(listener.url.clone())
+            if listener.internal_url.scheme() == "ws" || listener.internal_url.scheme() == "wss" {
+                Some(listener.internal_url.clone())
             } else {
                 None
             }


### PR DESCRIPTION
- All env. variable are now DGATEWAY_XYZ

Parameters added:
- farm-name
- application-protocols (only rdp and wayk can be specified for now. Only rdp is used to replace old rdp parameter)

Parameters renamed:
- jet-instance --> hostname

Parameters removed:
- rdp

Parameters updated:
- certificate-file and private-key-file can specify a full path OR a filename and the config path will be added
- listeners has to be defined with * instead of <jet_instance> (example : -l tcp://*:8080,tcp://*:8080)

Other:
- Health check will return the string : "Devolutions Gateway "<hostname>" is alive and healthy."