### PR TITLE
DPS-5167: duplicate root HTTP endpoints under jet/

### DIFF
--- a/devolutions-gateway/src/http/controllers/diagnostics.rs
+++ b/devolutions-gateway/src/http/controllers/diagnostics.rs
@@ -71,7 +71,7 @@ async fn get_configuration_stub(controller: &DiagnosticsController) -> Json<Gate
     Json(controller.config.clone().into())
 }
 
-// TODO: remove legacy controller after 2022/11/19
+// NOTE: legacy controller starting 2021/11/25
 
 pub struct LegacyDiagnosticsController {
     inner: DiagnosticsController,

--- a/devolutions-gateway/src/http/controllers/health.rs
+++ b/devolutions-gateway/src/http/controllers/health.rs
@@ -32,7 +32,7 @@ fn get_health_stub(controller: &HealthController) -> String {
     )
 }
 
-// TODO: remove legacy controller after 2022/11/19
+// NOTE: legacy controller starting 2021/11/25
 
 pub struct LegacyHealthController {
     inner: HealthController,

--- a/devolutions-gateway/src/http/controllers/http_bridge.rs
+++ b/devolutions-gateway/src/http/controllers/http_bridge.rs
@@ -22,7 +22,7 @@ impl Default for HttpBridgeController {
     }
 }
 
-#[controller(name = "bridge")]
+#[controller(name = "jet/bridge")]
 impl HttpBridgeController {
     #[get("/message")]
     #[post("/message")]

--- a/devolutions-gateway/src/http/controllers/mod.rs
+++ b/devolutions-gateway/src/http/controllers/mod.rs
@@ -1,6 +1,6 @@
+pub mod association;
 pub mod diagnostics;
 pub mod health;
 pub mod http_bridge;
-pub mod jet;
 pub mod sessions;
 pub mod sogar_token;

--- a/devolutions-gateway/src/http/controllers/sessions.rs
+++ b/devolutions-gateway/src/http/controllers/sessions.rs
@@ -9,7 +9,7 @@ use saphir::prelude::Json;
 
 pub struct SessionsController;
 
-#[controller(name = "sessions")]
+#[controller(name = "jet/sessions")]
 impl SessionsController {
     #[get("/count")]
     #[guard(
@@ -17,8 +17,7 @@ impl SessionsController {
         init_expr = r#"JetTokenType::Scope(JetAccessScope::GatewaySessionsRead)"#
     )]
     async fn get_count(&self) -> (StatusCode, String) {
-        let sessions = SESSIONS_IN_PROGRESS.read().await;
-        (StatusCode::OK, sessions.len().to_string())
+        get_count_stub().await
     }
 
     #[get("/")]
@@ -27,10 +26,44 @@ impl SessionsController {
         init_expr = r#"JetTokenType::Scope(JetAccessScope::GatewaySessionsRead)"#
     )]
     async fn get_sessions(&self) -> Result<Json<Vec<GatewaySessionInfo>>, HttpErrorStatus> {
-        let sessions = SESSIONS_IN_PROGRESS.read().await;
+        get_sessions_stub().await
+    }
+}
 
-        let sessions_in_progress: Vec<GatewaySessionInfo> = sessions.values().cloned().collect();
+async fn get_count_stub() -> (StatusCode, String) {
+    let sessions = SESSIONS_IN_PROGRESS.read().await;
+    (StatusCode::OK, sessions.len().to_string())
+}
 
-        Ok(Json(sessions_in_progress))
+async fn get_sessions_stub() -> Result<Json<Vec<GatewaySessionInfo>>, HttpErrorStatus> {
+    let sessions = SESSIONS_IN_PROGRESS.read().await;
+
+    let sessions_in_progress: Vec<GatewaySessionInfo> = sessions.values().cloned().collect();
+
+    Ok(Json(sessions_in_progress))
+}
+
+// TODO: remove legacy controller after 2022/11/19
+
+pub struct LegacySessionsController;
+
+#[controller(name = "sessions")]
+impl LegacySessionsController {
+    #[get("/count")]
+    #[guard(
+        AccessGuard,
+        init_expr = r#"JetTokenType::Scope(JetAccessScope::GatewaySessionsRead)"#
+    )]
+    async fn get_count(&self) -> (StatusCode, String) {
+        get_count_stub().await
+    }
+
+    #[get("/")]
+    #[guard(
+        AccessGuard,
+        init_expr = r#"JetTokenType::Scope(JetAccessScope::GatewaySessionsRead)"#
+    )]
+    async fn get_sessions(&self) -> Result<Json<Vec<GatewaySessionInfo>>, HttpErrorStatus> {
+        get_sessions_stub().await
     }
 }

--- a/devolutions-gateway/src/http/controllers/sessions.rs
+++ b/devolutions-gateway/src/http/controllers/sessions.rs
@@ -43,7 +43,7 @@ async fn get_sessions_stub() -> Result<Json<Vec<GatewaySessionInfo>>, HttpErrorS
     Ok(Json(sessions_in_progress))
 }
 
-// TODO: remove legacy controller after 2022/11/19
+// NOTE: legacy controller starting 2021/11/25
 
 pub struct LegacySessionsController;
 

--- a/devolutions-gateway/src/http/http_server.rs
+++ b/devolutions-gateway/src/http/http_server.rs
@@ -1,9 +1,9 @@
 use crate::config::Config;
+use crate::http::controllers::association::AssociationController;
 use crate::http::controllers::diagnostics::DiagnosticsController;
 use crate::http::controllers::health::HealthController;
 use crate::http::controllers::http_bridge::HttpBridgeController;
-use crate::http::controllers::jet::JetController;
-use crate::http::controllers::sessions::SessionsController;
+use crate::http::controllers::sessions::{LegacySessionsController, SessionsController};
 use crate::http::controllers::sogar_token::TokenController;
 use crate::http::middlewares::auth::AuthMiddleware;
 use crate::http::middlewares::log::LogMiddleware;
@@ -26,37 +26,36 @@ pub fn configure_http_server(config: Arc<Config>, jet_associations: JetAssociati
                 .apply(
                     AuthMiddleware::new(config.clone()),
                     vec!["/"],
-                    vec!["/registry", "/health"],
+                    vec!["/registry", "/health", "/jet/health"],
                 )
                 .apply(
                     SogarAuthMiddleware::new(config.clone()),
                     vec!["/registry"],
-                    vec!["registry/oauth2/token"],
+                    vec!["/registry/oauth2/token"],
                 )
                 .apply(LogMiddleware, vec!["/"], None)
         })
         .configure_router(|router| {
             info!("Loading HTTP controllers");
-            let diagnostics = DiagnosticsController::new(config.clone());
-            let health = HealthController::new(config.clone());
-            let http_bridge = HttpBridgeController::new();
-            let jet = JetController::new(config.clone(), jet_associations.clone());
-            let session = SessionsController;
 
+            let (diagnostics, legacy_diagnostics) = DiagnosticsController::new(config.clone());
+            let (health, legacy_health) = HealthController::new(config.clone());
+            let http_bridge = HttpBridgeController::new();
+            let jet = AssociationController::new(config.clone(), jet_associations.clone());
+
+            // sogar stuff
+            let token_controller = TokenController::new(config.clone());
             let registry_name = config
                 .sogar_registry_config
                 .local_registry_name
                 .clone()
                 .unwrap_or_else(|| String::from(REGISTRY_NAME));
-
             let registry_namespace = config
                 .sogar_registry_config
                 .local_registry_image
                 .clone()
                 .unwrap_or_else(|| String::from(NAMESPACE));
-
             let sogar = SogarController::new(registry_name.as_str(), registry_namespace.as_str());
-            let token_controller = TokenController::new(config.clone());
 
             info!("Configuring HTTP router");
 
@@ -65,9 +64,12 @@ pub fn configure_http_server(config: Arc<Config>, jet_associations: JetAssociati
                 .controller(health)
                 .controller(http_bridge)
                 .controller(jet)
-                .controller(session)
+                .controller(SessionsController)
                 .controller(sogar)
                 .controller(token_controller)
+                .controller(legacy_health)
+                .controller(legacy_diagnostics)
+                .controller(LegacySessionsController)
         })
         .configure_listener(|listener| listener.server_name("Devolutions Gateway"))
         .build_stack_only()

--- a/devolutions-gateway/src/jet_rendezvous_tcp_proxy.rs
+++ b/devolutions-gateway/src/jet_rendezvous_tcp_proxy.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::http::controllers::jet::start_remove_association_future;
+use crate::http::controllers::association::start_remove_association_future;
 use crate::jet::candidate::CandidateState;
 use crate::jet_client::JetAssociationsMap;
 use crate::proxy::Proxy;


### PR DESCRIPTION
We need to be able to access all important endpoints through `jet/*` to
simplify routing rules.

Older endpoints are still accessibles for compatibility, but will be
removed after one year starting today (2021/11/19).

Note 1: this also fixes DPS-5166 (`jet/health` requiring authorization)

Note 2: `bridge/*` is moved to `jet/bridge/*` without adding compatibility
routes because it's currently unused.

Note 3: `registry/*` is left untouched for now, particular attention is
needed. Since it's not yet used in other products, this shouldn't be an
issue to postpone decision here.