### PR TITLE
JMUX websocket endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,19 +1390,17 @@ version = "2021.1.6"
 dependencies = [
  "anyhow",
  "async-tungstenite",
- "bitvec 0.22.3",
- "bytes 1.0.1",
  "dirs-next",
  "futures-util",
  "jet-proto",
  "jetsocat-proxy",
+ "jmux-proxy",
  "proxy_cfg",
  "seahorse",
  "slog",
  "slog-async",
  "slog-term",
  "tokio 1.10.1",
- "tokio-util",
  "uuid",
 ]
 
@@ -1411,6 +1409,27 @@ name = "jetsocat-proxy"
 version = "0.1.0"
 dependencies = [
  "tokio 1.10.1",
+]
+
+[[package]]
+name = "jmux-proto"
+version = "0.1.0"
+dependencies = [
+ "bytes 1.0.1",
+]
+
+[[package]]
+name = "jmux-proxy"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitvec 0.22.3",
+ "bytes 1.0.1",
+ "futures-util",
+ "jmux-proto",
+ "slog",
+ "tokio 1.10.1",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "indexmap",
  "ironrdp",
  "jet-proto",
+ "jmux-proxy",
  "lazy_static",
  "native-tls",
  "packet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "jet-proto",
     "jetsocat",
     "jetsocat/proxy",
+    "jmux-proto",
+    "jmux-proxy",
     "benchmark",
     "tools/*"
 ]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["François Dubois <fdubois@devolutions.net>",
 
 [dependencies]
 jet-proto = { path = "../jet-proto" }
+jmux-proxy = { path = "../jmux-proxy" }
 picky = { version = "6.3", default-features = false, features = ["jose"] }
 ceviche = "0.4"
 ctrlc = "3.1"

--- a/devolutions-gateway/src/http/controllers/jet.rs
+++ b/devolutions-gateway/src/http/controllers/jet.rs
@@ -140,7 +140,7 @@ impl JetController {
 
             if association.get_candidates().is_empty() {
                 for listener in &self.config.listeners {
-                    if let Some(candidate) = Candidate::new(&listener.external_url.to_string().trim_end_matches('/')) {
+                    if let Some(candidate) = Candidate::new(listener.external_url.to_string().trim_end_matches('/')) {
                         association.add_candidate(candidate);
                     }
                 }

--- a/devolutions-gateway/src/http/middlewares/auth.rs
+++ b/devolutions-gateway/src/http/middlewares/auth.rs
@@ -72,7 +72,7 @@ async fn auth_middleware(
     };
 
     if let Some((AuthHeaderType::Bearer, token)) = parse_auth_header(auth_value) {
-        match validate_bearer_token(&config, &token) {
+        match validate_bearer_token(&config, token) {
             Ok(jet_token) => {
                 request.extensions_mut().insert(jet_token);
                 return chain.next(ctx).await;
@@ -128,7 +128,7 @@ fn validate_bearer_token(config: &Config, token: &str) -> Result<JetAccessTokenC
     let now = JwtDate::new_with_leeway(Utc::now().timestamp(), 10 * 60);
     let validator = JwtValidator::strict(&now);
 
-    let jwt = JwtSig::<JetAccessTokenClaims>::decode(&token, key, &validator)
+    let jwt = JwtSig::<JetAccessTokenClaims>::decode(token, key, &validator)
         .map_err(|e| format!("Invalid jet token: {:?}", e))?;
 
     Ok(jwt.claims)

--- a/devolutions-gateway/src/http/middlewares/auth.rs
+++ b/devolutions-gateway/src/http/middlewares/auth.rs
@@ -117,7 +117,7 @@ pub fn parse_auth_header(auth_header: &str) -> Option<(AuthHeaderType, &str)> {
     }
 }
 
-fn validate_bearer_token(config: &Config, token: &str) -> Result<JetAccessTokenClaims, String> {
+pub fn validate_bearer_token(config: &Config, token: &str) -> Result<JetAccessTokenClaims, String> {
     use picky::jose::jwt::{JwtSig, JwtValidator};
 
     let key = config

--- a/devolutions-gateway/src/preconnection_pdu.rs
+++ b/devolutions-gateway/src/preconnection_pdu.rs
@@ -36,7 +36,7 @@ pub fn extract_association_claims(
             .as_ref()
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Delegation key is missing"))?;
 
-        jwe_token = Jwe::decode(&encrypted_jwt, &delegation_key).map_err(|e| {
+        jwe_token = Jwe::decode(encrypted_jwt, delegation_key).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Failed to decode encrypted JWT routing token: {}", e),
@@ -62,7 +62,7 @@ pub fn extract_association_claims(
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "Provisioner key is missing"))?;
 
     let jwt_token =
-        JwtSig::<JetAssociationTokenClaims>::decode(signed_jwt, &provisioner_key, &validator).map_err(|e| {
+        JwtSig::<JetAssociationTokenClaims>::decode(signed_jwt, provisioner_key, &validator).map_err(|e| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Failed to decode signed payload of JWT routing token: {}", e),

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -320,12 +320,10 @@ async fn start_tcp_server(
                                     .serve(JetTransport::new_tcp(conn), tls_acceptor)
                                     .await
                                 }
-                                [b'J', b'M', b'U', b'X'] => {
-                                    return Err(io::Error::new(
-                                        io::ErrorKind::Other,
-                                        "JMUX listener not yet implemented",
-                                    ));
-                                }
+                                [b'J', b'M', b'U', b'X'] => Err(io::Error::new(
+                                    io::ErrorKind::Other,
+                                    "JMUX TCP listener not yet implemented",
+                                )),
                                 _ => {
                                     GenericClient {
                                         config,

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -33,10 +33,7 @@ pub struct JetAssociationTokenClaims {
 
 impl JetAssociationTokenClaims {
     pub fn contains_secrets(&self) -> bool {
-        match &self.jet_cm {
-            ConnectionMode::Fwd { creds: Some(_), .. } => true,
-            _ => false,
-        }
+        matches!(&self.jet_cm, ConnectionMode::Fwd { creds: Some(_), .. })
     }
 }
 

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -8,6 +8,7 @@ pub enum JetAccessTokenClaims {
     Association(JetAssociationTokenClaims),
     Scope(JetScopeTokenClaims),
     Bridge(JetBridgeTokenClaims),
+    Jmux(JetJmuxTokenClaims),
 }
 
 #[derive(Deserialize, Clone)]
@@ -98,4 +99,9 @@ pub enum JetAccessScope {
 #[derive(Clone, Deserialize)]
 pub struct JetBridgeTokenClaims {
     pub target_host: String, // "<HOST>:<PORT>"
+}
+
+#[derive(Clone, Deserialize)]
+pub struct JetJmuxTokenClaims {
+    filtering: Option<()>, // TODO
 }

--- a/devolutions-gateway/src/utils.rs
+++ b/devolutions-gateway/src/utils.rs
@@ -52,7 +52,7 @@ macro_rules! io_try {
 }
 
 pub fn get_tls_peer_pubkey<S>(stream: &tokio_rustls::TlsStream<S>) -> io::Result<Vec<u8>> {
-    let der = get_der_cert_from_stream(&stream)?;
+    let der = get_der_cert_from_stream(stream)?;
     get_pub_key_from_der(&der)
 }
 

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -14,9 +14,12 @@ native-tls = ["async-tungstenite/tokio-native-tls"]
 
 [dependencies]
 
-# jet protocol for TCP transport
+# jet protocol support
 jet-proto = { path = "../jet-proto" }
 uuid = "0.8"
+
+# jmux protocol support
+jmux-proxy = { path = "../jmux-proxy" }
 
 # proxy support
 jetsocat-proxy = { path = "./proxy" }
@@ -27,7 +30,6 @@ seahorse = "1"
 
 # async
 tokio = { version = "1", features = ["io-std", "io-util", "net", "rt", "sync", "process", "rt-multi-thread", "macros"] }
-tokio-util = { version = "0.6", features = ["codec"] }
 futures-util = "0.3"
 async-tungstenite = "0.14"
 
@@ -41,8 +43,3 @@ anyhow = "1"
 
 # location of special directories
 dirs-next = "2"
-
-# utils
-bytes = "1"
-bitvec = "0.22"
-

--- a/jetsocat/proxy/Cargo.toml
+++ b/jetsocat/proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "jetsocat-proxy"
 version = "0.1.0"
 authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
 edition = "2021"
-description = "SOCKS proxy clients implementation for jetsocat"
+description = "HTTP(S)/SOCKS proxy clients and acceptors implementations for jetsocat"
 
 [[bin]]
 name = "socks5_server"

--- a/jetsocat/proxy/src/lib.rs
+++ b/jetsocat/proxy/src/lib.rs
@@ -103,14 +103,12 @@ impl<'a> ToDestAddr for &'a str {
             return addr.to_dest_addr();
         }
 
-        let parts: Vec<&str> = self.rsplitn(2, ':').collect();
+        let (host, port) = self
+            .rsplit_once(':')
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "bad socket address format"))?;
 
-        if parts.len() < 2 {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "bad socket address format"));
-        }
-
-        let host = parts[1].to_owned();
-        let port = parts[0]
+        let host = host.to_owned();
+        let port = port
             .parse()
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, format!("invalid port value: {}", e)))?;
 

--- a/jetsocat/src/listener.rs
+++ b/jetsocat/src/listener.rs
@@ -21,6 +21,8 @@ pub async fn tcp_listener_task(
     use anyhow::Context as _;
     use tokio::net::TcpListener;
 
+    let destination_url = format!("tcp://{}", destination_url);
+
     let listener = TcpListener::bind(&bind_addr)
         .await
         .with_context(|| format!("Couldn’t bind listener to {}", bind_addr))?;
@@ -124,8 +126,8 @@ async fn socks5_process_socket(
 
     if acceptor.is_connect_command() {
         let destination_url = match acceptor.dest_addr() {
-            jetsocat_proxy::DestAddr::Ip(addr) => addr.to_string(),
-            jetsocat_proxy::DestAddr::Domain(domain, port) => format!("{}:{}", domain, port),
+            jetsocat_proxy::DestAddr::Ip(addr) => format!("tcp://{}", addr),
+            jetsocat_proxy::DestAddr::Domain(domain, port) => format!("tcp://{}:{}", domain, port),
         };
 
         debug!(log, "Request {}", destination_url);
@@ -150,7 +152,7 @@ async fn socks5_process_socket(
             }
         };
 
-        // Dummy local address required for SOCKS5 response (JMUX doesn't send this information).
+        // Dummy local address required for SOCKS5 response (JMUX protocol doesn't include this information).
         // It appears to not be an issue in general: it's used to act as if the SOCKS5 client opened a
         // socket stream as usual with a local bound address [provided by TcpStream::local_addr],
         // but I'm not aware of many application relying on this. If this become an issue we may

--- a/jetsocat/src/listener.rs
+++ b/jetsocat/src/listener.rs
@@ -55,7 +55,7 @@ pub async fn tcp_listener_task(
                             let _ = api_request_tx.send(JmuxApiRequest::Start { id, stream });
                         }
                         Some(JmuxApiResponse::Failure { id, reason_code }) => {
-                            warn!(log, "Channel {} failed with reason code: {}", id, reason_code);
+                            debug!(log, "Channel {} failure: {}", id, reason_code);
                         }
                         None => {}
                     }
@@ -146,8 +146,7 @@ async fn socks5_process_socket(
         let id = match receiver.recv().await.context("negotiation interrupted")? {
             JmuxApiResponse::Success { id } => id,
             JmuxApiResponse::Failure { id, reason_code } => {
-                warn!(log, "Channel {} failed with reason code: {}", id, reason_code);
-                anyhow::bail!("Channel creation failed");
+                anyhow::bail!("Channel {} failure: {}", id, reason_code);
             }
         };
 

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Context as _;
-use jetsocat::jmux::listener::ListenerMode;
+use jetsocat::listener::ListenerMode;
 use jetsocat::pipe::PipeMode;
 use jetsocat::proxy::{detect_proxy, ProxyConfig, ProxyType};
 use seahorse::{App, Command, Context, Flag, FlagType};

--- a/jetsocat/src/pipe.rs
+++ b/jetsocat/src/pipe.rs
@@ -196,7 +196,16 @@ pub async fn open_pipe(mode: PipeMode, proxy_cfg: Option<ProxyConfig>, log: Logg
         PipeMode::WebSocket { url } => {
             use crate::utils::ws_connect;
 
-            info!(log, "Connecting WebSocket at {}", url);
+            info!(
+                log,
+                "Connecting WebSocket at {}",
+                // Do not log the query part at info level
+                if let Some((without_query, _)) = url.split_once('?') {
+                    without_query
+                } else {
+                    &url
+                }
+            );
 
             let (read, write, rsp) = ws_connect(url, proxy_cfg)
                 .await

--- a/jmux-proto/Cargo.toml
+++ b/jmux-proto/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "jmux-proto"
+version = "0.1.0"
+authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
+edition = "2021"
+
+[dependencies]
+bytes = "1"

--- a/jmux-proto/src/lib.rs
+++ b/jmux-proto/src/lib.rs
@@ -695,7 +695,10 @@ mod tests {
     #[test]
     fn header_decode_buffer_too_short_err() {
         let err = Header::decode(Bytes::from_static(&[])).err().unwrap();
-        assert_eq!("Not enough bytes provided to decode HEADER: received 0 bytes, expected 4 bytes", err.to_string());
+        assert_eq!(
+            "Not enough bytes provided to decode HEADER: received 0 bytes, expected 4 bytes",
+            err.to_string()
+        );
     }
 
     #[test]

--- a/jmux-proto/src/lib.rs
+++ b/jmux-proto/src/lib.rs
@@ -395,11 +395,15 @@ impl ChannelOpen {
     pub const FIXED_PART_SIZE: usize = 4 /* senderChannelId */ + 4 /* initialWindowSize */ + 2 /* maximumPacketSize */;
 
     pub fn new(id: LocalChannelId, maximum_packet_size: u16, destination_url: impl Into<String>) -> Self {
+        let destination_url = destination_url.into();
+        // Debug-only sanity checks
+        debug_assert!(destination_url.contains("://"));
+        debug_assert!(destination_url.rfind(':').is_some());
         Self {
             sender_channel_id: u32::from(id),
             initial_window_size: Self::DEFAULT_INITIAL_WINDOW_SIZE,
             maximum_packet_size,
-            destination_url: destination_url.into(),
+            destination_url,
         }
     }
 
@@ -691,7 +695,7 @@ mod tests {
     #[test]
     fn header_decode_buffer_too_short_err() {
         let err = Header::decode(Bytes::from_static(&[])).err().unwrap();
-        assert_eq!("Not enough bytes provided to decode HEADER", err.to_string());
+        assert_eq!("Not enough bytes provided to decode HEADER: received 0 bytes, expected 4 bytes", err.to_string());
     }
 
     #[test]

--- a/jmux-proxy/Cargo.toml
+++ b/jmux-proxy/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "jmux-proxy"
+version = "0.1.0"
+authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
+edition = "2021"
+description = "JMUX proxy server implementation"
+
+[dependencies]
+
+# jmux
+jmux-proto = { path = "../jmux-proto" }
+
+# async
+tokio = { version = "1", features = ["net", "rt", "io-util", "macros"] }
+tokio-util = { version = "0.6", features = ["codec"] }
+futures-util = { version = "0.3", features = ["sink"] }
+
+# error handling
+anyhow = "1"
+
+# logging
+slog = "2"
+
+# codec implementation
+bytes = "1"
+bitvec = "0.22"

--- a/jmux-proxy/src/codec.rs
+++ b/jmux-proxy/src/codec.rs
@@ -1,8 +1,9 @@
-use crate::jmux::proto::{Header, Message};
 use anyhow::Context as _;
 use bytes::BytesMut;
+use jmux_proto::{Header, Message};
 use tokio_util::codec::{Decoder, Encoder};
 
+/// This is a purely arbitrary number
 pub const MAXIMUM_PACKET_SIZE_IN_BYTES: usize = 4096;
 
 pub struct JmuxCodec;
@@ -55,10 +56,10 @@ impl Encoder<Message> for JmuxCodec {
     type Error = anyhow::Error;
 
     fn encode(&mut self, item: Message, dst: &mut BytesMut) -> Result<(), Self::Error> {
-        if item.len() > MAXIMUM_PACKET_SIZE_IN_BYTES {
+        if item.size() > MAXIMUM_PACKET_SIZE_IN_BYTES {
             anyhow::bail!(
                 "Attempted to send a JMUX packet whose size is too big: {} (max is {})",
-                item.len(),
+                item.size(),
                 MAXIMUM_PACKET_SIZE_IN_BYTES
             );
         }

--- a/jmux-proxy/src/config.rs
+++ b/jmux-proxy/src/config.rs
@@ -1,0 +1,235 @@
+use anyhow::Context;
+
+/// JMUX proxy configuration struct.
+///
+/// All paramaters are designed to be opt-in rather than opt-out: default values are conservatives
+/// and always safe (whitelist approach).
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct JmuxConfig {
+    /// Rule to use when filtering requests.
+    pub filtering: FilteringRule,
+}
+
+impl JmuxConfig {
+    /// A safe default JMUX configuration.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The most permissive configuration.
+    pub fn permissive() -> Self {
+        Self {
+            filtering: FilteringRule::Allow,
+        }
+    }
+
+    /// A safe default for client only.
+    ///
+    /// This configuration effectively disable proxying abilities and kind of
+    /// reduce the JMUX "proxy" to a JMUX client.
+    pub fn client() -> Self {
+        Self {
+            filtering: FilteringRule::Deny,
+            ..Self::default()
+        }
+    }
+}
+
+/// Filtering rule for JMUX requests.
+///
+/// ```
+/// use jmux_proxy::FilteringRule;
+///
+/// # fn main() -> anyhow::Result<()> {
+/// let always_allow = FilteringRule::Allow;
+///
+/// always_allow.validate_target("devolutions.net:80")?;
+/// always_allow.validate_target("127.0.0.1:8080")?;
+///
+/// // Let's build this rule:
+/// //   (
+/// //     port 80
+/// //     AND ( host doc.rust-lang.org OR second-level domain segment named "devolutions" )
+/// //   )
+/// //   OR ( port 22 AND any domain segment named "vps" )
+/// //   OR ( NOT { port 1080 } AND host sekai.net )
+/// //   OR host:port 127.0.0.1:8080
+/// let elaborated_rule = FilteringRule::port(80)
+///     .and(
+///         FilteringRule::host("doc.rust-lang.org")
+///             .or(FilteringRule::specific_domain_segment("devolutions", 2))
+///     )
+///     .or(FilteringRule::port(22).and(FilteringRule::any_domain_segment("vps")))
+///     .or(FilteringRule::port(1080).invert().and(FilteringRule::host("sekai.net")))
+///     .or(FilteringRule::host_and_port("127.0.0.1", 8080));
+///
+/// elaborated_rule.validate_target("doc.rust-lang.org:80")?;
+/// elaborated_rule.validate_target("devolutions.net:80")?;
+/// elaborated_rule.validate_target("dvls.devolutions.net:80")?;
+/// assert!(elaborated_rule.validate_target("devolutions.bad.ninja:80").is_err());
+/// assert!(elaborated_rule.validate_target("duckduckgo.com:80").is_err());
+///
+/// elaborated_rule.validate_target("vps.my-web-site.com:22")?;
+/// elaborated_rule.validate_target("vps.rust-lang.org:22")?;
+/// elaborated_rule.validate_target("super.vps.ninja:22")?;
+/// assert!(elaborated_rule.validate_target("vps.my-web-site.com:2222").is_err());
+/// assert!(elaborated_rule.validate_target("myvps.ovh.com:22").is_err());
+/// assert!(elaborated_rule.validate_target("doc.rust-lang.org:22").is_err());
+/// assert!(elaborated_rule.validate_target("127.0.0.1:22").is_err());
+///
+/// elaborated_rule.validate_target("sekai.net:80")?;
+/// elaborated_rule.validate_target("sekai.net:8080")?;
+/// elaborated_rule.validate_target("sekai.net:22")?;
+/// assert!(elaborated_rule.validate_target("sekai.net:1080").is_err());
+///
+/// elaborated_rule.validate_target("127.0.0.1:8080")?;
+/// assert!(elaborated_rule.validate_target("doc.rust-lang.org:8080").is_err());
+/// assert!(elaborated_rule.validate_target("127.0.0.1:80").is_err());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub enum FilteringRule {
+    /// Always denied.
+    Deny,
+    /// Always allowed.
+    Allow,
+    /// Invert the rule
+    Not(Box<FilteringRule>),
+    /// Must fullfill every rule.
+    All(Vec<FilteringRule>),
+    /// Must fullfill at least one rule.
+    Any(Vec<FilteringRule>),
+    /// Host must match exactly.
+    Host(String),
+    /// Port must match exactly.
+    Port(u16),
+    /// Host and port must match exactly.
+    HostAndPort { host: String, port: u16 },
+    /// Name must match exactly
+    SpecificDomainSegment { name: String, level: usize },
+    /// Name must match exactly.
+    AnyDomainSegment { name: String },
+}
+
+impl Default for FilteringRule {
+    fn default() -> Self {
+        FilteringRule::Deny
+    }
+}
+
+impl FilteringRule {
+    pub fn deny() -> Self {
+        Self::Deny
+    }
+
+    pub fn allow() -> Self {
+        Self::Allow
+    }
+
+    /// Puts current rule behind a NOT operator
+    pub fn invert(self) -> Self {
+        Self::Not(Box::new(self))
+    }
+
+    pub fn host(host: impl Into<String>) -> Self {
+        Self::Host(host.into())
+    }
+
+    pub fn port(port: u16) -> Self {
+        Self::Port(port)
+    }
+
+    pub fn host_and_port(host: impl Into<String>, port: u16) -> Self {
+        Self::HostAndPort {
+            host: host.into(),
+            port,
+        }
+    }
+
+    pub fn specific_domain_segment(name: impl Into<String>, level: usize) -> Self {
+        Self::SpecificDomainSegment {
+            name: name.into(),
+            level,
+        }
+    }
+
+    pub fn any_domain_segment(name: impl Into<String>) -> Self {
+        Self::AnyDomainSegment { name: name.into() }
+    }
+
+    /// Combine current rule using an "AND" operator
+    pub fn and(self, rule: Self) -> Self {
+        match self {
+            Self::Allow => rule,
+            Self::All(mut sub_rules) => {
+                sub_rules.push(rule);
+                Self::All(sub_rules)
+            }
+            current_rule => {
+                let mut sub_rules = Vec::with_capacity(16);
+                sub_rules.push(current_rule);
+                sub_rules.push(rule);
+                Self::All(sub_rules)
+            }
+        }
+    }
+
+    /// Combine current rule using an "OR" operator
+    pub fn or(self, rule: Self) -> Self {
+        match self {
+            Self::Deny => rule,
+            Self::Any(mut sub_rules) => {
+                sub_rules.push(rule);
+                Self::Any(sub_rules)
+            }
+            current_rule => {
+                let mut sub_rules = Vec::with_capacity(16);
+                sub_rules.push(current_rule);
+                sub_rules.push(rule);
+                Self::Any(sub_rules)
+            }
+        }
+    }
+
+    pub fn validate_target(&self, target: impl AsRef<str>) -> anyhow::Result<()> {
+        validate_target_impl(self, target.as_ref())
+    }
+}
+
+fn validate_target_impl(rule: &FilteringRule, target: &str) -> anyhow::Result<()> {
+    let (host, port) = target.rsplit_once(':').context("invalid target format")?;
+    let port = port.parse().context("invalid port value")?;
+
+    if is_valid(rule, host, port) {
+        Ok(())
+    } else {
+        anyhow::bail!("target doesn't obey the filtering rule");
+    }
+}
+
+fn is_valid(rule: &FilteringRule, target_host: &str, target_port: u16) -> bool {
+    match rule {
+        FilteringRule::Deny => false,
+        FilteringRule::Allow => true,
+        FilteringRule::Not(rule) => !is_valid(rule, target_host, target_port),
+        FilteringRule::All(rules) => rules.iter().all(|r| is_valid(r, target_host, target_port)),
+        FilteringRule::Any(rules) => rules.iter().any(|r| is_valid(r, target_host, target_port)),
+        FilteringRule::Host(host) => target_host == host,
+        FilteringRule::Port(port) => target_port == *port,
+        FilteringRule::HostAndPort { host, port } => target_host == host && target_port == *port,
+        FilteringRule::SpecificDomainSegment { name, level } => {
+            if *level == 0 {
+                false
+            } else {
+                target_host
+                    .rsplit('.')
+                    .nth(level - 1)
+                    .into_iter()
+                    .all(|segment| segment == name)
+            }
+        }
+        FilteringRule::AnyDomainSegment { name } => target_host.rsplit('.').any(|segment| segment == name),
+    }
+}

--- a/jmux-proxy/src/id_allocator.rs
+++ b/jmux-proxy/src/id_allocator.rs
@@ -1,55 +1,10 @@
 use bitvec::prelude::*;
+use jmux_proto::LocalChannelId;
 use std::convert::TryFrom;
 
 pub trait Id: Copy + From<u32> + Into<u32> {}
 
-/// Distant identifier for a channel
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct DistantChannelId(u32);
-
-impl From<u32> for DistantChannelId {
-    fn from(v: u32) -> Self {
-        Self(v)
-    }
-}
-
-impl From<DistantChannelId> for u32 {
-    fn from(id: DistantChannelId) -> Self {
-        id.0
-    }
-}
-
-impl Id for DistantChannelId {}
-
-impl std::fmt::Display for DistantChannelId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "d#{}", self.0)
-    }
-}
-
-/// Local identifier for a channel
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-pub struct LocalChannelId(u32);
-
-impl From<u32> for LocalChannelId {
-    fn from(v: u32) -> Self {
-        Self(v)
-    }
-}
-
-impl From<LocalChannelId> for u32 {
-    fn from(id: LocalChannelId) -> Self {
-        id.0
-    }
-}
-
 impl Id for LocalChannelId {}
-
-impl std::fmt::Display for LocalChannelId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "l#{}", self.0)
-    }
-}
 
 pub struct IdAllocator<T: Id> {
     taken: BitVec,

--- a/tools/tokengen/src/main.rs
+++ b/tools/tokengen/src/main.rs
@@ -30,6 +30,7 @@ enum SubCommand {
     RdpTls(TlsParams),
     RdpTcpRendezvous,
     Scope(ScopeParams),
+    Jmux,
 }
 
 #[derive(Clap)]
@@ -65,11 +66,11 @@ struct ScopeParams {
 
 #[derive(Clone, Serialize)]
 #[serde(tag = "type")]
+#[serde(rename_all = "kebab-case")]
 enum GatewayAccessClaims<'a> {
-    #[serde(rename = "association")]
     RoutingClaims(RoutingClaims<'a>),
-    #[serde(rename = "scope")]
     ScopeClaims(ScopeClaims),
+    Jmux(JmuxClaims),
 }
 
 #[derive(Clone, Serialize)]
@@ -89,6 +90,12 @@ struct ScopeClaims {
     exp: i64,
     nbf: i64,
     scope: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct JmuxClaims {
+    exp: i64,
+    nbf: i64,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -128,6 +135,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             exp: exp as i64,
             nbf: now.as_secs() as i64,
             scope: params.scope.clone(),
+        }),
+        SubCommand::Jmux => GatewayAccessClaims::Jmux(JmuxClaims {
+            exp: exp as i64,
+            nbf: now.as_secs() as i64,
         }),
         _ => GatewayAccessClaims::RoutingClaims(RoutingClaims {
             exp: exp as i64,


### PR DESCRIPTION
Expose JMUX proxy through the new `/jmux` websocket endpoint.

A JMUX token must be provided either through query params or the `Authorization` header.

## Misc

- Extracted jmux-related code into jmux-proto and jmux-proxy crates
- Improved JMUX proxy related logs
- Support for target filtering

## Demo

![image](https://user-images.githubusercontent.com/3809077/139746655-6b1ee4ad-11ef-4ecb-847c-3a5670b85995.png)
![image](https://user-images.githubusercontent.com/3809077/139746692-e913c997-e094-4c3b-9e69-1ac64f7b14a3.png)

### Commands used:

```
$ cargo run -p devolutions-gateway -- --hostname jet-relay.ngrok.io -l "ws://*:7171,wss://*:443" --provisioner-public-key-file /etc/wayk-bastion/den-gateway/provisioner.pem
```

```
$ cargo run -p tokengen -- --provider-private-key /etc/wayk-bastion/den-server/den-private.key jmux
```

```
$ cargo run -p jetsocat -- jmux-proxy "ws://127.0.0.1:7171/jmux?token=<GENERATED TOKEN>" socks5-listen://0.0.0.0:5003 --log-term
```