### PR TITLE
WAYK-2565: reject proxy if rec policy can't be met

### DIFF
--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -69,6 +69,10 @@ impl GenericClient {
                             application_protocol
                         );
 
+                        if association_claims.jet_rec {
+                            return Err(utils::into_other_io_error("can't meet recording policy"));
+                        }
+
                         let mut dest_host = Vec::with_capacity(dst_alt.len() + 1);
                         dest_host.push(dst_hst);
                         dest_host.extend(dst_alt);

--- a/devolutions-gateway/src/jet_client.rs
+++ b/devolutions-gateway/src/jet_client.rs
@@ -118,27 +118,30 @@ async fn handle_build_proxy(
     let mut recording_dir = None;
     let mut file_pattern = None;
 
-    let associations = jet_associations.lock().await;
-    if let Some(association) = associations.get(&association_id) {
-        if association.record_session() && config.plugins.is_some() {
-            let mut interceptor = PcapRecordingInterceptor::new(
-                response.server_transport.peer_addr().unwrap(),
-                response.client_transport.peer_addr().unwrap(),
-                association_id.clone().to_string(),
-                response.candidate_id.clone().to_string(),
-            );
+    if let Some(association) = jet_associations.lock().await.get(&association_id) {
+        match (association.record_session(), config.plugins.is_some()) {
+            (true, true) => {
+                let mut interceptor = PcapRecordingInterceptor::new(
+                    response.server_transport.peer_addr().unwrap(),
+                    response.client_transport.peer_addr().unwrap(),
+                    association_id.clone().to_string(),
+                    response.candidate_id.clone().to_string(),
+                );
 
-            recording_dir = match &config.recording_path {
-                Some(path) => {
-                    interceptor.set_recording_directory(path.as_str());
-                    Some(PathBuf::from(path))
-                }
-                _ => interceptor.get_recording_directory(),
-            };
+                recording_dir = match &config.recording_path {
+                    Some(path) => {
+                        interceptor.set_recording_directory(path.as_str());
+                        Some(PathBuf::from(path))
+                    }
+                    _ => interceptor.get_recording_directory(),
+                };
 
-            file_pattern = Some(interceptor.get_filename_pattern());
+                file_pattern = Some(interceptor.get_filename_pattern());
 
-            recording_interceptor = Some(interceptor);
+                recording_interceptor = Some(interceptor);
+            }
+            (true, false) => return Err(io::Error::new(io::ErrorKind::Other, "can't meet recording policy")),
+            (false, _) => {}
         }
     }
 

--- a/devolutions-gateway/src/jet_rendezvous_tcp_proxy.rs
+++ b/devolutions-gateway/src/jet_rendezvous_tcp_proxy.rs
@@ -50,6 +50,10 @@ impl JetRendezvousTcpProxy {
                 .with_recording_policy(claims.jet_rec)
                 .with_filtering_policy(claims.jet_flt);
 
+            if claims.jet_rec {
+                return Err(into_other_io_error("can't meet recording policy"));
+            }
+
             let candidate = assc.get_first_accepted_tcp_candidate().ok_or_else(|| {
                 into_other_io_error(format!(
                     "There is not any candidates in {} JetAssociations map",

--- a/devolutions-gateway/src/rdp.rs
+++ b/devolutions-gateway/src/rdp.rs
@@ -84,6 +84,10 @@ impl RdpClient {
             jet_associations,
         } = self;
 
+        if association_claims.jet_rec {
+            return Err(io::Error::new(io::ErrorKind::Other, "can't meet recording policy"));
+        }
+
         let routing_mode = resolve_rdp_routing_mode(&association_claims)?;
 
         match routing_mode {
@@ -126,7 +130,7 @@ impl RdpClient {
                 let tls_conf = config
                     .tls
                     .clone()
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "TLS configuration is missing"))?;
+                    .ok_or_else(|| utils::into_other_io_error("TLS configuration is missing"))?;
 
                 // We can't use FramedRead directly here, because we still have to use
                 // the leftover bytes. As an alternative, the decoder could be modified to use the


### PR DESCRIPTION
As per the spec, if session recording is required through the `jet_rec` claim,
but the relay happen to be unable to perform the recording, the connection MUST be rejected.