### PR TITLE
Add logs to track all HTTP requests received and processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This document provides a list of notable changes introduced in Devolutions Gateway by release.
 
+## Next release ()
+  * Add logs to track all HTTP requests received and processed
+
 ## 2021.1.3 (2021-04-13)
   * Fix infinite loop issue when the precondition pdu was not completely received
   * Fix possible stability issue with protocol peeking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2716,6 +2716,7 @@ dependencies = [
  "tokio 0.2.25",
  "tokio-rustls 0.14.1",
  "tower-service",
+ "uuid 0.8.2",
 ]
 
 [[package]]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -61,7 +61,7 @@ dlopen_derive = "0.1.4"
 [dependencies.saphir]
 version = "2.8"
 default-features = false
-features = ["https", "json", "macro", "form"]
+features = ["https", "json", "macro", "form", "operation"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["winbase", "winuser", "winsvc", "libloaderapi", "errhandlingapi", "winerror"] }

--- a/devolutions-gateway/src/http/http_server.rs
+++ b/devolutions-gateway/src/http/http_server.rs
@@ -3,6 +3,7 @@ use crate::http::controllers::health::HealthController;
 use crate::http::controllers::jet::JetController;
 use crate::http::controllers::sessions::SessionsController;
 use crate::http::middlewares::auth::AuthMiddleware;
+use crate::http::middlewares::log::LogMiddleware;
 use crate::jet_client::JetAssociationsMap;
 use saphir::server::Server as SaphirServer;
 use slog_scope::info;
@@ -23,11 +24,13 @@ pub fn configure_http_server(config: Arc<Config>, jet_associations: JetAssociati
                 auth_include_path.push("/jet/association/<association_id>");
             }
 
-            middlewares.apply(
-                AuthMiddleware::new(config.clone()),
-                auth_include_path,
-                Some(auth_exclude_path),
-            )
+            middlewares
+                .apply(
+                    AuthMiddleware::new(config.clone()),
+                    auth_include_path,
+                    Some(auth_exclude_path),
+                )
+                .apply(LogMiddleware, vec!["/"], None)
         })
         .configure_router(|router| {
             info!("Loading HTTP controllers");

--- a/devolutions-gateway/src/http/middlewares/log.rs
+++ b/devolutions-gateway/src/http/middlewares/log.rs
@@ -1,0 +1,35 @@
+use saphir::error::SaphirError;
+use saphir::http_context::HttpContext;
+use saphir::middleware::MiddlewareChain;
+use saphir::prelude::*;
+use slog::o;
+use slog::{slog_debug, slog_info};
+use slog_scope;
+use slog_scope_futures::future03::FutureExt as SLogFutureEx;
+use std::time::Instant;
+
+pub struct LogMiddleware;
+
+#[middleware]
+impl LogMiddleware {
+    async fn next(&self, mut ctx: HttpContext, chain: &dyn MiddlewareChain) -> Result<HttpContext, SaphirError> {
+        let request = ctx.state.request_unchecked();
+        let start_time = Instant::now();
+        let operation_id = ctx.operation_id.to_string();
+
+        let uri = request.uri().path().to_owned();
+        let method = request.method().to_owned();
+
+        let logger = slog_scope::logger().new(o!("request_id" => operation_id));
+        slog_debug!(logger, "Request received: {} {}", method, uri);
+
+        ctx = chain.next(ctx).with_logger(logger.clone()).await?;
+
+        let status = ctx.state.response_unchecked().status();
+        let duration = format!("Duration_ms={}", start_time.elapsed().as_millis());
+
+        slog_info!(logger, "{} {} {} ({})", method, uri, status, duration);
+
+        Ok(ctx)
+    }
+}

--- a/devolutions-gateway/src/http/middlewares/mod.rs
+++ b/devolutions-gateway/src/http/middlewares/mod.rs
@@ -1,1 +1,2 @@
 pub mod auth;
+pub mod log;

--- a/powershell/build.ps1
+++ b/powershell/build.ps1
@@ -15,6 +15,8 @@ New-Item -Path "$PSModuleOutputPath\$ModuleName" -ItemType 'Directory' -Force | 
     New-Item -Path "$PSModuleOutputPath\$ModuleName\$_" -ItemType 'Directory' -Force | Out-Null
 }
 
+& dotnet nuget add source "https://api.nuget.org/v3/index.json" -n "nuget.org" | Out-Null
+
 & dotnet publish "$PSScriptRoot\$ModuleName\src" -f netstandard2.0 -c Release -o "$PSScriptRoot\$ModuleName\bin"
 
 Copy-Item "$PSScriptRoot\$ModuleName\bin" -Destination "$PSModuleOutputPath\$ModuleName" -Recurse -Force


### PR DESCRIPTION
I added a log for each http request received.  I also added the request_id in the slog logger.  It means that all logs during the request process will be tagged with request_id=XYZ.  It could be useful. For example : 

2021-04-20 19:15:23:343338 DEBG Request received: POST /jet/association/e531a228-027c-49fd-a74c-0474e5e63963/candidates, **request_id: 50772e60-01f7-419c-958a-230d1894484d**, listener: 0.0.0.0:7171, module: [devolutions_gateway::http::middlewares::log]
2021-04-20 19:15:23:356786 DEBG The jet_tp claim is None, **request_id: 50772e60-01f7-419c-958a-230d1894484d**, listener: 0.0.0.0:7171, module: [devolutions_gateway::http::controllers::jet::SG_JetController]
2021-04-20 19:15:23:357645 INFO POST /jet/association/e531a228-027c-49fd-a74c-0474e5e63963/candidates 200 OK (Duration_ms=14), **request_id: 50772e60-01f7-419c-958a-230d1894484d**, listener: 0.0.0.0:7171, module: [devolutions_gateway::http::middlewares::log]
