### PR TITLE
Panic if a configuration file is provided but can't be read or it has a bad format

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -250,8 +250,15 @@ fn get_config_file_path() -> PathBuf {
 
 fn load_config_file(file_path: PathBuf) -> Option<ConfigFile> {
     let file = File::open(file_path.as_path()).ok()?;
-    let result = serde_json::from_reader(BufReader::new(file));
-    result.ok()
+
+    match serde_json::from_reader(BufReader::new(file)) {
+        Ok(config_file) => Some(config_file),
+        Err(e) => panic!(
+            "A configuration file has been provided ({}), but it can't be used: {}",
+            file_path.to_str().unwrap_or("unknown file path"),
+            e
+        ),
+    }
 }
 
 pub fn get_program_data_file_path(filename: &str) -> PathBuf {


### PR DESCRIPTION
Si un fichier est fourni, c'est probablement que l'on veut appliquer cette config. Ainsi, si le fichier de config ne peut être lu ou le format n'est pas bon, il y aura un panic afin d'éviter de démarrer avec des valeurs par défaut.  On imprime l'erreur afin d'orienter les recherches. On aura des erreurs de ce genre : 

`A configuration file has been provided (/etc/devolutions-gateway/gateway.json), but it can't be used: invalid type: string "true", expected a boolean at line 13 column 26', src/config.rs:256:19`

`A configuration file has been provided (/etc/devolutions-gateway/gateway.json), but it can't be used: missing field `Listeners` at line 6 column 1', src/config.rs:256:19`