### PR TITLE
WAYK-2568: Add an endpoint to get configuration information

### DIFF
--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -63,7 +63,7 @@ pub enum Protocol {
     Unknown,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct ListenerConfig {
     pub internal_url: Url,
     pub external_url: Url,

--- a/devolutions-gateway/src/http/controllers/diagnostics.rs
+++ b/devolutions-gateway/src/http/controllers/diagnostics.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, ListenerConfig};
 use crate::http::guards::access::{AccessGuard, JetTokenType};
 use crate::http::HttpErrorStatus;
 use jet_proto::token::JetAccessScope;
@@ -7,6 +7,21 @@ use std::sync::Arc;
 
 pub struct DiagnosticsController {
     config: Arc<Config>,
+}
+
+#[derive(Serialize)]
+struct GatewayConfigurationResponse {
+    hostname: String,
+    listeners: Vec<ListenerConfig>,
+}
+
+impl From<Arc<Config>> for GatewayConfigurationResponse {
+    fn from(config: Arc<Config>) -> Self {
+        GatewayConfigurationResponse {
+            listeners: config.listeners.clone(),
+            hostname: config.hostname.clone(),
+        }
+    }
 }
 
 impl DiagnosticsController {
@@ -29,5 +44,14 @@ impl DiagnosticsController {
             .as_ref()
             .ok_or_else(|| HttpErrorStatus::not_found("Log file is not configured"))?;
         File::open(log_file_path).await.map_err(HttpErrorStatus::internal)
+    }
+
+    #[get("/configuration")]
+    #[guard(
+        AccessGuard,
+        init_expr = r#"JetTokenType::Scope(JetAccessScope::GatewayDiagnosticsRead)"#
+    )]
+    async fn get_configuration(&self) -> Json<GatewayConfigurationResponse> {
+        Json(self.config.clone().into())
     }
 }


### PR DESCRIPTION
I added endpoint ``/diagnostics/configuration`
To access this endpoint, you need a valid scope token with scope "gateway.diagnostics.read"
It returns hostname + listeners. Here is an example : 

```
{
    "hostname": "jet-fdubois.ngrok.io",
    "listeners": [
        {
            "internal_url": "ws://0.0.0.0:7171/",
            "external_url": "wss://jet-fdubois.ngrok.io:7171/"
        },
        {
            "internal_url": "tcp://0.0.0.0:8080",
            "external_url": "tcp://3.tcp.ngrok.io:21405"
        }
    ]
}
```


