### PR TITLE
DPS-5332: default port based on protocol claim

### DIFF
--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -60,11 +60,7 @@ impl GenericClient {
                         .proxy(config, &*leftover_bytes)
                         .await
                     }
-                    ConnectionMode::Fwd {
-                        dst_hst,
-                        creds: None,
-                        dst_alt,
-                    } => {
+                    ConnectionMode::Fwd { targets, creds: None } => {
                         info!(
                             "Starting plain TCP forward redirection for application protocol {:?}",
                             application_protocol
@@ -74,12 +70,8 @@ impl GenericClient {
                             return Err(utils::into_other_io_error("can't meet recording policy"));
                         }
 
-                        let mut dest_host = Vec::with_capacity(dst_alt.len() + 1);
-                        dest_host.push(dst_hst);
-                        dest_host.extend(dst_alt);
-
                         let (mut server_conn, selected_target) =
-                            utils::successive_try(&dest_host, utils::tcp_transport_connect).await?;
+                            utils::successive_try(&targets, utils::tcp_transport_connect).await?;
 
                         let client_transport = TcpTransport::new(client_stream);
 

--- a/devolutions-gateway/src/rdp.rs
+++ b/devolutions-gateway/src/rdp.rs
@@ -263,31 +263,23 @@ fn resolve_rdp_routing_mode(claims: &JetAssociationTokenClaims) -> Result<RdpRou
 
     match &claims.jet_cm {
         ConnectionMode::Rdv => Ok(RdpRoutingMode::TcpRendezvous(claims.jet_aid)),
-        ConnectionMode::Fwd {
-            dst_hst,
-            creds,
-            dst_alt,
-        } => {
-            let mut targets = Vec::with_capacity(dst_alt.len() + 1);
-            targets.push(dst_hst.clone());
-            targets.extend(dst_alt.clone());
-
+        ConnectionMode::Fwd { targets, creds } => {
             if let Some(creds) = creds {
                 Ok(RdpRoutingMode::Tls(RdpIdentity {
                     proxy: AuthIdentity {
-                        username: creds.prx_usr.to_owned(),
-                        password: creds.prx_pwd.to_owned(),
+                        username: creds.prx_usr.clone(),
+                        password: creds.prx_pwd.clone(),
                         domain: None,
                     },
                     target: AuthIdentity {
-                        username: creds.dst_usr.to_owned(),
-                        password: creds.dst_pwd.to_owned(),
+                        username: creds.dst_usr.clone(),
+                        password: creds.dst_pwd.clone(),
                         domain: None,
                     },
-                    targets,
+                    targets: targets.clone(),
                 }))
             } else {
-                Ok(RdpRoutingMode::Tcp(targets))
+                Ok(RdpRoutingMode::Tcp(targets.clone()))
             }
         }
     }

--- a/devolutions-gateway/src/transport/tcp.rs
+++ b/devolutions-gateway/src/transport/tcp.rs
@@ -134,12 +134,7 @@ impl AsyncWrite for TcpTransport {
 
 impl TcpTransport {
     async fn create_connect_impl_future(url: Url) -> Result<TcpTransport, std::io::Error> {
-        let socket_addr = utils::resolve_url_to_socket_addr(&url).await.ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::ConnectionRefused,
-                format!("couldn't resolve {}", url),
-            )
-        })?;
+        let socket_addr = utils::resolve_url_to_socket_addr(&url).await?;
 
         match url.scheme() {
             "tcp" => TcpStream::connect(&socket_addr).await.map(TcpTransport::new),

--- a/devolutions-gateway/src/transport/ws.rs
+++ b/devolutions-gateway/src/transport/ws.rs
@@ -278,14 +278,7 @@ impl WsTransport {
     }
 
     async fn async_connect(url: Url) -> Result<Self, std::io::Error> {
-        let socket_addr = if let Some(addr) = utils::resolve_url_to_socket_addr(&url).await {
-            addr
-        } else {
-            return Err(io::Error::new(
-                io::ErrorKind::ConnectionRefused,
-                format!("couldn't resolve {}", url),
-            ));
-        };
+        let socket_addr = utils::resolve_url_to_socket_addr(&url).await?;
 
         let request = match Request::builder().uri(url.as_str()).body(()) {
             Ok(req) => req,


### PR DESCRIPTION
A custom `serde::de::Deserialize` trait implementation is used in order to dynamically validate target addresses based on the application protocol claim provided in the same token:

- If the application protocol claim is set to a known protocol for which the default port is known, then the port can be omitted.
- Otherwise, the port must be included or token will be rejected.

This PR also adds timeout to host connections.