### PR TITLE
Simplify association token claims

### DIFF
--- a/devolutions-gateway/src/preconnection_pdu.rs
+++ b/devolutions-gateway/src/preconnection_pdu.rs
@@ -39,14 +39,14 @@ pub fn extract_association_claims(
         jwe_token = Jwe::decode(&encrypted_jwt, &delegation_key).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Failed to resolve route via JWT routing token: {}", e),
+                format!("Failed to decode encrypted JWT routing token: {}", e),
             )
         })?;
 
         signed_jwt = std::str::from_utf8(&jwe_token.payload).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Failed to resolve route via JWT routing token: {}", e),
+                format!("Failed to decode encrypted JWT routing token payload: {}", e),
             )
         })?;
     } else {
@@ -65,7 +65,7 @@ pub fn extract_association_claims(
         JwtSig::<JetAssociationTokenClaims>::decode(signed_jwt, &provisioner_key, &validator).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("Failed to resolve route via JWT routing token: {}", e),
+                format!("Failed to decode signed payload of JWT routing token: {}", e),
             )
         })?;
 

--- a/devolutions-gateway/src/rdp.rs
+++ b/devolutions-gateway/src/rdp.rs
@@ -12,7 +12,7 @@ use crate::interceptor::rdp::RdpMessageReader;
 use crate::jet_client::JetAssociationsMap;
 use crate::jet_rendezvous_tcp_proxy::JetRendezvousTcpProxy;
 use crate::preconnection_pdu::{extract_association_claims, read_preconnection_pdu};
-use crate::token::{ConnectionMode, JetAssociationTokenClaims};
+use crate::token::{ApplicationProtocol, ConnectionMode, JetAssociationTokenClaims};
 use crate::transport::tcp::TcpTransport;
 use crate::transport::x224::NegotiationWithClientTransport;
 use crate::transport::{JetTransport, Transport};
@@ -228,7 +228,7 @@ fn resolve_rdp_routing_mode(claims: &JetAssociationTokenClaims) -> Result<RdpRou
     const DEFAULT_ROUTING_HOST_SCHEME: &str = "tcp://";
     const DEFAULT_RDP_PORT: u16 = 3389;
 
-    if !claims.jet_ap.is_rdp() {
+    if claims.jet_ap != ApplicationProtocol::Rdp {
         return Err(io::Error::new(
             io::ErrorKind::Other,
             format!(

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -40,43 +40,17 @@ impl JetAssociationTokenClaims {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum ApplicationProtocol {
     Wayk,
-
     Pwsh,
-
-    #[serde(alias = "rdp_tcp")]
-    RdpTcp,
     Rdp,
-
-    #[serde(alias = "ard_tcp")]
-    ArdTcp,
     Ard,
-
-    #[serde(alias = "ssh_tcp")]
-    SshTcp,
     Ssh,
-
     Sftp,
-
     #[serde(other)]
     Unknown,
-}
-
-impl ApplicationProtocol {
-    pub fn is_rdp(self) -> bool {
-        matches!(self, Self::Rdp | Self::RdpTcp)
-    }
-
-    pub fn is_ard(self) -> bool {
-        matches!(self, Self::Ard | Self::ArdTcp)
-    }
-
-    pub fn is_ssh(self) -> bool {
-        matches!(self, Self::Ssh | Self::SshTcp)
-    }
 }
 
 #[derive(Deserialize, Clone)]

--- a/tools/tokengen/src/main.rs
+++ b/tools/tokengen/src/main.rs
@@ -26,20 +26,20 @@ struct App {
 #[allow(clippy::enum_variant_names)]
 #[derive(Clap)]
 enum SubCommand {
-    RdpTcp(RdpTcpParams),
-    RdpTls(RdpTlsIdentity),
-    RdpTcpRendezvous(RdpTcpRendezvousJetAID),
+    RdpTcp(TcpParams),
+    RdpTls(TlsParams),
+    RdpTcpRendezvous,
     Scope(ScopeParams),
 }
 
 #[derive(Clap)]
-struct RdpTcpParams {
+struct TcpParams {
     #[clap(long)]
     dst_hst: String,
 }
 
 #[derive(Clone, Clap, Serialize)]
-struct RdpTlsIdentity {
+struct TlsParams {
     #[serde(skip_serializing)]
     #[clap(long)]
     jet_public_key: PathBuf,
@@ -57,11 +57,6 @@ struct RdpTlsIdentity {
     dst_pwd: String,
 }
 
-#[derive(Clone, Clap, Serialize)]
-struct RdpTcpRendezvousJetAID {
-    jet_aid: Uuid,
-}
-
 #[derive(Clap)]
 struct ScopeParams {
     #[clap(long)]
@@ -70,23 +65,23 @@ struct ScopeParams {
 
 #[derive(Clone, Serialize)]
 #[serde(tag = "type")]
-enum GatewayAccessClaims {
+enum GatewayAccessClaims<'a> {
     #[serde(rename = "association")]
-    RoutingClaims(RoutingClaims),
+    RoutingClaims(RoutingClaims<'a>),
     #[serde(rename = "scope")]
     ScopeClaims(ScopeClaims),
 }
 
 #[derive(Clone, Serialize)]
-struct RoutingClaims {
+struct RoutingClaims<'a> {
     exp: i64,
     nbf: i64,
-    jet_cm: String,
-    jet_ap: String,
-    jet_aid: Option<Uuid>,
-    dst_hst: Option<String>,
+    jet_cm: &'a str,
+    jet_ap: &'a str,
+    jet_aid: Uuid,
+    dst_hst: Option<&'a str>,
     #[serde(flatten)]
-    identity: Option<RdpTlsIdentity>,
+    identity: Option<TlsParams>,
 }
 
 #[derive(Clone, Serialize)]
@@ -109,19 +104,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let exp = (now + validity_duration).as_secs();
 
     let jet_cm = match app.subcmd {
-        SubCommand::RdpTcpRendezvous(_) => "rdv".to_owned(),
-        _ => "fwd".to_owned(),
+        SubCommand::RdpTcpRendezvous => "rdv",
+        _ => "fwd",
     };
 
-    let jet_ap = match app.subcmd {
-        SubCommand::RdpTcpRendezvous(_) => "rdp_tcp".to_owned(),
-        _ => "rdp".to_owned(),
-    };
+    let jet_ap = "rdp";
 
-    let jet_aid = match &app.subcmd {
-        SubCommand::RdpTcpRendezvous(rdv) => Some(rdv.jet_aid),
-        _ => None,
-    };
+    let jet_aid = Uuid::new_v4();
 
     let identity = match &app.subcmd {
         SubCommand::RdpTls(identity) => Some(identity.clone()),
@@ -129,8 +118,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let dst_hst = match &app.subcmd {
-        SubCommand::RdpTcp(params) => Some(params.dst_hst.clone()),
-        SubCommand::RdpTls(identity) => Some(identity.dst_hst.clone()),
+        SubCommand::RdpTcp(params) => Some(params.dst_hst.as_str()),
+        SubCommand::RdpTls(identity) => Some(identity.dst_hst.as_str()),
         _ => None,
     };
 
@@ -154,7 +143,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let signed = JwtSig::new(JwsAlg::RS256, claims.clone()).encode(&private_key)?;
 
     let result = if let GatewayAccessClaims::RoutingClaims(routing_claims) = claims {
-        if let Some(RdpTlsIdentity { jet_public_key, .. }) = routing_claims.identity {
+        if let Some(TlsParams { jet_public_key, .. }) = routing_claims.identity {
             let public_key_str = std::fs::read_to_string(&jet_public_key)?;
             let public_key_pem = public_key_str.parse::<Pem>()?;
             let public_key = PublicKey::from_pem(&public_key_pem)?;


### PR DESCRIPTION
Mostly remove alternative `jet_ap` claim values such as "rdp-tcp".

I also updated the tokengen tool.