### PR TITLE
Bridge all verbs (get/put/patch/post/delete) + Authorization is set in Gateway-Authorization header

### DIFF
--- a/devolutions-gateway/src/http/middlewares/auth.rs
+++ b/devolutions-gateway/src/http/middlewares/auth.rs
@@ -11,6 +11,8 @@ use saphir::response::Builder as ResponseBuilder;
 use slog_scope::error;
 use std::sync::Arc;
 
+const GATEWAY_AUTHORIZATION_HDR_NAME: &str = "Gateway-Authorization";
+
 pub struct AuthMiddleware {
     config: Arc<Config>,
 }
@@ -38,7 +40,10 @@ async fn auth_middleware(
 ) -> Result<HttpContext, SaphirError> {
     let request = ctx.state.request_unchecked_mut();
 
-    let auth_header = request.headers().get(http::header::AUTHORIZATION);
+    let gateway_auth_header = request.headers_mut().remove(GATEWAY_AUTHORIZATION_HDR_NAME);
+    let auth_header = gateway_auth_header
+        .as_ref()
+        .or_else(|| request.headers().get(http::header::AUTHORIZATION));
 
     let auth_header = match auth_header {
         Some(header) => header.clone(),

--- a/powershell/DevolutionsGateway/Public/DGateway.ps1
+++ b/powershell/DevolutionsGateway/Public/DGateway.ps1
@@ -620,7 +620,7 @@ function New-DGatewayToken {
     param(
         [string] $ConfigPath,
 
-        [ValidateSet('association', 'scope')]
+        [ValidateSet('association', 'scope', 'bridge')]
         [Parameter(Mandatory = $true)]
         [string] $Type, #type
 
@@ -639,6 +639,9 @@ function New-DGatewayToken {
         
         #private scope claims
         [string] $Scope, # scope
+
+        #private bridge claims
+        [string] $Target, # target
 
         # signature parameters
         [string] $PrivateKeyFile
@@ -720,6 +723,10 @@ function New-DGatewayToken {
 
     if (($Type -eq 'scope') -and ($Scope)) {
         $Payload | Add-Member -MemberType NoteProperty -Name 'scope' -Value $Scope
+    }
+
+    if (($Type -eq 'bridge') -and ($Target)) {
+        $Payload | Add-Member -MemberType NoteProperty -Name 'target' -Value $Target
     }
 
     New-JwtRs256 -Header $Header -Payload $Payload -PrivateKey $PrivateKey


### PR DESCRIPTION
To forward a request via the Gateway, the only thing to do is : 
1 - Create a token that will contain the target
2 - Add a header Gateway-Authorization with that bearer token

For example : 
Gateway-Autorization : Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9DQo.eyJpYXQiOjE2MjgwMDgyMjUsIm5iZiI6MTYyODAwODIyNSwiZXhwIjoxNjI4MDA4MzQ1LCJ0eXBlIjoiYnJpZGdlIiwidGFyZ2V0IjoiaHR0cDovL2xvY2FsaG9zdDo3MTcxL2hlYWx0aCJ9DQo.FGJUjppORtVivURoNE15uE3nycb9Dymh5OU9acAsSuH-MP3DlxpCyiy3KLT3tv4i1SNhLiOR_5-joiT474KtSN4wZLPgU7BV4_uN_SXR0qkW3iu1tW3lmSlbvNiLTLNB32aaLedFIHuAreR8HtQUm7KNV1TdpOIScjWjgBS78xSdMaxkfVAD-MZToWTpr0HKJFyME4DzZoDZX6Xz9r6VKTiAmRTD10Ni5m-USvgi53CMWEoI8hY-TVroUEhARbx8JK5CeGzPYUfyORXHGUnR5Wc8gBJZZwDEN-GCelXP57Gc81oeZ4HQoMmpmMILwTi5ygujmA5jtCNC5mvgRiH5lA

I also added parameters to the powershell function New-DGatewayToken to generate "bridge" token 