### PR TITLE
Jetsocat fixes

### DIFF
--- a/jetsocat/src/io.rs
+++ b/jetsocat/src/io.rs
@@ -14,7 +14,7 @@ where
 {
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
-    let mut buf = [0u8; 1024];
+    let mut buf = [0u8; 5120];
 
     loop {
         let bytes_read = reader.read(&mut buf).await?;
@@ -26,6 +26,7 @@ where
         trace!(logger, r#""{}""#, String::from_utf8_lossy(&buf[..bytes_read]));
 
         writer.write_all(&buf[..bytes_read]).await?;
+        writer.flush().await?;
     }
 
     Ok(())

--- a/jetsocat/src/io.rs
+++ b/jetsocat/src/io.rs
@@ -90,6 +90,7 @@ where
 
         let dest = buf.initialize_unfilled_to(bytes_to_copy);
         dest.copy_from_slice(&data[..bytes_to_copy]);
+        buf.advance(bytes_to_copy);
 
         if data.len() > bytes_to_copy {
             data.drain(..bytes_to_copy);

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -43,7 +43,7 @@ fn generate_usage() -> String {
         \n\
         \tExample: unauthenticated PowerShell\n\
         \n\
-        \t  {command} forward tcp-listen://127.0.0.1:5002 'cmd://pwsh -sshs -NoLogo -NoProfile'\n\
+        \t  {command} forward tcp-listen://127.0.0.1:5002 cmd://'pwsh -sshs -NoLogo -NoProfile'\n\
         \n\
         For detailed logs use debug binary or any binary built with 'verbose' feature enabled.\n\
         This binary was built as:\n\
@@ -102,7 +102,7 @@ Pipe formats:
 
 Example: unauthenticated PowerShell
 
-    {command} forward tcp-listen://127.0.0.1:5002 'cmd://pwsh -sshs -NoLogo -NoProfile'"##,
+    {command} forward tcp-listen://127.0.0.1:5002 cmd://'pwsh -sshs -NoLogo -NoProfile'"##,
         command = env!("CARGO_PKG_NAME")
     );
 
@@ -302,9 +302,13 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
     }
 
     match scheme {
-        "tcp-listen" => Ok(PipeMode::TcpListener(value.to_owned())),
-        "cmd" => Ok(PipeMode::ProcessCmd(value.to_owned())),
-        "tcp" => Ok(PipeMode::Tcp(value.to_owned())),
+        "tcp-listen" => Ok(PipeMode::TcpListener {
+            bind_addr: value.to_owned(),
+        }),
+        "cmd" => Ok(PipeMode::ProcessCmd {
+            command: value.to_owned(),
+        }),
+        "tcp" => Ok(PipeMode::Tcp { addr: value.to_owned() }),
         "jet-tcp-connect" => {
             let (addr, association_id, candidate_id) = parse_jet_pipe_format(value)?;
             Ok(PipeMode::JetTcpConnect {
@@ -321,7 +325,7 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
                 candidate_id,
             })
         }
-        "ws" | "wss" => Ok(PipeMode::WebSocket(arg)),
+        "ws" | "wss" => Ok(PipeMode::WebSocket { url: arg }),
         _ => anyhow::bail!("Unknown pipe scheme: {}", scheme),
     }
 }

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -101,9 +101,17 @@ Pipe formats:
     `wss://<URL>`: WebSocket Secure
     `ws-listen://<BINDING ADDRESS>`: WebSocket listener"
 
-Example: unauthenticated PowerShell
+Example: unauthenticated PowerShell server
 
-    {command} forward tcp-listen://127.0.0.1:5002 cmd://'pwsh -sshs -NoLogo -NoProfile'"##,
+    {command} forward tcp-listen://127.0.0.1:5002 cmd://'pwsh -sshs -NoLogo -NoProfile'
+
+Example: unauthenticated sftp server
+
+    {command} forward tcp-listen://0.0.0.0:2222 cmd://'/usr/lib/openssh/sftp-server'
+
+Example: unauthenticated sftp client
+
+    JETSOCAT_ARGS="forward - tcp://192.168.122.178:2222" sftp -D {command}"##,
         command = env!("CARGO_PKG_NAME")
     );
 
@@ -327,7 +335,9 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
             })
         }
         "ws" | "wss" => Ok(PipeMode::WebSocket { url: arg }),
-        "ws-listen" => Ok(PipeMode::WebSocketListen { bind_addr: value.to_owned() }),
+        "ws-listen" => Ok(PipeMode::WebSocketListen {
+            bind_addr: value.to_owned(),
+        }),
         _ => anyhow::bail!("Unknown pipe scheme: {}", scheme),
     }
 }

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -98,7 +98,8 @@ Pipe formats:
     `jet-tcp-connect://<ADDRESS>/<ASSOCIATION ID>/<CANDIDATE ID>`: TCP stream over JET protocol as client
     `jet-tcp-accept://<ADDRESS>/<ASSOCIATION ID>/<CANDIDATE ID>`: TCP stream over JET protocol as server
     `ws://<URL>`: WebSocket
-    `wss://<URL>`: WebSocket Secure"
+    `wss://<URL>`: WebSocket Secure
+    `ws-listen://<BINDING ADDRESS>`: WebSocket listener"
 
 Example: unauthenticated PowerShell
 
@@ -302,7 +303,7 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
     }
 
     match scheme {
-        "tcp-listen" => Ok(PipeMode::TcpListener {
+        "tcp-listen" => Ok(PipeMode::TcpListen {
             bind_addr: value.to_owned(),
         }),
         "cmd" => Ok(PipeMode::ProcessCmd {
@@ -326,6 +327,7 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
             })
         }
         "ws" | "wss" => Ok(PipeMode::WebSocket { url: arg }),
+        "ws-listen" => Ok(PipeMode::WebSocketListen { bind_addr: value.to_owned() }),
         _ => anyhow::bail!("Unknown pipe scheme: {}", scheme),
     }
 }

--- a/jetsocat/src/utils.rs
+++ b/jetsocat/src/utils.rs
@@ -103,7 +103,9 @@ pub async fn ws_connect(addr: String, proxy_cfg: Option<ProxyConfig>) -> Result<
 
     impl_tcp_connect!(req_addr, proxy_cfg, Result<WebSocketConnectOutput>, |stream| {
         async {
-            let (ws, rsp) = client_async_tls(req, stream).await?;
+            let (ws, rsp) = client_async_tls(req, stream)
+                .await
+                .context("WebSocket handshake failed")?;
             let (sink, stream) = ws.split();
             let read = Box::new(ReadableWebSocketHalf::new(stream)) as Box<dyn AsyncRead + Unpin>;
             let write = Box::new(WritableWebSocketHalf::new(sink)) as Box<dyn AsyncWrite + Unpin>;


### PR DESCRIPTION
* Fix process piping.
Process was closed early.
To fix this, a handle is kept alive until piping operation ends.

* Fix WebSocket read buffer advancing.
Buffer was not marked as filled causing WebSocket to close itself.

* Flush on write. `sftp` works thanks to this.

* Add `ws-listen` pipe. Useful for debugging but might be used for other purposes as well.