### PR TITLE
DPS-5255: support for alternate hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "chrono",
  "clap 2.33.3",
  "ctrlc",
+ "display_utils",
  "dlopen",
  "dlopen_derive",
  "embed-resource",
@@ -740,6 +741,7 @@ dependencies = [
  "slog-scope-futures 0.1.1 (git+https://github.com/Devolutions/slog-scope-futures.git)",
  "slog-stdlog",
  "slog-term",
+ "smol_str",
  "sogar-core",
  "spsc-bip-buffer",
  "sspi",
@@ -793,6 +795,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "display_utils"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cabb9d45c20801e16b8483e998bd1ebe4a07bc56406135ded5b4e3ad140c30"
 
 [[package]]
 name = "dlopen"
@@ -2944,6 +2952,15 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
+name = "smol_str"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61d15c83e300cce35b7c8cd39ff567c1ef42dde6d4a1a38dbdbf9a59902261bd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -59,6 +59,8 @@ reqwest = "0.11.6"
 http = "0.2.5"
 zeroize = "1.4.2"
 camino = { version = "1.0.5", features = ["serde1"] }
+smol_str = "0.1.21"
+display_utils = "0.4.0"
 
 [dependencies.saphir]
 version = "2.8"

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -721,9 +721,11 @@ impl Config {
                 rustls::PrivateKey(pem.into_data().into_owned())
             });
 
-        config.tls = tls_certificate
+        tls_certificate
             .zip(tls_private_key)
-            .map(|(certificate, key)| TlsConfig::init(certificate, key).expect("couldn't init TLS config"));
+            .map(|(certificate, key)| TlsConfig::init(certificate, key).expect("couldn't init TLS config"))
+            .into_iter()
+            .for_each(|tls_conf| config.tls = Some(tls_conf));
 
         // provisioner key
 

--- a/devolutions-gateway/src/http/controllers/http_bridge.rs
+++ b/devolutions-gateway/src/http/controllers/http_bridge.rs
@@ -61,9 +61,12 @@ impl HttpBridgeController {
                 .next()
                 .expect("Split always returns at least one element");
 
-            format!("http://{}{}", claims.target_host, request_target)
-                .parse()
-                .map_err(HttpErrorStatus::bad_request)?
+            claims
+                .target_host
+                .to_uri_with_path_and_query(request_target)
+                .map_err(|e| {
+                    HttpErrorStatus::bad_request(format!("Request-Target header has an invalid value: {}", e))
+                })?
         } else {
             return Err(HttpErrorStatus::forbidden("token not allowed"));
         };

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -32,71 +32,58 @@ pub use proxy::Proxy;
 use chrono::{DateTime, Utc};
 use lazy_static::lazy_static;
 use std::collections::HashMap;
-use token::{ApplicationProtocol, ConnectionMode, JetAssociationTokenClaims};
+use token::ApplicationProtocol;
 use tokio::sync::RwLock;
+use utils::TargetAddr;
 use uuid::Uuid;
 
 lazy_static! {
     pub static ref SESSIONS_IN_PROGRESS: RwLock<HashMap<Uuid, GatewaySessionInfo>> = RwLock::new(HashMap::new());
 }
 
-#[derive(Serialize, Clone, Copy)]
-#[serde(rename_all = "kebab-case")]
-pub enum SessionConnectionMode {
-    Rdv,
-    Fwd,
-}
-
 #[derive(Serialize, Clone)]
 pub struct GatewaySessionInfo {
     association_id: Uuid,
     application_protocol: ApplicationProtocol,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    destination_host: Option<String>,
-    connection_mode: SessionConnectionMode,
     recording_policy: bool,
     filtering_policy: bool,
     start_timestamp: DateTime<Utc>,
+    #[serde(flatten)]
+    mode_details: ConnectionModeDetails,
 }
 
-impl Default for GatewaySessionInfo {
-    fn default() -> Self {
-        GatewaySessionInfo {
-            association_id: Uuid::new_v4(),
-            application_protocol: ApplicationProtocol::Unknown,
-            destination_host: None,
-            // FIXME: we actually don't know the jet connection mode at this point.
-            // A "default" session info is not very useful.
-            connection_mode: SessionConnectionMode::Rdv,
-            recording_policy: false,
-            filtering_policy: false,
-            start_timestamp: Utc::now(),
-        }
-    }
+#[derive(Serialize, Clone)]
+#[serde(tag = "connection_mode")]
+#[serde(rename_all = "lowercase")]
+pub enum ConnectionModeDetails {
+    Rdv,
+    Fwd { destination_host: TargetAddr },
 }
 
 impl GatewaySessionInfo {
+    pub fn new(association_id: Uuid, ap: ApplicationProtocol, mode_details: ConnectionModeDetails) -> Self {
+        Self {
+            association_id,
+            application_protocol: ap,
+            recording_policy: false,
+            filtering_policy: false,
+            start_timestamp: Utc::now(),
+            mode_details,
+        }
+    }
+
+    pub fn with_recording_policy(mut self, value: bool) -> Self {
+        self.recording_policy = value;
+        self
+    }
+
+    pub fn with_filtering_policy(mut self, value: bool) -> Self {
+        self.filtering_policy = value;
+        self
+    }
+
     pub fn id(&self) -> Uuid {
         self.association_id
-    }
-}
-
-impl From<JetAssociationTokenClaims> for GatewaySessionInfo {
-    fn from(association_token: JetAssociationTokenClaims) -> Self {
-        let (destination_host, connection_mode) = match association_token.jet_cm {
-            ConnectionMode::Rdv => (None, SessionConnectionMode::Rdv),
-            ConnectionMode::Fwd { dst_hst, .. } => (Some(dst_hst), SessionConnectionMode::Fwd),
-        };
-
-        GatewaySessionInfo {
-            association_id: association_token.jet_aid,
-            application_protocol: association_token.jet_ap,
-            destination_host,
-            connection_mode,
-            recording_policy: association_token.jet_rec,
-            filtering_policy: association_token.jet_flt,
-            start_timestamp: Utc::now(),
-        }
     }
 }
 

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -1,3 +1,4 @@
+use crate::utils::TargetAddr;
 use uuid::Uuid;
 use zeroize::Zeroize;
 
@@ -13,7 +14,7 @@ pub enum JetAccessTokenClaims {
 
 #[derive(Deserialize, Clone)]
 pub struct JetAssociationTokenClaims {
-    /// Jet Association ID
+    /// Jet Association ID (= Session ID)
     #[serde(default = "Uuid::new_v4")] // legacy: DVLS up to 2021.2.10 do not generate this claim.
     pub jet_aid: Uuid,
 
@@ -55,14 +56,19 @@ pub enum ApplicationProtocol {
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
 #[serde(tag = "jet_cm")]
+#[allow(clippy::large_enum_variant)]
 pub enum ConnectionMode {
     /// Connection should be processed following the rendez-vous protocol
     Rdv,
 
     /// Connection should be forwared to a given destination host
     Fwd {
-        /// Destination Host "<host>:<port>"
-        dst_hst: String,
+        /// Destination Host
+        dst_hst: TargetAddr,
+
+        /// Alternate Destination Hosts
+        #[serde(default)]
+        dst_alt: Vec<TargetAddr>,
 
         /// Credentials to use if protocol is wrapped by the Gateway (e.g. RDP TLS)
         #[serde(flatten)]
@@ -99,7 +105,7 @@ pub enum JetAccessScope {
 
 #[derive(Clone, Deserialize)]
 pub struct JetBridgeTokenClaims {
-    pub target_host: String, // "<HOST>:<PORT>"
+    pub target_host: TargetAddr,
 }
 
 #[derive(Clone, Deserialize)]

--- a/devolutions-gateway/src/transport/tcp.rs
+++ b/devolutions-gateway/src/transport/tcp.rs
@@ -1,17 +1,15 @@
+use crate::transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport};
+use crate::utils;
+use spsc_bip_buffer::{BipBufferReader, BipBufferWriter};
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-
-use spsc_bip_buffer::{BipBufferReader, BipBufferWriter};
 use tokio::io::{self, AsyncRead, AsyncWrite, ReadBuf};
 use tokio::net::TcpStream;
 use tokio_rustls::TlsStream;
 use url::Url;
-
-use crate::transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport};
-use crate::utils::{create_tls_connector, resolve_url_to_socket_arr};
 
 #[allow(clippy::large_enum_variant)]
 pub enum TcpStreamWrapper {
@@ -136,7 +134,7 @@ impl AsyncWrite for TcpTransport {
 
 impl TcpTransport {
     async fn create_connect_impl_future(url: Url) -> Result<TcpTransport, std::io::Error> {
-        let socket_addr = resolve_url_to_socket_arr(&url).await.ok_or_else(|| {
+        let socket_addr = utils::resolve_url_to_socket_addr(&url).await.ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::ConnectionRefused,
                 format!("couldn't resolve {}", url),
@@ -148,7 +146,7 @@ impl TcpTransport {
             "tls" => {
                 let socket = TcpStream::connect(&socket_addr).await?;
 
-                let tls_handshake = create_tls_connector(socket)
+                let tls_handshake = utils::create_tls_connector(socket)
                     .await
                     .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 

--- a/devolutions-gateway/src/transport/ws.rs
+++ b/devolutions-gateway/src/transport/ws.rs
@@ -1,5 +1,5 @@
 use crate::transport::{JetFuture, JetSinkImpl, JetSinkType, JetStreamImpl, JetStreamType, Transport};
-use crate::utils::{danger_transport, resolve_url_to_socket_arr};
+use crate::utils;
 use futures::{ready, Sink, Stream};
 use hyper::upgrade::Upgraded;
 use spsc_bip_buffer::{BipBufferReader, BipBufferWriter};
@@ -278,7 +278,7 @@ impl WsTransport {
     }
 
     async fn async_connect(url: Url) -> Result<Self, std::io::Error> {
-        let socket_addr = if let Some(addr) = resolve_url_to_socket_arr(&url).await {
+        let socket_addr = if let Some(addr) = utils::resolve_url_to_socket_addr(&url).await {
             addr
         } else {
             return Err(io::Error::new(
@@ -312,7 +312,7 @@ impl WsTransport {
 
                 let rustls_client_conf = rustls::ClientConfig::builder()
                     .with_safe_defaults()
-                    .with_custom_certificate_verifier(Arc::new(danger_transport::NoCertificateVerification))
+                    .with_custom_certificate_verifier(Arc::new(utils::danger_transport::NoCertificateVerification))
                     .with_no_client_auth();
                 let rustls_client_conf = Arc::new(rustls_client_conf);
                 let cx = TlsConnector::from(rustls_client_conf);


### PR DESCRIPTION
A new optional claim `dst_hst` is added to the association token.
A list of target addresses can be specified through it.
A connection will be attempted to each host successively until one succeeds, or all fail.

Todo:

- [x] implementation
- [x] tests