### PR TITLE
GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ runner.arch }}"
 
           if ($Env:RUNNER_OS -eq "Windows") {
-            $ExecutableFileName = "$(ExecutableFileName).exe"
+            $ExecutableFileName = "$($ExecutableFileName).exe"
             $PackageFileName = "DevolutionsGateway-${{ runner.arch }}-${PackageVersion}.msi"
             $PSModuleOutputPath = Join-Path $StagingPath PowerShell
             $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   jetsocat:
-    name: jetsocat [${{ matrix.os }} (${{ matrix.arch }})]
+    name: jetsocat [${{ matrix.os }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
     env:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -47,7 +47,7 @@ jobs:
           $JetsocatExecutable = Join-Path $TargetOutputPath $ExecutableFileName
           $CargoPackage = "jetsocat"
           echo "::set-output name=package-version::$PackageVersion"
-          echo "::set-output name=target-staging-path::$StagingPath"
+          echo "::set-output name=staging-path::$StagingPath"
           echo "::set-output name=target-output-path::$TargetOutputPath"
           echo "::set-output name=jetsocat-executable::$JetsocatExecutable"
           echo "::set-output name=cargo-package::$CargoPackage"
@@ -57,6 +57,17 @@ jobs:
         run: |
           sudo apt update
           sudo apt install python3-wget python3-setuptools
+
+      - name: configure Windows x86 runner
+        if: matrix.os == 'windows' && matrix.arch == 'x86'
+        run: |
+          rustup target add i686-pc-windows-msvc
+
+      - name: configure macOS arm64 runner
+        if: matrix.os == 'macos' && matrix.arch == 'arm64'
+        run: |
+          sudo rm -rf /Library/Developer/CommandLineTools
+          rustup target add aarch64-apple-darwin
 
       - name: Configure conan
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,13 +175,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install dh_make python3-wget python3-setuptools libsystemd-dev
+          sudo apt install dh-make python3-wget python3-setuptools libsystemd-dev
 
-      - name: Configure Windows runner
-        if: runner.os == 'Windows'
-        run: |
-          echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      # - name: Configure Windows runner
+      #   if: runner.os == 'Windows'
+      #   run: |
+      #     echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      #     echo "C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup code signing
         if: matrix.os == 'windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
           sudo rm -rf /Library/Developer/CommandLineTools
           rustup target add aarch64-apple-darwin
 
+      - name: configure Windows signing certificate
+        if: matrix.os == 'windows'
+        env:
+          CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
+          CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
+        run: |
+          $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
+          [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
+          $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
+          Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+
       - name: Configure conan
         run: |
           pip3 install conan==1.40.0 --upgrade
@@ -82,7 +93,14 @@ jobs:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
           JETSOCAT_EXECUTABLE: ${{ steps.load-variables.outputs.jetsocat-executable }}
           CARGO_PACKAGE: ${{ steps.load-variables.outputs.cargo-package }}
-        run: ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }}
+        run: |
+          if ($Env:RUNNER_OS -eq "Windows") {
+            $Env:CARGO_NO_DEFAULT_FEATURES = "true"
+            $Env:CARGO_FEATURES = "native-tls"
+            $Env:SIGNTOOL_NAME = "Devolutions"
+          }
+
+          ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }}
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,12 +177,6 @@ jobs:
           sudo apt update
           sudo apt install dh-make python3-wget python3-setuptools libsystemd-dev
 
-      # - name: Configure Windows runner
-      #   if: runner.os == 'Windows'
-      #   run: |
-      #     echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      #     echo "C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
       - name: Setup code signing
         if: matrix.os == 'windows'
         run: echo "::warning::Artifacts not code-signed, to be implemented"
@@ -206,7 +200,7 @@ jobs:
       - name: Build PowerShell module
         if: matrix.os == 'windows'
         env:
-          SMODULE_OUTPUT_PATH: ${{ steps.load-variables.outputs.psmodule-output-path }}
+          PSMODULE_OUTPUT_PATH: ${{ steps.load-variables.outputs.psmodule-output-path }}
         run: .\powershell\build.ps1
 
       - name: Package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           $PackageVersion = Get-Content "./VERSION"
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "jetsocat_${{ runner.os }}_${PackageVersion}_${{ runner.arch }}"
+          $ExecutableFileName = "jetsocat_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
           $JetsocatExecutable = Join-Path $TargetOutputPath $ExecutableFileName
           $CargoPackage = "jetsocat"
           echo "::set-output name=staging-path::$StagingPath"
@@ -150,11 +150,11 @@ jobs:
           $PackageVersion = Get-Content "./VERSION"
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ runner.arch }}"
+          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
 
           if ($Env:RUNNER_OS -eq "Windows") {
             $ExecutableFileName = "$($ExecutableFileName).exe"
-            $PackageFileName = "DevolutionsGateway-${{ runner.arch }}-${PackageVersion}.msi"
+            $PackageFileName = "DevolutionsGateway-${{ matrix.arch }}-${PackageVersion}.msi"
             $PSModuleOutputPath = Join-Path $StagingPath PowerShell
             $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
             $DGatewayPackage = Join-Path $TargetOutputPath $PackageFileName

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,27 +58,20 @@ jobs:
           sudo apt update
           sudo apt install python3-wget python3-setuptools
 
-      - name: configure Windows x86 runner
+      - name: Configure Windows x86 runner
         if: matrix.os == 'windows' && matrix.arch == 'x86'
         run: |
           rustup target add i686-pc-windows-msvc
 
-      - name: configure macOS arm64 runner
+      - name: Configure macOS arm64 runner
         if: matrix.os == 'macos' && matrix.arch == 'arm64'
         run: |
           sudo rm -rf /Library/Developer/CommandLineTools
           rustup target add aarch64-apple-darwin
 
-      - name: configure Windows signing certificate
-        if: matrix.os == 'windows'
-        env:
-          CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
-          CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
-        run: |
-          $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
-          [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
-          $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
-          Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+      - name: Setup code signing
+        if: matrix.os == 'windows' || matrix.os == 'macos'
+        run: echo "::warning::Artifacts not code-signed, to be implemented"
 
       - name: Configure conan
         run: |
@@ -97,12 +90,11 @@ jobs:
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:CARGO_NO_DEFAULT_FEATURES = "true"
             $Env:CARGO_FEATURES = "native-tls"
-            $Env:SIGNTOOL_NAME = "Devolutions"
           }
 
           ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }}
 
-      - name: upload artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: jetsocat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
           DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}
         run: |
           if ($Env:RUNNER_OS -eq "Windows") {
-            $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}""
+            $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}"
             $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
             $Env:DGATEWAY_PSMODULE_CLEAN = "1"
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   jetsocat:
-    name: jetsocat [${{ matrix.os }} (${{ matrix.os }})]
+    name: jetsocat [${{ matrix.os }} (${{ matrix.arch }})]
     runs-on: ${{ matrix.runner }}
     env:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
@@ -52,6 +52,12 @@ jobs:
           echo "::set-output name=jetsocat-executable::$JetsocatExecutable"
           echo "::set-output name=cargo-package::$CargoPackage"
 
+      - name: Configure Linux runner
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install python3-wget python3-setuptools
+
       - name: Configure conan
         run: |
           pip3 install conan==1.40.0 --upgrade
@@ -65,7 +71,7 @@ jobs:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
           JETSOCAT_EXECUTABLE: ${{ steps.load-variables.outputs.jetsocat-executable }}
           CARGO_PACKAGE: ${{ steps.load-variables.outputs.cargo-package }}
-        run: ./ci/tlk.ps1 build -Platform ${{ runner.os }} -Architecture ${{ runner.arch }}
+        run: ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }}
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,10 @@ jobs:
           sudo apt update
           sudo apt install python3-wget python3-setuptools libsystemd-dev
 
+      - name: Configure Windows runner
+        if: runner.os == 'Windows'
+        run: echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Setup code signing
         if: matrix.os == 'windows'
         run: echo "::warning::Artifacts not code-signed, to be implemented"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install python3-wget python3-setuptools
+          sudo apt install python3-wget python3-setuptools libsystemd-dev
 
       - name: Setup code signing
         if: matrix.os == 'windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
         run: |
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}""
-            $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}""
+            $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
             $Env:DGATEWAY_PSMODULE_CLEAN = "1"
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,71 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  jetsocat:
+    name: jetsocat [${{ matrix.os }} (${{ matrix.os }})]
+    runs-on: ${{ matrix.runner }}
+    env:
+      CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x86, x86_64, arm64 ]
+        os: [ windows, macos, linux ]
+        include:
+          - os: windows
+            runner: windows-2019
+          - os: macos
+            runner: macos-10.15
+          - os: linux
+            runner: ubuntu-18.04
+        exclude:
+          - arch: x86
+            os: macos
+          - arch: x86
+            os: linux
+          - arch: arm64
+            os: windows
+          - arch: arm64
+            os: linux
+
     steps:
-      - uses: actions/checkout@v2
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+
+      - name: Load dynamic variables
+        id: load-variables
+        shell: pwsh
+        run: |
+          $PackageVersion = Get-Content "./VERSION"
+          $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
+          $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
+          $ExecutableFileName = "jetsocat_${{ runner.os }}_${PackageVersion}_${{ runner.arch }}"
+          $JetsocatExecutable = Join-Path $TargetOutputPath $ExecutableFileName
+          $CargoPackage = "jetsocat"
+          echo "::set-output name=package-version::$PackageVersion"
+          echo "::set-output name=target-staging-path::$StagingPath"
+          echo "::set-output name=target-output-path::$TargetOutputPath"
+          echo "::set-output name=jetsocat-executable::$JetsocatExecutable"
+          echo "::set-output name=cargo-package::$CargoPackage"
+
+      - name: Configure conan
+        run: |
+          pip3 install conan==1.40.0 --upgrade
+          conan config install --type=git -sf settings https://github.com/Devolutions/conan-public
+          conan remote clean
+          conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
+
+      - name: Build
+        shell: pwsh
+        env:
+          TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
+          JETSOCAT_EXECUTABLE: ${{ steps.load-variables.outputs.jetsocat-executable }}
+          CARGO_PACKAGE: ${{ steps.load-variables.outputs.cargo-package }}
+        run: ./ci/tlk.ps1 build -Platform ${{ runner.os }} -Architecture ${{ runner.arch }}
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jetsocat
+          path: ${{ steps.load-variables.outputs.staging-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,11 +175,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt update
-          sudo apt install python3-wget python3-setuptools libsystemd-dev
+          sudo apt install dh_make python3-wget python3-setuptools libsystemd-dev
 
       - name: Configure Windows runner
         if: runner.os == 'Windows'
-        run: echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: |
+          echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\um" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Setup code signing
         if: matrix.os == 'windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,29 @@ on:
   workflow_dispatch:
 
 jobs:
+
+  preflight:
+    name: preflight
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+
+      - name: Check formatting
+        run: |
+          cargo fmt --all -- --check
+          if ! [ $? -eq 0 ] ; then
+              echo "::error::Bad formatting, please run 'cargo +stable fmt --all'"
+              exit 1
+          fi
+
+      - name: Upload version artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: version
+          path: VERSION
+
   jetsocat:
     name: jetsocat [${{ matrix.os }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
@@ -46,7 +69,6 @@ jobs:
           $ExecutableFileName = "jetsocat_${{ runner.os }}_${PackageVersion}_${{ runner.arch }}"
           $JetsocatExecutable = Join-Path $TargetOutputPath $ExecutableFileName
           $CargoPackage = "jetsocat"
-          echo "::set-output name=package-version::$PackageVersion"
           echo "::set-output name=staging-path::$StagingPath"
           echo "::set-output name=target-output-path::$TargetOutputPath"
           echo "::set-output name=jetsocat-executable::$JetsocatExecutable"
@@ -98,4 +120,105 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: jetsocat
+          path: ${{ steps.load-variables.outputs.staging-path }}
+
+  devolutions-gateway:
+    name: devolutions-gateway [${{ matrix.os }} ${{ matrix.arch }}]
+    runs-on: ${{ matrix.runner }}
+    env:
+      CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ x86_64 ]
+        os: [ windows, linux ]
+        include:
+          - os: windows
+            runner: windows-2019
+          - os: linux
+            runner: ubuntu-18.04
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+
+      - name: Load dynamic variables
+        id: load-variables
+        shell: pwsh
+        run: |
+          $PackageVersion = Get-Content "./VERSION"
+          $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
+          $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
+          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ runner.arch }}"
+
+          if ($Env:RUNNER_OS -eq "Windows") {
+            $ExecutableFileName = "$(ExecutableFileName).exe"
+            $PackageFileName = "DevolutionsGateway-${{ runner.arch }}-${PackageVersion}.msi"
+            $PSModuleOutputPath = Join-Path $StagingPath PowerShell
+            $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
+            $DGatewayPackage = Join-Path $TargetOutputPath $PackageFileName
+
+            echo "::set-output name=psmodule-output-path::$PSModuleOutputPath"
+            echo "::set-output name=dgateway-psmodule-output-path::$DGatewayPSModulePath"
+            echo "::set-output name=dgateway-package::$DGatewayPackage"
+          }
+
+          $DGatewayExecutable = Join-Path $TargetOutputPath $ExecutableFileName
+          $CargoPackage = "devolutions-gateway"
+          echo "::set-output name=staging-path::$StagingPath"
+          echo "::set-output name=target-output-path::$TargetOutputPath"
+          echo "::set-output name=dgateway-executable::$DGatewayExecutable"
+          echo "::set-output name=cargo-package::$CargoPackage"
+
+      - name: Configure Linux runner
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt install python3-wget python3-setuptools
+
+      - name: Setup code signing
+        if: matrix.os == 'windows'
+        run: echo "::warning::Artifacts not code-signed, to be implemented"
+
+      - name: Configure conan
+        run: |
+          pip3 install conan==1.40.0 --upgrade
+          conan config install --type=git -sf settings https://github.com/Devolutions/conan-public
+          conan remote clean
+          conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
+
+      - name: Build
+        shell: pwsh
+        env:
+          TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
+          DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}
+          CARGO_PACKAGE: ${{ steps.load-variables.outputs.cargo-package }}
+        run: |
+          ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }}
+
+      - name: Build PowerShell module
+        if: matrix.os == 'windows'
+        env:
+          SMODULE_OUTPUT_PATH: ${{ steps.load-variables.outputs.psmodule-output-path }}
+        run: .\powershell\build.ps1
+
+      - name: Package
+        shell: pwsh
+        env:
+          TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
+          DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}
+        run: |
+          if ($Env:RUNNER_OS -eq "Windows") {
+            $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}""
+            $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}""
+            $Env:DGATEWAY_PSMODULE_CLEAN = "1"
+          }
+
+          ./ci/tlk.ps1 package -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: devolutions-gateway
           path: ${{ steps.load-variables.outputs.staging-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,11 @@ jobs:
           sudo apt update
           sudo apt install dh-make python3-wget python3-setuptools libsystemd-dev
 
+      - name: Configure Windows runner
+        if: runner.os == 'Windows'
+        run: |
+          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Setup code signing
         if: matrix.os == 'windows'
         run: echo "::warning::Artifacts not code-signed, to be implemented"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -72,6 +72,7 @@ branch = "hyper-update"
 winapi = { version = "0.3", features = ["winbase", "winuser", "winsvc", "libloaderapi", "errhandlingapi", "winerror"] }
 
 [target.'cfg(windows)'.build-dependencies]
+# FIXME: update once next embed-resource version is published
 embed-resource =  { git = "https://github.com/thenextman/rust-embed-resource" }
 
 [dev-dependencies]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -72,7 +72,7 @@ branch = "hyper-update"
 winapi = { version = "0.3", features = ["winbase", "winuser", "winsvc", "libloaderapi", "errhandlingapi", "winerror"] }
 
 [target.'cfg(windows)'.build-dependencies]
-embed-resource =  "1.3"
+embed-resource =  { git = "https://github.com/thenextman/rust-embed-resource" }
 
 [dev-dependencies]
 exitcode = "1.1"


### PR DESCRIPTION
Port the CI build into GitHub workflow

- A patch is required for `embed-resource` build dependency, I raised a PR for the issue. Alternatively we could manually set the Windows SDK include paths
- Artifacts are not code-signed, as the relevant secrets are not yet available. Once they're made available in a properly configured environment, code-signing will probably be refactored into new "release {dev/production}" jobs. Currently the workflow prints a notice that artifacts are *not* code-signed.

Performance is roughly on-par with Azure, since we are able to parallelize the builds