### PR TITLE
WAYK 2256: jetsocat proxy support for SOCKS4, SOCKS4a, SOCKS5 and SOCKS5H

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
  "num-derive 0.2.5",
  "num-traits",
  "objc",
- "system-configuration-sys",
+ "system-configuration-sys 0.4.1",
  "systemd-rs",
  "timer",
  "widestring",
@@ -500,6 +500,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+dependencies = [
+ "core-foundation-sys 0.6.2",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
@@ -517,6 +527,12 @@ dependencies = [
  "core-foundation-sys 0.8.2",
  "libc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1471,6 +1487,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "jetsocat-proxy",
+ "proxy_cfg",
  "seahorse",
  "slog",
  "slog-async",
@@ -2292,6 +2309,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
+]
+
+[[package]]
+name = "proxy_cfg"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2fc88689c67c50b7d78763f338bc227a1ab58322b97ccc5b5cb7ef70536652"
+dependencies = [
+ "core-foundation 0.6.4",
+ "system-configuration-sys 0.3.0",
+ "url 2.2.0",
+ "winapi 0.3.9",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -3224,6 +3254,16 @@ dependencies = [
 
 [[package]]
 name = "system-configuration-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd906a2882d54084bfdf517bf03892ac06820f1c0a3d37e48609f334798ad99"
+dependencies = [
+ "core-foundation-sys 0.6.2",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269e271436d8e4bb2621c535a11fe03d5d012f74b19af72f80288f3a72f6180a"
@@ -4152,6 +4192,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.9",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,19 +113,19 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-tungstenite"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7cc5408453d37e2b1c6f01d8078af1da58b6cfa6a80fa2ede3bd2b9a6ada9c4"
+checksum = "e00550829ef8e2c4115250d0ee43305649b0fa95f78a32ce5b07da0b73d95c5c"
 dependencies = [
  "futures-io",
  "futures-util",
  "log",
  "native-tls",
- "pin-project 1.0.2",
+ "pin-project-lite 0.2.0",
  "tokio 1.0.1",
  "tokio-native-tls 0.3.0",
  "tokio-rustls 0.22.0",
- "tungstenite",
+ "tungstenite 0.12.0",
  "webpki-roots",
 ]
 
@@ -1081,6 +1081,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,6 +1386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
  "bytes 0.5.6",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes 1.0.0",
 ]
 
 [[package]]
@@ -2336,11 +2356,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2364,6 +2396,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,7 +2426,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -2403,6 +2454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2479,7 +2539,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -3633,7 +3693,7 @@ dependencies = [
  "pin-project 1.0.2",
  "tokio 0.3.6",
  "tokio-native-tls 0.2.0",
- "tungstenite",
+ "tungstenite 0.11.1",
 ]
 
 [[package]]
@@ -3727,10 +3787,30 @@ dependencies = [
  "bytes 0.5.6",
  "http 0.2.2",
  "httparse",
- "input_buffer",
+ "input_buffer 0.3.1",
  "log",
  "native-tls",
  "rand 0.7.3",
+ "sha-1",
+ "url 2.2.0",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.0.0",
+ "http 0.2.2",
+ "httparse",
+ "input_buffer 0.4.0",
+ "log",
+ "native-tls",
+ "rand 0.8.2",
  "sha-1",
  "url 2.2.0",
  "utf-8",
@@ -4011,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
+checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
 dependencies = [
  "webpki",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,10 +1450,18 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
+ "jetsocat-proxy",
  "seahorse",
  "slog",
  "slog-async",
  "slog-term",
+ "tokio 1.0.1",
+]
+
+[[package]]
+name = "jetsocat-proxy"
+version = "0.1.0"
+dependencies = [
  "tokio 1.0.1",
 ]
 
@@ -3397,6 +3405,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.0",
  "signal-hook-registry",
+ "tokio-macros 1.0.0",
  "winapi 0.3.9",
 ]
 
@@ -3471,6 +3480,17 @@ name = "tokio-macros"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "syn 1.0.57",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ default-members = [
 [patch.crates-io]
 rustls = { git = "https://github.com/Devolutions/rustls.git", branch = "v0.18.1-patched", features = ["dangerous_configuration"] }
 
+[profile.release]
+lto = true
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "devolutions-gateway",
     "jet-proto",
     "jetsocat",
+    "jetsocat/proxy",
     "benchmark",
     "tools/*"
 ]

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.0", features = ["io-std", "io-util", "net", "rt", "sync",
 futures-util = "0.3"
 futures-channel = "0.3"
 futures-io = "0.3"
-async-tungstenite = "0.11"
+async-tungstenite = "0.12"
 
 # logging
 slog = "2.5"

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -13,6 +13,8 @@ native-tls = ["async-tungstenite/tokio-native-tls"]
 
 [dependencies]
 
+jetsocat-proxy = { path = "./proxy" }
+
 # cli
 seahorse = "1.1"
 

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -6,14 +6,17 @@ edition = "2018"
 description = "WebSocket toolkit for jet protocol related operations"
 
 [features]
-default = ["rustls"]
+default = ["rustls", "detect-proxy"]
 verbose = ["slog/max_level_trace"]
+detect-proxy = ["proxy_cfg"]
 rustls = ["async-tungstenite/tokio-rustls"]
 native-tls = ["async-tungstenite/tokio-native-tls"]
 
 [dependencies]
 
+# proxy support
 jetsocat-proxy = { path = "./proxy" }
+proxy_cfg = { version = "0.3.6", optional = true }
 
 # cli
 seahorse = "1.1"

--- a/jetsocat/proxy/Cargo.toml
+++ b/jetsocat/proxy/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "jetsocat-proxy"
+version = "0.1.0"
+authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
+edition = "2018"
+description = "SOCKS proxy clients implementation for jetsocat"
+
+[dependencies]
+tokio = { version = "1", features = ["io-util"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["io-util", "rt", "macros", "net"] }
+

--- a/jetsocat/proxy/README.md
+++ b/jetsocat/proxy/README.md
@@ -1,0 +1,36 @@
+# SOCKS4, SOCKS4a, SOCKS5, SOCKS5H, HTTPS implementation for jetsocat
+
+## Testing
+
+Offline tests can be performed using standard `cargo test` command.
+
+Advanced tests are provided as additional binaries.
+For these, a running proxy server is required with specific configurations.
+
+### No authentication method testing
+
+Setup a proxy server permitting all connections (no authentication required).
+Using CCProxy all you need is to open `Account Manager` pop-up and set `Permit Category` to `Permit All`.
+
+Let's assume proxy address for SOCKS is `192.168.122.70:1080`.
+
+SOCKS tests are run by running
+
+```
+cargo run --bin socks_test -- --addr 192.168.122.70:1080
+```
+
+### Username/Password authentication method testing
+
+Setup a proxy server permitting only connection with a valid username / password pair.
+Using CCProxy, open `Account Manager` pop-up, set `Permit Category` to `Permit Only` and `Auth Type` to `User/Password`.
+You also need to have a user account with a password. Make sure no other restriction are enabled (untick `IP Address/IP Range`, `MAC Address/Hostname`…).
+
+Let's assume proxy address for SOCKS is `192.168.122.70:1080` and credential pair is `username`/`password`.
+
+SOCKS tests are run by running
+
+```
+cargo run --bin socks_test -- --addr 192.168.122.70:1080 --pass username --pass password
+```
+

--- a/jetsocat/proxy/src/bin/socks_test.rs
+++ b/jetsocat/proxy/src/bin/socks_test.rs
@@ -1,0 +1,177 @@
+use jetsocat_proxy::socks5::Socks5Stream;
+use std::collections::HashMap;
+use std::env;
+use std::io;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+macro_rules! test {
+    ( $test:expr ) => {{
+        let expr_str = stringify!($test);
+        let parenthesis_idx = expr_str.find('(').unwrap_or(expr_str.len());
+        let test_name = &expr_str[..parenthesis_idx];
+
+        println!("⇢ test `{}` ...", test_name);
+        let res = ::std::panic::catch_unwind(|| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async { $test });
+        });
+        match res {
+            Ok(()) => println!("◉ test `{}` succeeded!\n", test_name),
+            Err(_) => println!("✗ test `{}` failed!\n", test_name),
+        }
+    }};
+    ($( $test:expr ; )+) => {{
+        $( test!( $test ); )+
+    }}
+}
+
+const GOOGLE_ADDR: &str = "google.com:80";
+const USAGE: &str = "--addr <PROXY_ADDR> [--pass <PASSWORD> --user <USERNAME>]";
+
+fn usage() {
+    let prgm_name = env::args().next().unwrap();
+    println!("Usage: {} {}", prgm_name, USAGE);
+}
+
+fn parse_args() -> HashMap<String, String> {
+    let mut args = HashMap::new();
+    let mut iter = env::args().skip(1);
+    loop {
+        match (iter.next(), iter.next()) {
+            (Some(key), Some(value)) => {
+                args.insert(key, value);
+            }
+            (None, None) => break,
+            _ => {
+                eprintln!("Invalid argument");
+                usage();
+                std::process::exit(1);
+            }
+        }
+    }
+    args
+}
+
+trait OkOrUsage {
+    type T;
+    fn ok_or_usage(self, msg: &str) -> Self::T;
+}
+
+impl<T> OkOrUsage for Option<T> {
+    type T = T;
+
+    fn ok_or_usage(self, msg: &str) -> Self::T {
+        match self {
+            Some(v) => v,
+            None => {
+                eprintln!("{}", msg);
+                usage();
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+fn main() {
+    let args = parse_args();
+
+    let addr = args.get("--addr").ok_or_usage("argument --addr is missing");
+
+    if let (Some(username), Some(password)) = (args.get("--user"), args.get("--pass")) {
+        password::test(addr, username, password);
+    } else {
+        no_password::test(addr);
+    }
+}
+
+async fn ping_google<S>(mut stream: S)
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    stream.write_all(b"GET / HTTP/1.0\r\n\r\n").await.unwrap();
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await.unwrap();
+    assert!(buf.starts_with(b"HTTP/1.0"));
+    assert!(buf.ends_with(b"</HTML>\r\n") || buf.ends_with(b"</html>"));
+}
+
+async fn socks5_connect(addr: &str) -> io::Result<Socks5Stream<TcpStream>> {
+    let socket = TcpStream::connect(addr).await?;
+    Socks5Stream::connect(socket, GOOGLE_ADDR).await
+}
+
+async fn socks5_connect_with_password(
+    addr: &str,
+    username: &str,
+    password: &str,
+) -> io::Result<Socks5Stream<TcpStream>> {
+    let socket = TcpStream::connect(addr).await?;
+    Socks5Stream::connect_with_password(socket, GOOGLE_ADDR, username, password).await
+}
+
+mod no_password {
+    use super::*;
+
+    use jetsocat_proxy::socks4::Socks4Stream;
+
+    pub fn test(addr: &str) {
+        test! {
+            socks5_no_auth_connect(addr).await;
+            socks5_unrequired_username_password_pair(addr).await;
+            socks4_connect(addr).await;
+        }
+    }
+
+    async fn socks5_no_auth_connect(addr: &str) {
+        let stream = socks5_connect(addr).await.unwrap();
+        crate::ping_google(stream).await;
+    }
+
+    async fn socks4_connect(addr: &str) {
+        let socket = TcpStream::connect(addr).await.unwrap();
+        let stream = Socks4Stream::connect(socket, GOOGLE_ADDR, "david").await.unwrap();
+        crate::ping_google(stream).await;
+    }
+
+    async fn socks5_unrequired_username_password_pair(addr: &str) {
+        let stream = socks5_connect_with_password(addr, "xxxxxxxxxxx", "xxxxxxxxxxx")
+            .await
+            .unwrap();
+        crate::ping_google(stream).await;
+    }
+}
+
+mod password {
+    use super::*;
+
+    pub fn test(addr: &str, username: &str, password: &str) {
+        test! {
+            socks5_with_password(addr, username, password).await;
+            socks5_incorrect_password(addr).await;
+            socks5_auth_method_not_supported(addr).await;
+        }
+    }
+
+    async fn socks5_with_password(addr: &str, username: &str, password: &str) {
+        let stream = socks5_connect_with_password(addr, username, password).await.unwrap();
+        crate::ping_google(stream).await;
+    }
+
+    async fn socks5_incorrect_password(addr: &str) {
+        let err = socks5_connect_with_password(addr, "xxxxxxxxxxx", "xxxxxxxxxxx")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert_eq!(err.to_string(), "password authentication failed");
+    }
+
+    async fn socks5_auth_method_not_supported(addr: &str) {
+        let err = socks5_connect(addr).await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert_eq!(err.to_string(), "no acceptable auth method");
+    }
+}

--- a/jetsocat/proxy/src/lib.rs
+++ b/jetsocat/proxy/src/lib.rs
@@ -1,0 +1,117 @@
+pub mod https;
+pub mod socks4;
+pub mod socks5;
+
+#[cfg(test)]
+pub mod test_utils;
+
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DestAddr {
+    Ip(SocketAddr),
+    Domain(String, u16),
+}
+
+impl DestAddr {
+    pub fn as_ip(&self) -> Option<SocketAddr> {
+        match self {
+            DestAddr::Ip(ip) => Some(*ip),
+            _ => None,
+        }
+    }
+    
+    pub fn as_domain(&self) -> Option<(&str, u16)> {
+        match self {
+            DestAddr::Domain(dns, port) => Some((&dns, *port)),
+            _ => None,
+        }
+    }
+}
+
+/// A trait to convert to `TargetAddr` (destination) similar to `std::net::ToSocketAddrs`
+pub trait ToDestAddr {
+    fn to_dest_addr(&self) -> io::Result<DestAddr>;
+}
+
+impl ToDestAddr for DestAddr {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        Ok(self.clone())
+    }
+}
+
+impl ToDestAddr for SocketAddr {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        Ok(DestAddr::Ip(*self))
+    }
+}
+
+impl ToDestAddr for SocketAddrV4 {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        Ok(DestAddr::Ip(SocketAddr::V4(*self)))
+    }
+}
+
+impl ToDestAddr for SocketAddrV6 {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        Ok(DestAddr::Ip(SocketAddr::V6(*self)))
+    }
+}
+
+impl ToDestAddr for (Ipv4Addr, u16) {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        Ok(DestAddr::Ip(SocketAddr::V4(SocketAddrV4::new(self.0, self.1))))
+    }
+}
+
+impl ToDestAddr for (Ipv6Addr, u16) {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        Ok(DestAddr::Ip(SocketAddr::V6(SocketAddrV6::new(self.0, self.1, 0, 0))))
+    }
+}
+
+impl<'a> ToDestAddr for (&'a str, u16) {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        if let Ok(addr) = self.0.parse::<Ipv4Addr>() {
+            return (addr, self.1).to_dest_addr();
+        }
+
+        if let Ok(addr) = self.0.parse::<Ipv6Addr>() {
+            return (addr, self.1).to_dest_addr();
+        }
+
+        Ok(DestAddr::Domain(self.0.to_owned(), self.1))
+    }
+}
+
+impl<'a> ToDestAddr for &'a str {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        if let Ok(addr) = self.parse::<SocketAddrV4>() {
+            return addr.to_dest_addr();
+        }
+
+        if let Ok(addr) = self.parse::<SocketAddrV6>() {
+            return addr.to_dest_addr();
+        }
+
+        let parts: Vec<&str> = self.rsplitn(2, ':').collect();
+
+        if parts.len() < 2 {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "bad socket address format"));
+        }
+
+        let host = parts[1].to_owned();
+        let port = parts[0]
+            .parse()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid port value: {}", e)))?;
+
+        Ok(DestAddr::Domain(host, port))
+    }
+}
+
+impl<T: ToDestAddr + ?Sized> ToDestAddr for &T {
+    fn to_dest_addr(&self) -> io::Result<DestAddr> {
+        (**self).to_dest_addr()
+    }
+}

--- a/jetsocat/proxy/src/lib.rs
+++ b/jetsocat/proxy/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod https;
 pub mod socks4;
 pub mod socks5;
 
@@ -21,7 +20,7 @@ impl DestAddr {
             _ => None,
         }
     }
-    
+
     pub fn as_domain(&self) -> Option<(&str, u16)> {
         match self {
             DestAddr::Domain(dns, port) => Some((&dns, *port)),

--- a/jetsocat/proxy/src/socks4.rs
+++ b/jetsocat/proxy/src/socks4.rs
@@ -1,0 +1,204 @@
+use crate::{DestAddr, ToDestAddr};
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::pin::Pin;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// SOCKS4 CONNECT client.
+#[derive(Debug)]
+pub struct Socks4Stream<S> {
+    inner: S,
+    dest_addr: SocketAddrV4,
+}
+
+impl<S> Socks4Stream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Initiates a CONNECT request to the specified proxy.
+    pub async fn connect(mut stream: S, dest: impl ToDestAddr, userid: &str) -> io::Result<Self> {
+        let dest = dest.to_dest_addr()?;
+
+        // SOCKS request
+        write_socks_request(&mut stream, &dest, userid).await?;
+
+        // SOCKS reply
+        let dest_addr = read_socks_reply(&mut stream).await?;
+
+        Ok(Socks4Stream {
+            inner: stream,
+            dest_addr,
+        })
+    }
+
+    /// Returns the destination address that the proxy server connects to.
+    pub fn dest_addr(&self) -> SocketAddrV4 {
+        self.dest_addr
+    }
+}
+
+impl<S> AsyncRead for Socks4Stream<S>
+where
+    S: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for Socks4Stream<S>
+where
+    S: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+async fn write_socks_request<S>(stream: &mut S, dest: &DestAddr, userid: &str) -> io::Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    // https://www.openssh.com/txt/socks4.protocol
+    //             +----+----+----+----+----+----+----+----+----+----+....+----+
+    //             | VN | CD | DSTPORT |      DSTIP        | USERID       |NULL|
+    //             +----+----+----+----+----+----+----+----+----+----+....+----+
+    // # of bytes:   1    1      2              4           variable       1
+    //
+    // VN is the SOCKS protocol version number and should be 4. CD is the
+    // SOCKS command code and should be 1 for CONNECT request. NULL is a byte
+    // of all zero bits.
+
+    let mut packet = vec![
+        4, // version
+        1, // command (1 = CONNECT)
+    ];
+
+    match dest {
+        DestAddr::Ip(SocketAddr::V4(addr)) => {
+            packet.extend_from_slice(&addr.port().to_be_bytes());
+            packet.extend_from_slice(&u32::from(*addr.ip()).to_be_bytes());
+            packet.extend_from_slice(userid.as_bytes());
+            packet.push(0);
+        }
+        DestAddr::Ip(SocketAddr::V6(_)) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SOCKS4 does not support IPv6",
+            ));
+        }
+        DestAddr::Domain(domain, port) => {
+            packet.extend_from_slice(&port.to_be_bytes());
+            packet.extend_from_slice(&u32::from(Ipv4Addr::new(0, 0, 0, 1)).to_be_bytes());
+            packet.extend_from_slice(userid.as_bytes());
+            packet.push(0);
+            packet.extend_from_slice(domain.as_bytes());
+            packet.push(0);
+        }
+    }
+
+    stream.write_all(&packet).await?;
+
+    Ok(())
+}
+
+async fn read_socks_reply<S>(stream: &mut S) -> io::Result<SocketAddrV4>
+where
+    S: AsyncRead + Unpin,
+{
+    // https://www.openssh.com/txt/socks4.protocol
+    //	        	+----+----+----+----+----+----+----+----+
+    //	        	| VN | CD | DSTPORT |      DSTIP        |
+    //	        	+----+----+----+----+----+----+----+----+
+    // # of bytes:	   1    1      2              4
+    //
+    // VN is the version of the reply code and should be 0. CD is the result code.
+
+    if stream.read_u8().await? != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "invalid version of reply code",
+        ));
+    }
+
+    match stream.read_u8().await? {
+        90 => {}
+        91 => return Err(io::Error::new(io::ErrorKind::Other, "request rejected or failed")),
+        92 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "request rejected because SOCKS server cannot connect to identd on the client",
+            ))
+        }
+        93 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "request rejected because the client program and identd report different user-ids",
+            ))
+        }
+        _ => return Err(io::Error::new(io::ErrorKind::Other, "invalid result code")),
+    }
+
+    let port = stream.read_u16().await?;
+    let ip = stream.read_u32().await?;
+
+    Ok(SocketAddrV4::new(Ipv4Addr::from(ip), port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::AsyncStdIo;
+
+    async fn assert_encoding(addr: DestAddr, userid: &str, encoded: &[u8]) {
+        let mut buf = Vec::new();
+        let mut writer = AsyncStdIo(&mut buf);
+        write_socks_request(&mut writer, &addr, userid).await.unwrap();
+        assert_eq!(buf.as_slice(), encoded);
+    }
+
+    #[tokio::test]
+    async fn ipv4_addr() {
+        assert_encoding(
+            "192.168.0.39:80".to_dest_addr().unwrap(),
+            "david",
+            &[4, 1, 0, 80, 192, 168, 0, 39, 100, 97, 118, 105, 100, 0],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn domain_addr() {
+        assert_encoding(
+            "devolutions.net:80".to_dest_addr().unwrap(),
+            "david",
+            &[
+                4, 1, 0, 80, 0, 0, 0, 1, 100, 97, 118, 105, 100, 0, 100, 101, 118, 111, 108, 117, 116, 105, 111, 110,
+                115, 46, 110, 101, 116, 0,
+            ],
+        )
+        .await;
+    }
+}

--- a/jetsocat/proxy/src/socks5.rs
+++ b/jetsocat/proxy/src/socks5.rs
@@ -211,7 +211,7 @@ where
                 // as per RFC server should send 0xFF as method if none of the methods
                 // listed by client are acceptable.
                 // However some implementation ignores this (ie: CCProxy 8.0).
-                return Err(io::Error::new(io::ErrorKind::Other, "no acceptable auth method"))
+                return Err(io::Error::new(io::ErrorKind::Other, "no acceptable auth method"));
             }
             _ => {
                 return Err(io::Error::new(

--- a/jetsocat/proxy/src/socks5.rs
+++ b/jetsocat/proxy/src/socks5.rs
@@ -1,0 +1,465 @@
+use crate::{DestAddr, ToDestAddr};
+use std::convert::TryFrom;
+use std::io::{self, Write};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+use std::pin::Pin;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+const MAX_ADDR_LEN: usize = 260;
+const METHOD_NO_AUTH_REQUIRED: u8 = 0x00;
+const METHOD_USERNAME_PASSWORD: u8 = 0x02;
+
+/// SOCKS5 CONNECT client.
+#[derive(Debug)]
+pub struct Socks5Stream<S> {
+    inner: S,
+    dest_addr: DestAddr,
+}
+
+impl<S> Socks5Stream<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Initiates a CONNECT request to the specified proxy.
+    pub async fn connect(stream: S, dest: impl ToDestAddr) -> io::Result<Self> {
+        connect_impl(Command::Connect, stream, dest, AuthMethod::None).await
+    }
+
+    /// Initiates a CONNECT request to the specified proxy with username and password.
+    pub async fn connect_with_password(
+        stream: S,
+        dest: impl ToDestAddr,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> io::Result<Self> {
+        connect_impl(
+            Command::Connect,
+            stream,
+            dest,
+            AuthMethod::Password {
+                username: username.into(),
+                password: password.into(),
+            },
+        )
+        .await
+    }
+
+    /// Returns the destination address that the proxy server connects to.
+    pub fn dest_addr(&self) -> &DestAddr {
+        &self.dest_addr
+    }
+}
+
+impl<S> AsyncRead for Socks5Stream<S>
+where
+    S: AsyncRead + Unpin,
+{
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S> AsyncWrite for Socks5Stream<S>
+where
+    S: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, io::Error>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// SOCKS5 BIND client.
+#[derive(Debug)]
+pub struct Socks5Listener<S>(Socks5Stream<S>);
+
+impl<S> Socks5Listener<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Initiates a BIND request to the specified proxy.
+    ///
+    /// Incoming connections are filtered based on the value of `dest`.
+    pub async fn bind(stream: S, dest: impl ToDestAddr) -> io::Result<Self> {
+        let stream = connect_impl(Command::Bind, stream, dest, AuthMethod::None).await?;
+        Ok(Self(stream))
+    }
+
+    /// Initiates a BIND request to the specified proxy with username and password.
+    ///
+    /// Incoming connections are filtered based on the value of `dest`.
+    pub async fn bind_with_password(
+        stream: S,
+        dest: impl ToDestAddr,
+        username: impl Into<String>,
+        password: impl Into<String>,
+    ) -> io::Result<Self> {
+        let stream = connect_impl(
+            Command::Bind,
+            stream,
+            dest,
+            AuthMethod::Password {
+                username: username.into(),
+                password: password.into(),
+            },
+        )
+        .await?;
+
+        Ok(Self(stream))
+    }
+
+    /// Returns the address of the proxy-side TCP listener.
+    ///
+    /// This should be forwarded to the remote process, which should open a
+    /// connection to it.
+    pub fn bind_addr(&self) -> &DestAddr {
+        &self.0.dest_addr
+    }
+
+    /// Waits for the remote process to connect to the proxy server.
+    ///
+    /// The value of `bind_addr` should be forwarded to the remote process,
+    /// which should open a connection to it.
+    pub async fn accept(self) -> io::Result<Socks5Stream<S>> {
+        let mut stream = self.0;
+        Ok(Socks5Stream {
+            dest_addr: read_socks_reply(&mut stream.inner).await?,
+            inner: stream.inner,
+        })
+    }
+}
+
+#[repr(u8)]
+enum Command {
+    Connect = 0x01,
+    Bind = 0x02,
+    // UdpAssociate = 0x03,
+}
+
+enum AuthMethod {
+    Password { username: String, password: String },
+    None,
+}
+
+async fn connect_impl<S>(
+    command: Command,
+    mut stream: S,
+    dest: impl ToDestAddr,
+    auth: AuthMethod,
+) -> io::Result<Socks5Stream<S>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let dest = dest.to_dest_addr()?;
+
+    let auth_methods = {
+        let mut methods: Vec<u8> = vec![METHOD_NO_AUTH_REQUIRED];
+        if let AuthMethod::Password { .. } = &auth {
+            methods.push(METHOD_USERNAME_PASSWORD);
+        }
+        methods
+    };
+
+    {
+        // negotation request
+
+        let mut packet = vec![5, auth_methods.len() as u8];
+        packet.extend_from_slice(&auth_methods);
+        stream.write_all(&packet).await?;
+    }
+
+    {
+        // negotiation response
+
+        let mut buffer = [0; 2];
+        stream.read_exact(&mut buffer).await?;
+        let [resp_version, resp_auth_method] = buffer;
+
+        if resp_version != 5 {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid response version"));
+        }
+
+        // actual authentication if required
+
+        match (resp_auth_method, auth) {
+            (METHOD_NO_AUTH_REQUIRED, _) => {}
+            (METHOD_USERNAME_PASSWORD, AuthMethod::Password { username, password }) => {
+                password_authentication(&mut stream, username, password).await?
+            }
+            (method, _) if !auth_methods.contains(&method) => {
+                // as per RFC server should send 0xFF as method if none of the methods
+                // listed by client are acceptable.
+                // However some implementation ignores this (ie: CCProxy 8.0).
+                return Err(io::Error::new(io::ErrorKind::Other, "no acceptable auth method"))
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "unknown / unsupported auth method",
+                ))
+            }
+        }
+    }
+
+    {
+        // SOCKS request
+
+        let mut packet = [0; MAX_ADDR_LEN + 3];
+        packet[0] = 5; // protocol version
+        packet[1] = command as u8; // command
+        packet[2] = 0; // reserved
+        let len = write_addr(&mut packet[3..], &dest)?;
+        stream.write_all(&packet[..len + 3]).await?;
+    }
+
+    // SOCKS reply
+    let dest_addr = read_socks_reply(&mut stream).await?;
+
+    Ok(Socks5Stream {
+        inner: stream,
+        dest_addr,
+    })
+}
+
+async fn read_socks_reply<S>(stream: &mut S) -> io::Result<DestAddr>
+where
+    S: AsyncRead + Unpin,
+{
+    if stream.read_u8().await? != 5 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid response version"));
+    }
+
+    match stream.read_u8().await? {
+        0 => {}
+        1 => return Err(io::Error::new(io::ErrorKind::Other, "general SOCKS server failure")),
+        2 => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "connection not allowed by ruleset",
+            ))
+        }
+        3 => return Err(io::Error::new(io::ErrorKind::Other, "network unreachable")),
+        4 => return Err(io::Error::new(io::ErrorKind::Other, "host unreachable")),
+        5 => return Err(io::Error::new(io::ErrorKind::Other, "connection refused")),
+        6 => return Err(io::Error::new(io::ErrorKind::Other, "TTL expired")),
+        7 => return Err(io::Error::new(io::ErrorKind::Other, "command not supported")),
+        8 => return Err(io::Error::new(io::ErrorKind::Other, "address kind not supported")),
+        _ => return Err(io::Error::new(io::ErrorKind::Other, "unknown error")),
+    }
+
+    if stream.read_u8().await? != 0 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid reserved byte"));
+    }
+
+    read_addr(stream).await
+}
+
+async fn password_authentication<S>(socket: &mut S, username: String, password: String) -> io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let username_len = match u8::try_from(username.len()) {
+        Ok(len) if len > 0 => len,
+        _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid username")),
+    };
+
+    let password_len = match u8::try_from(password.len()) {
+        Ok(len) if len > 0 => len,
+        _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid password")),
+    };
+
+    let mut packet = [0; 515];
+    let mut writer: &mut [u8] = &mut packet;
+    writer.write_all(&[
+        1, // version
+        username_len,
+    ])?;
+    writer.write_all(username.as_bytes())?;
+    writer.write_all(&[password_len])?;
+    writer.write_all(password.as_bytes())?;
+
+    let packet_size = 3 + username.len() + password.len();
+    socket.write_all(&packet[..packet_size]).await?;
+
+    let mut buffer = [0; 2];
+    socket.read_exact(&mut buffer).await?;
+    let [resp_version, resp_result] = buffer;
+
+    if resp_version != 1 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid response version"));
+    }
+
+    if resp_result != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "password authentication failed",
+        ));
+    }
+
+    Ok(())
+}
+
+// https://www.ietf.org/rfc/rfc1928.txt
+// o  ATYP (1 byte)  address type of following addresses:
+//     o  IP V4 address: X'01'
+//     o  DOMAINNAME: X'03'
+//     o  IP V6 address: X'04'
+// o  DST.ADDR (variable)
+//      desired destination address
+// o  DST.PORT (2 bytes)
+//      desired destination port
+
+async fn read_addr<S: AsyncRead + Unpin>(stream: &mut S) -> io::Result<DestAddr> {
+    match stream.read_u8().await? {
+        1 => {
+            let ip = Ipv4Addr::from(stream.read_u32().await?);
+            let port = stream.read_u16().await?;
+            Ok(DestAddr::Ip(SocketAddr::V4(SocketAddrV4::new(ip, port))))
+        }
+        3 => {
+            let len = stream.read_u8().await?;
+            let mut domain = vec![0; len as usize];
+            stream.read_exact(&mut domain).await?;
+            let domain = String::from_utf8(domain).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            let port = stream.read_u16().await?;
+            Ok(DestAddr::Domain(domain, port))
+        }
+        4 => {
+            let mut ip = [0; 16];
+            stream.read_exact(&mut ip).await?;
+            let ip = Ipv6Addr::from(ip);
+            let port = stream.read_u16().await?;
+            Ok(DestAddr::Ip(SocketAddr::V6(SocketAddrV6::new(ip, port, 0, 0))))
+        }
+        _ => Err(io::Error::new(io::ErrorKind::Other, "unsupported address type")),
+    }
+}
+
+fn write_addr(mut addr_buf: &mut [u8], dest: &DestAddr) -> io::Result<usize> {
+    let initial_len = addr_buf.len();
+    match dest {
+        DestAddr::Ip(SocketAddr::V4(addr)) => {
+            addr_buf.write_all(&[1])?;
+            addr_buf.write_all(&u32::from(*addr.ip()).to_be_bytes())?;
+            addr_buf.write_all(&addr.port().to_be_bytes())?;
+        }
+        DestAddr::Ip(SocketAddr::V6(addr)) => {
+            addr_buf.write_all(&[4])?;
+            addr_buf.write_all(&addr.ip().octets())?;
+            addr_buf.write_all(&addr.port().to_be_bytes())?;
+        }
+        DestAddr::Domain(domain, port) => {
+            if let Ok(len) = u8::try_from(domain.len()) {
+                addr_buf.write_all(&[3, len])?;
+            } else {
+                return Err(io::Error::new(io::ErrorKind::InvalidInput, "domain name too long"));
+            }
+            addr_buf.write_all(domain.as_bytes())?;
+            addr_buf.write_all(&port.to_be_bytes())?;
+        }
+    }
+
+    Ok(initial_len - addr_buf.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{AsyncStdIo, DummyStream};
+
+    const GOOGLE_ADDR: &str = "google.com:80";
+
+    fn socks5_dummy() -> DummyStream {
+        DummyStream(vec![5, METHOD_USERNAME_PASSWORD])
+    }
+
+    #[tokio::test]
+    async fn invalid_username() {
+        let err = Socks5Stream::connect_with_password(socks5_dummy(), GOOGLE_ADDR, "", "x".repeat(255))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.to_string(), "invalid username");
+
+        let err = Socks5Stream::connect_with_password(socks5_dummy(), GOOGLE_ADDR, "x".repeat(256), "x".repeat(255))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.to_string(), "invalid username");
+    }
+
+    #[tokio::test]
+    async fn invalid_password() {
+        let err = Socks5Stream::connect_with_password(socks5_dummy(), GOOGLE_ADDR, "x".repeat(255), "")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.to_string(), "invalid password");
+
+        let err = Socks5Stream::connect_with_password(socks5_dummy(), GOOGLE_ADDR, "x".repeat(255), "x".repeat(256))
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(err.to_string(), "invalid password");
+    }
+
+    async fn assert_encoding(addr: DestAddr, encoded: &[u8]) {
+        // encode
+        let mut buf = [0; MAX_ADDR_LEN];
+        let len = write_addr(&mut buf, &addr).unwrap();
+        assert_eq!(&buf[..len], encoded);
+
+        // decode
+        let mut reader = AsyncStdIo(encoded);
+        let decoded = read_addr(&mut reader).await.unwrap();
+        assert_eq!(decoded, addr);
+    }
+
+    #[tokio::test]
+    async fn ipv4_addr() {
+        assert_encoding("192.168.0.39:80".to_dest_addr().unwrap(), &[1, 192, 168, 0, 39, 0, 80]).await;
+    }
+
+    #[tokio::test]
+    async fn ipv6_addr() {
+        assert_encoding(
+            "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443".to_dest_addr().unwrap(),
+            &[
+                4, 32, 1, 13, 184, 133, 163, 8, 211, 19, 25, 138, 46, 3, 112, 115, 72, 1, 187,
+            ],
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn domain_addr() {
+        assert_encoding(
+            "devolutions.net:80".to_dest_addr().unwrap(),
+            &[
+                3, 15, 100, 101, 118, 111, 108, 117, 116, 105, 111, 110, 115, 46, 110, 101, 116, 0, 80,
+            ],
+        )
+        .await;
+    }
+}

--- a/jetsocat/proxy/src/test_utils.rs
+++ b/jetsocat/proxy/src/test_utils.rs
@@ -1,0 +1,134 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{fmt, io};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+#[derive(Debug, Clone)]
+pub struct DummyStream(pub Vec<u8>);
+
+impl AsyncWrite for DummyStream {
+    fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, io::Error>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.poll_flush(cx)
+    }
+}
+
+impl AsyncRead for DummyStream {
+    fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, buf: &mut tokio::io::ReadBuf<'_>) -> Poll<io::Result<()>> {
+        buf.put_slice(&self.0);
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AsyncStdIo<T>(pub T);
+
+impl<T> Unpin for AsyncStdIo<T> {}
+
+macro_rules! try_with_interrupt {
+    ($e:expr) => {
+        loop {
+            match $e {
+                Ok(e) => {
+                    break e;
+                }
+                Err(ref e) if e.kind() == ::std::io::ErrorKind::Interrupted => {
+                    continue;
+                }
+                Err(e) => {
+                    return Poll::Ready(Err(e));
+                }
+            }
+        }
+    };
+}
+
+impl<T> io::Write for AsyncStdIo<T>
+where
+    T: io::Write,
+{
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.write(buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.0.write_vectored(bufs)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.0.write_fmt(fmt)
+    }
+}
+
+impl<T> AsyncWrite for AsyncStdIo<T>
+where
+    T: io::Write,
+{
+    fn poll_write(mut self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, io::Error>> {
+        Poll::Ready(Ok(try_with_interrupt!(self.0.write(buf))))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        try_with_interrupt!(self.0.flush());
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.poll_flush(cx)
+    }
+}
+
+impl<T> io::Read for AsyncStdIo<T>
+where
+    T: io::Read,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.read(buf)
+    }
+
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.0.read_vectored(bufs)
+    }
+
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.0.read_to_end(buf)
+    }
+
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.0.read_to_string(buf)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.0.read_exact(buf)
+    }
+}
+
+impl<T> AsyncRead for AsyncStdIo<T>
+where
+    T: io::Read,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let read = try_with_interrupt!(self.0.read(buf.initialize_unfilled()));
+        buf.advance(read);
+        Poll::Ready(Ok(()))
+    }
+}

--- a/jetsocat/src/client.rs
+++ b/jetsocat/src/client.rs
@@ -1,4 +1,4 @@
-use crate::ProxyConfig;
+use crate::proxy::ProxyConfig;
 use anyhow::Result;
 use futures_channel::mpsc;
 use slog::*;

--- a/jetsocat/src/client.rs
+++ b/jetsocat/src/client.rs
@@ -1,16 +1,17 @@
+use crate::ProxyConfig;
 use anyhow::Result;
 use futures_channel::mpsc;
 use slog::*;
 
-pub async fn connect(addr: String, log: Logger) -> Result<()> {
+pub async fn connect(addr: String, proxy_cfg: Option<ProxyConfig>, log: Logger) -> Result<()> {
     use crate::io::{read_and_send, ws_stream_to_writer};
-    use async_tungstenite::tokio::connect_async;
+    use crate::utils::ws_connect_async;
     use futures_util::StreamExt as _;
     use futures_util::{future, pin_mut};
 
     let connect_log = log.new(o!("connect" => addr.clone()));
     info!(connect_log, "Connecting");
-    let (ws_stream, rsp) = connect_async(addr).await?;
+    let (ws_stream, rsp) = ws_connect_async(addr, proxy_cfg).await?;
     debug!(connect_log, "Connected: {:?}", rsp);
     let (write, read) = ws_stream.split();
 

--- a/jetsocat/src/lib.rs
+++ b/jetsocat/src/lib.rs
@@ -3,3 +3,9 @@ pub mod pipe;
 pub mod server;
 
 mod io;
+mod utils;
+
+pub enum ProxyConfig {
+    Socks4 { addr: String },
+    Socks5 { addr: String },
+}

--- a/jetsocat/src/lib.rs
+++ b/jetsocat/src/lib.rs
@@ -1,11 +1,7 @@
 pub mod client;
 pub mod pipe;
+pub mod proxy;
 pub mod server;
 
 mod io;
 mod utils;
-
-pub enum ProxyConfig {
-    Socks4 { addr: String },
-    Socks5 { addr: String },
-}

--- a/jetsocat/src/proxy.rs
+++ b/jetsocat/src/proxy.rs
@@ -1,0 +1,61 @@
+#[derive(Clone, Copy, Debug)]
+pub enum ProxyType {
+    Socks4,
+    Socks5,
+    Socks, // unknown SOCKS version
+    Https,
+    Http,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProxyConfig {
+    pub ty: ProxyType,
+    pub addr: String,
+}
+
+#[cfg(feature = "detect-proxy")]
+pub fn detect_proxy() -> Option<ProxyConfig> {
+    let mut cfg = proxy_cfg::get_proxy_config().ok()??;
+
+    if let Some(addr) = cfg.proxies.remove("socks5").or_else(|| cfg.proxies.remove("socks5h")) {
+        return Some(ProxyConfig {
+            ty: ProxyType::Socks5,
+            addr,
+        });
+    }
+
+    if let Some(addr) = cfg.proxies.remove("socks4").or_else(|| cfg.proxies.remove("socks4a")) {
+        return Some(ProxyConfig {
+            ty: ProxyType::Socks4,
+            addr,
+        });
+    }
+
+    if let Some(addr) = cfg.proxies.remove("socks") {
+        return Some(ProxyConfig {
+            ty: ProxyType::Socks,
+            addr,
+        });
+    }
+
+    if let Some(addr) = cfg.proxies.remove("https") {
+        return Some(ProxyConfig {
+            ty: ProxyType::Https,
+            addr,
+        });
+    }
+
+    if let Some(addr) = cfg.proxies.remove("http") {
+        return Some(ProxyConfig {
+            ty: ProxyType::Http,
+            addr,
+        });
+    }
+
+    None
+}
+
+#[cfg(not(feature = "detect-proxy"))]
+pub fn detect_proxy() -> Option<ProxyConfig> {
+    None
+}

--- a/jetsocat/src/server.rs
+++ b/jetsocat/src/server.rs
@@ -1,5 +1,5 @@
 use crate::pipe::{pipe_with_ws, PipeCmd};
-use crate::ProxyConfig;
+use crate::proxy::ProxyConfig;
 use anyhow::{Context as _, Result};
 use slog::{debug, o};
 

--- a/jetsocat/src/server.rs
+++ b/jetsocat/src/server.rs
@@ -1,13 +1,15 @@
 use crate::pipe::{pipe_with_ws, PipeCmd};
+use crate::ProxyConfig;
 use anyhow::{Context as _, Result};
 use slog::{debug, o};
 
-pub async fn accept(addr: String, pipe: PipeCmd, log: slog::Logger) -> Result<()> {
-    use async_tungstenite::tokio::connect_async;
+pub async fn accept(addr: String, pipe: PipeCmd, proxy_cfg: Option<ProxyConfig>, log: slog::Logger) -> Result<()> {
+    use crate::utils::ws_connect_async;
 
     let accept_log = log.new(o!("accept" => addr.clone()));
+
     debug!(accept_log, "Connecting");
-    let (ws_stream, rsp) = connect_async(addr).await?;
+    let (ws_stream, rsp) = ws_connect_async(addr, proxy_cfg).await?;
     debug!(accept_log, "Connected: {:?}", rsp);
 
     pipe_with_ws(ws_stream, pipe, accept_log)

--- a/jetsocat/src/utils.rs
+++ b/jetsocat/src/utils.rs
@@ -1,0 +1,46 @@
+use crate::ProxyConfig;
+use anyhow::{Context as _, Result};
+use async_tungstenite::{
+    tokio::ClientStream,
+    tungstenite::{client::IntoClientRequest, handshake::client::Response},
+    WebSocketStream,
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+// See E0225 to understand why this trait is required
+pub trait MetaAsyncStream: 'static + AsyncRead + AsyncWrite + Unpin {}
+
+impl<T> MetaAsyncStream for T where T: 'static + AsyncRead + AsyncWrite + Unpin {}
+
+pub type AsyncStream = Box<dyn MetaAsyncStream>;
+
+pub async fn ws_connect_async(
+    addr: String,
+    proxy_cfg: Option<ProxyConfig>,
+) -> Result<(WebSocketStream<ClientStream<AsyncStream>>, Response)> {
+    use async_tungstenite::tokio::client_async_tls;
+    use jetsocat_proxy::socks4::Socks4Stream;
+    use jetsocat_proxy::socks5::Socks5Stream;
+    use tokio::net::TcpStream;
+
+    let req = addr.into_client_request()?;
+    let domain = req.uri().host().context("no host name in the url")?;
+    let port = req.uri().port_u16().context("no port in the url")?;
+    let req_addr = (domain, port);
+
+    let stream: AsyncStream = match proxy_cfg {
+        Some(ProxyConfig::Socks4 { addr: proxy_addr }) => {
+            let stream = TcpStream::connect(proxy_addr).await?;
+            Box::new(Socks4Stream::connect(stream, req_addr, "jetsocat").await?)
+        }
+        Some(ProxyConfig::Socks5 { addr: proxy_addr }) => {
+            let stream = TcpStream::connect(proxy_addr).await?;
+            Box::new(Socks5Stream::connect(stream, req_addr).await?)
+        }
+        None => Box::new(TcpStream::connect(req_addr).await?),
+    };
+
+    let (ws_stream, rsp) = client_async_tls(req, stream).await?;
+
+    Ok((ws_stream, rsp))
+}


### PR DESCRIPTION
Missing HTTP/HTTPS proxy support, but this is a feature complete for SOCKS family.