### PR TITLE
WAYK-2577: Devolutions-Gateway - Log invalid configuration

### DIFF
--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -53,6 +53,11 @@ impl GatewayService {
         let logger_guard = slog_scope::set_global_logger(logger.clone());
         slog_stdlog::init().expect("failed to init logger");
 
+        if let Err(e) = config.validate() {
+            error!("Devolutions Gateway can't be launched. Invalid configuration: {}", e);
+            return None;
+        }
+
         Some(GatewayService {
             config,
             logger,


### PR DESCRIPTION
If the provisionner public key is not set, the gateway doesn't start. It was a panic so no log file generated. Hard to debug, you had to launch the gateway on a command line to see the error. I changed that for a log message... It will panic anyway, but at least, the log file will be there with a log similar to that

2021-09-01 10:27:22:677491 ERRO Devolutions Gateway can't be launched. Invalid configuration: provisioner public key is missing, module: [devolutions_gateway::service]