### PR TITLE
Use tlk.ps1 for build + packaging on all platforms

### DIFF
--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -73,24 +73,34 @@ stages:
               contents: 'CodeSigningCertificateUnsecure.pfx'
 
           - powershell: |
+              $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
+              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
+              $ExecutableFileName = "jetsocat_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
+              $JetsocatExecutable = "$TargetOutputPath/$ExecutableFileName"
+              $CargoPackage = "jetsocat"
+              Write-Host "##vso[task.setvariable variable=PackageVersion]$PackageVersion"
+              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
+              Write-Host "##vso[task.setvariable variable=JetsocatExecutable]$JetsocatExecutable"
+              Write-Host "##vso[task.setvariable variable=CargoPackage]$CargoPackage"
+            displayName: Load dynamic variables
+
+          - powershell: |
               $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
               Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
               Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
             displayName: Import signing certificate
 
-          - powershell: |
-              $version = Get-Content "$(Build.Repository.LocalPath)\VERSION"
-              cargo build --release --package jetsocat
-              mkdir $(Build.StagingDirectory)/windows/x86_64
-              cp target/release/jetsocat.exe $(Build.StagingDirectory)/windows/x86_64/jetsocat_windows_"$version"_x86_64.exe
-            displayName: Building jetsocat
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
-              RUSTFLAGS: '-C target-feature=+crt-static'
-
-          - powershell: |
-              $version = Get-Content "$(Build.Repository.LocalPath)\VERSION"
-              signtool sign /fd SHA256 /v /t http://timestamp.verisign.com/scripts/timstamp.dll $(Build.StagingDirectory)/windows/x86_64/jetsocat_windows_"$version"_x86_64.exe
-            displayName: Signing binary
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
+              JETSOCAT_EXECUTABLE: "$(JetsocatExecutable)"
+              CARGO_PACKAGE: "$(CargoPackage)"
+              SIGNTOOL_NAME: "$(SignToolName)"
+            displayName: Building jetsocat
 
           - task: PublishBuildArtifacts@1
             inputs:
@@ -126,24 +136,34 @@ stages:
               contents: 'CodeSigningCertificateUnsecure.pfx'
 
           - powershell: |
+              $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
+              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
+              $ExecutableFileName = "jetsocat_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
+              $JetsocatExecutable = "$TargetOutputPath/$ExecutableFileName"
+              $CargoPackage = "jetsocat"
+              Write-Host "##vso[task.setvariable variable=PackageVersion]$PackageVersion"
+              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
+              Write-Host "##vso[task.setvariable variable=JetsocatExecutable]$JetsocatExecutable"
+              Write-Host "##vso[task.setvariable variable=CargoPackage]$CargoPackage"
+            displayName: Load dynamic variables
+
+          - powershell: |
               $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
               Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
               Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
             displayName: Import signing certificate
 
-          - powershell: |
-              $version = Get-Content "$(Build.Repository.LocalPath)\VERSION"
-              cargo build --release --target=i686-pc-windows-msvc --package jetsocat
-              mkdir $(Build.StagingDirectory)/windows/x86
-              cp target/i686-pc-windows-msvc/release/jetsocat.exe $(Build.StagingDirectory)/windows/x86/jetsocat_windows_"$version"_x86.exe
-            displayName: Building jetsocat
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
-              RUSTFLAGS: '-C target-feature=+crt-static'
-
-          - powershell: |
-              $version = Get-Content "$(Build.Repository.LocalPath)\VERSION"
-              signtool sign /fd SHA256 /v /t http://timestamp.verisign.com/scripts/timstamp.dll $(Build.StagingDirectory)/windows/x86/jetsocat_windows_"$version"_x86.exe
-            displayName: Signing binary
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
+              JETSOCAT_EXECUTABLE: "$(JetsocatExecutable)"
+              CARGO_PACKAGE: "$(CargoPackage)"
+              SIGNTOOL_NAME: "$(SignToolName)"
+            displayName: Building jetsocat
 
           - task: PublishBuildArtifacts@1
             inputs:

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -31,12 +31,27 @@ stages:
             clean: true
             fetchDepth: 1
 
-          - script: |
-              VERSION=`cat $(Build.Repository.LocalPath)/VERSION`
-              cargo build --release --package jetsocat
-              strip -s target/release/jetsocat
-              mkdir -p $(Build.StagingDirectory)/linux/x86_64
-              cp target/release/jetsocat $(Build.StagingDirectory)/linux/x86_64/jetsocat_linux_${VERSION}_x86_64
+          - powershell: |
+              $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
+              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
+              $ExecutableFileName = "jetsocat_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture)"
+              $JetsocatExecutable = "$TargetOutputPath/$ExecutableFileName"
+              $CargoPackage = "jetsocat"
+              Write-Host "##vso[task.setvariable variable=PackageVersion]$PackageVersion"
+              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
+              Write-Host "##vso[task.setvariable variable=JetsocatExecutable]$JetsocatExecutable"
+              Write-Host "##vso[task.setvariable variable=CargoPackage]$CargoPackage"
+            displayName: Load dynamic variables
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
+            env:
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
+              JETSOCAT_EXECUTABLE: "$(JetsocatExecutable)"
+              CARGO_PACKAGE: "$(CargoPackage)"
             displayName: Building jetsocat
 
           - task: PublishBuildArtifacts@1
@@ -73,6 +88,13 @@ stages:
               contents: 'CodeSigningCertificateUnsecure.pfx'
 
           - powershell: |
+              $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
+              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
+              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
+              Write-Host "##vso[task.setvariable variable=SignToolName]Devolutions"
+            displayName: Import signing certificate
+
+          - powershell: |
               $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
               $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
               $ExecutableFileName = "jetsocat_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
@@ -83,12 +105,6 @@ stages:
               Write-Host "##vso[task.setvariable variable=JetsocatExecutable]$JetsocatExecutable"
               Write-Host "##vso[task.setvariable variable=CargoPackage]$CargoPackage"
             displayName: Load dynamic variables
-
-          - powershell: |
-              $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
-              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
-              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
-            displayName: Import signing certificate
 
           - task: PowerShell@2
             inputs:
@@ -136,6 +152,13 @@ stages:
               contents: 'CodeSigningCertificateUnsecure.pfx'
 
           - powershell: |
+              $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
+              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
+              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
+              Write-Host "##vso[task.setvariable variable=SignToolName]Devolutions"
+            displayName: Import signing certificate
+
+          - powershell: |
               $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
               $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
               $ExecutableFileName = "jetsocat_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
@@ -146,12 +169,6 @@ stages:
               Write-Host "##vso[task.setvariable variable=JetsocatExecutable]$JetsocatExecutable"
               Write-Host "##vso[task.setvariable variable=CargoPackage]$CargoPackage"
             displayName: Load dynamic variables
-
-          - powershell: |
-              $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
-              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
-              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
-            displayName: Import signing certificate
 
           - task: PowerShell@2
             inputs:
@@ -186,12 +203,27 @@ stages:
             clean: true
             fetchDepth: 1
 
-          - script: |
-              VERSION=`cat $(Build.Repository.LocalPath)/VERSION`
-              cargo build --release --package jetsocat
-              strip target/release/jetsocat
-              mkdir -p $(Build.StagingDirectory)/macos/x86_64
-              cp target/release/jetsocat $(Build.StagingDirectory)/macos/x86_64/jetsocat_macos_${VERSION}_x86_64
+          - powershell: |
+              $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
+              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
+              $ExecutableFileName = "jetsocat_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture)"
+              $JetsocatExecutable = "$TargetOutputPath/$ExecutableFileName"
+              $CargoPackage = "jetsocat"
+              Write-Host "##vso[task.setvariable variable=PackageVersion]$PackageVersion"
+              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
+              Write-Host "##vso[task.setvariable variable=JetsocatExecutable]$JetsocatExecutable"
+              Write-Host "##vso[task.setvariable variable=CargoPackage]$CargoPackage"
+            displayName: Load dynamic variables
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
+            env:
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
+              JETSOCAT_EXECUTABLE: "$(JetsocatExecutable)"
+              CARGO_PACKAGE: "$(CargoPackage)"
             displayName: Building jetsocat
 
           - task: PublishBuildArtifacts@1
@@ -220,21 +252,33 @@ stages:
             fetchDepth: 1
 
           - script: |
-              VERSION=`cat $(Build.Repository.LocalPath)/VERSION`
-
               echo "Check formatting"
               cargo fmt --all -- --check
               if ! [ $? -eq 0 ] ; then
                   echo "Bad formatting, please run 'cargo +stable fmt --all'"
                   exit 1
               fi
+            displayName: Checking code format
 
-              conan install openssl/$(OPENSSL_VERSION)@devolutions/stable -g virtualenv -pr linux-x86_64
-              . activate.sh
-              cargo build --release --package devolutions-gateway
-              mkdir -p $(Build.StagingDirectory)/linux/x86_64
-              cp $(Build.Repository.LocalPath)/target/release/devolutions-gateway $(Build.StagingDirectory)/linux/x86_64/devolutions-gateway_linux_${VERSION}_x86_64
-            displayName: Building devolutions-gateway
+          - powershell: |
+              $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
+              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
+              $ExecutableFileName = "DevolutionsGateway_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture)"
+              $DGatewayExecutable = "$TargetOutputPath/$ExecutableFileName"
+              Write-Host "##vso[task.setvariable variable=PackageVersion]$PackageVersion"
+              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
+              Write-Host "##vso[task.setvariable variable=DGatewayExecutable]$DGatewayExecutable"
+            displayName: Load dynamic variables
+
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
+            env:
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
+              DGATEWAY_EXECUTABLE: "$(DGatewayExecutable)"
+            displayName: Building Devolutions Gateway
 
           - task: PublishBuildArtifacts@1
             inputs:
@@ -270,6 +314,13 @@ stages:
               contents: 'CodeSigningCertificateUnsecure.pfx'
 
           - powershell: |
+              $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
+              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
+              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
+              Write-Host "##vso[task.setvariable variable=SignToolName]Devolutions"
+            displayName: Import signing certificate
+
+          - powershell: |
               $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
               $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
               $ExecutableFileName = "DevolutionsGateway_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
@@ -281,13 +332,6 @@ stages:
               Write-Host "##vso[task.setvariable variable=DGatewayExecutable]$DGatewayExecutable"
               Write-Host "##vso[task.setvariable variable=DGatewayPackage]$DGatewayPackage"
             displayName: Load dynamic variables
-
-          - powershell: |
-              $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
-              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
-              Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
-              Write-Host "##vso[task.setvariable variable=SignToolName]Devolutions"
-            displayName: Import signing certificate
 
           - task: PowerShell@2
             inputs:

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -250,6 +250,19 @@ stages:
               contents: 'CodeSigningCertificateUnsecure.pfx'
 
           - powershell: |
+              $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
+              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
+              $ExecutableFileName = DevolutionsGateway_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
+              $PackageFileName = "DevolutionsGateway-$(TargetArchitecture)-${PackageVersion}.msi"
+              $DGatewayExecutable = "$TargetOutputPath/$ExecutableFileName"
+              $DGatewayPackage = "$TargetOutputPath/$PackageFileName"
+              Write-Host "##vso[task.setvariable variable=PackageVersion]$PackageVersion"
+              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
+              Write-Host "##vso[task.setvariable variable=DGatewayExecutable]$DGatewayExecutable"
+              Write-Host "##vso[task.setvariable variable=DGatewayPackage]$DGatewayPackage"
+            displayName: Load dynamic variables
+
+          - powershell: |
               $secureString = ConvertTo-SecureString "$(WINDOWS_SIGNING_PASSPHRASE)" -AsPlainText -Force
               Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\LocalMachine\My -Password $secureString
               Import-PfxCertificate -FilePath CodeSigningCertificateUnsecure.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
@@ -257,23 +270,17 @@ stages:
             displayName: Import signing certificate
 
           - powershell: |
-              $CargoVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
-              $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
-              Write-Host "##vso[task.setvariable variable=CargoVersion]$CargoVersion"
-              Write-Host "##vso[task.setvariable variable=TargetOutputPath]$TargetOutputPath"
               conan install openssl/$(OPENSSL_VERSION)@devolutions/stable -g virtualenv -pr $(TargetPlatform)-$(TargetArchitecture)
               .\activate.ps1
               cargo build --release --package devolutions-gateway
-              mkdir $TargetOutputPath
-              $DGatewayExecutable = "$TargetOutputPath/DevolutionsGateway_$(TargetPlatform)_${CargoVersion}_$(TargetArchitecture).exe"
-              cp $(Build.Repository.LocalPath)/target/release/devolutions-gateway.exe $DGatewayExecutable
-              Write-Host "##vso[task.setvariable variable=DGATEWAY_EXECUTABLE]$DGatewayExecutable"
+              mkdir $(TargetOutputPath)
+              cp $(Build.Repository.LocalPath)/target/release/devolutions-gateway.exe $(DGatewayExecutable)
             displayName: Building devolutions-gateway
             env:
               RUSTFLAGS: '-C target-feature=+crt-static'
 
           - powershell: |
-              signtool sign /fd SHA256 /v /t http://timestamp.verisign.com/scripts/timstamp.dll $(DGATEWAY_EXECUTABLE)
+              signtool sign /fd SHA256 /v /t http://timestamp.verisign.com/scripts/timstamp.dll $(DGatewayExecutable)
             displayName: Signing binary
 
           - task: PowerShell@2
@@ -282,9 +289,8 @@ stages:
               filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
               arguments: package -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
-              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
-              DGATEWAY_EXECUTABLE: "$(DGATEWAY_EXECUTABLE)"
-              DGATEWAY_PACKAGE_FILENAME: "DevolutionsGateway-$(TargetArchitecture)-$(CargoVersion).msi"
+              DGATEWAY_EXECUTABLE: "$(DGatewayExecutable)"
+              DGATEWAY_PACKAGE: "$(DGatewayPackage)"
               SIGNTOOL_NAME: "$(SignToolName)"
             displayName: Creating MSI package
 

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -252,7 +252,7 @@ stages:
           - powershell: |
               $PackageVersion = Get-Content "$(Build.Repository.LocalPath)\VERSION"
               $TargetOutputPath = "$(Build.StagingDirectory)/$(TargetPlatform)/$(TargetArchitecture)"
-              $ExecutableFileName = DevolutionsGateway_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
+              $ExecutableFileName = "DevolutionsGateway_$(TargetPlatform)_${PackageVersion}_$(TargetArchitecture).exe"
               $PackageFileName = "DevolutionsGateway-$(TargetArchitecture)-${PackageVersion}.msi"
               $DGatewayExecutable = "$TargetOutputPath/$ExecutableFileName"
               $DGatewayPackage = "$TargetOutputPath/$PackageFileName"
@@ -269,19 +269,16 @@ stages:
               Write-Host "##vso[task.setvariable variable=SignToolName]Devolutions"
             displayName: Import signing certificate
 
-          - powershell: |
-              conan install openssl/$(OPENSSL_VERSION)@devolutions/stable -g virtualenv -pr $(TargetPlatform)-$(TargetArchitecture)
-              .\activate.ps1
-              cargo build --release --package devolutions-gateway
-              mkdir $(TargetOutputPath)
-              cp $(Build.Repository.LocalPath)/target/release/devolutions-gateway.exe $(DGatewayExecutable)
-            displayName: Building devolutions-gateway
+          - task: PowerShell@2
+            inputs:
+              targetType: 'filePath'
+              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
-              RUSTFLAGS: '-C target-feature=+crt-static'
-
-          - powershell: |
-              signtool sign /fd SHA256 /v /t http://timestamp.verisign.com/scripts/timstamp.dll $(DGatewayExecutable)
-            displayName: Signing binary
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
+              DGATEWAY_EXECUTABLE: "$(DGatewayExecutable)"
+              SIGNTOOL_NAME: "$(SignToolName)"
+            displayName: Building Devolutions Gateway
 
           - task: PowerShell@2
             inputs:
@@ -289,10 +286,11 @@ stages:
               filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
               arguments: package -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
+              TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
               DGATEWAY_EXECUTABLE: "$(DGatewayExecutable)"
               DGATEWAY_PACKAGE: "$(DGatewayPackage)"
               SIGNTOOL_NAME: "$(SignToolName)"
-            displayName: Creating MSI package
+            displayName: Packaging Devolutions Gateway
 
           - task: PublishBuildArtifacts@1
             inputs:

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -46,7 +46,7 @@ stages:
           - task: PowerShell@2
             inputs:
               targetType: 'filePath'
-              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              filePath: $(System.DefaultWorkingDirectory)/ci/tlk.ps1
               arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
               TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
@@ -218,7 +218,7 @@ stages:
           - task: PowerShell@2
             inputs:
               targetType: 'filePath'
-              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              filePath: $(System.DefaultWorkingDirectory)/ci/tlk.ps1
               arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
               TARGET_OUTPUT_PATH: "$(TargetOutputPath)"
@@ -273,7 +273,7 @@ stages:
           - task: PowerShell@2
             inputs:
               targetType: 'filePath'
-              filePath: $(System.DefaultWorkingDirectory)\ci\tlk.ps1
+              filePath: $(System.DefaultWorkingDirectory)/ci/tlk.ps1
               arguments: build -Platform $(TargetPlatform) -Architecture $(TargetArchitecture)
             env:
               TARGET_OUTPUT_PATH: "$(TargetOutputPath)"

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -219,14 +219,9 @@ class TlkRecipe
             & 'cscript.exe' "/nologo" "WiLangId.vbs" "$($this.PackageName).msi" "Package" "1033,1036"
         }
 
-        if (Test-Path Env:TARGET_OUTPUT_PATH) {
-            $TargetOutputPath = $Env:TARGET_OUTPUT_PATH
-            $PackageFileName = "$($this.PackageName).msi"
-            if (Test-Path Env:DGATEWAY_PACKAGE_FILENAME) {
-                $PackageFileName = $Env:DGATEWAY_PACKAGE_FILENAME
-            }
-            $TargetPackageFile = $(Join-Path $TargetOutputPath $PackageFileName)
-            Copy-Item -Path "$($this.PackageName).msi" -Destination $TargetPackageFile
+        if (Test-Path Env:DGATEWAY_PACKAGE) {
+            $DGatewayPackage = $Env:DGATEWAY_PACKAGE
+            Copy-Item -Path "$($this.PackageName).msi" -Destination $DGatewayPackage
 
             if (Test-Path Env:SIGNTOOL_NAME) {
                 $SignToolName = $Env:SIGNTOOL_NAME
@@ -235,7 +230,7 @@ class TlkRecipe
                     'sign', '/fd', 'SHA256', '/v',
                     '/n', $SignToolName,
                     '/t', $TimestampServer,
-                    $TargetPackageFile
+                    $DGatewayPackage
                 )
                 & 'signtool' $SignToolArgs
             }

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -143,7 +143,7 @@ class TlkRecipe
         Push-Location
         Set-Location $this.SourcePath
 
-        $CargoArgs = @('cargo', 'build', '--release')
+        $CargoArgs = @('build', '--release')
         $CargoArgs += @('--package', 'devolutions-gateway')
 
         & 'cargo' $CargoArgs

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -144,15 +144,19 @@ class TlkRecipe
             $BuildStagingDirectory = $Env:TARGET_OUTPUT_PATH
         }
 
-        & 'conan' 'install' $ConanPackage '-g' 'virtualenv' '-pr' $ConanProfile
-        $dotenv = Get-DotEnvFile ".\environment.sh.env"
-    
-        Get-ChildItem 'conanbuildinfo.*' | Remove-Item
-        Get-ChildItem 'environment.*.env' | Remove-Item
-        Get-ChildItem '*activate.*' | Remove-Item
-    
-        $OPENSSL_DIR = $dotenv['OPENSSL_DIR']
-        $Env:OPENSSL_DIR = $OPENSSL_DIR
+        if (-Not $this.Target.IsMacOS()) {
+            # FIXME: this fails on CI build machines for macOS, maybe conan is outdated?
+            
+            & 'conan' 'install' $ConanPackage '-g' 'virtualenv' '-pr' $ConanProfile
+            $dotenv = Get-DotEnvFile ".\environment.sh.env"
+        
+            Get-ChildItem 'conanbuildinfo.*' | Remove-Item
+            Get-ChildItem 'environment.*.env' | Remove-Item
+            Get-ChildItem '*activate.*' | Remove-Item
+        
+            $OPENSSL_DIR = $dotenv['OPENSSL_DIR']
+            $Env:OPENSSL_DIR = $OPENSSL_DIR
+        }
     
         if ($this.Target.IsWindows()) {
             $Env:RUSTFLAGS = "-C target-feature=+crt-static"

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -107,7 +107,7 @@ class TlkTarget
             "android" { "linux-android" }
         }
 
-        "${CargoArchitecture}-${CargoPlatform}"
+        return "${CargoArchitecture}-${CargoPlatform}"
     }
 }
 


### PR DESCRIPTION
Refactor azure-pipelines.yaml to use tlk.ps1 as much as possible, with highly regular YAML sections using as much variables as possible. I guess we could come up with reusable YAML templates in the end and avoid copy/pasting the almost-identical sections we now have.