### PR TITLE
fix: add peer address when injecting HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,7 +2577,7 @@ checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 [[package]]
 name = "saphir"
 version = "2.8.2"
-source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#b1d92ca42a13167505e671567d840269c0f6650c"
+source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#dff5d11a57b7ae93e3004fccef6dc85a31753d12"
 dependencies = [
  "base64 0.13.0",
  "brotli",
@@ -2621,7 +2621,7 @@ dependencies = [
 [[package]]
 name = "saphir_macro"
 version = "2.1.1"
-source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#b1d92ca42a13167505e671567d840269c0f6650c"
+source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#dff5d11a57b7ae93e3004fccef6dc85a31753d12"
 dependencies = [
  "http",
  "proc-macro2 1.0.32",

--- a/devolutions-gateway/src/websocket_client.rs
+++ b/devolutions-gateway/src/websocket_client.rs
@@ -47,10 +47,12 @@ impl WebsocketService {
                 .await
                 .map_err(|err| io::Error::new(ErrorKind::Other, format!("Handle JMUX error - {:?}", err)))
         } else {
-            saphir::server::inject_raw(req).await.map_err(|err| match err {
-                error::SaphirError::Io(err) => err,
-                err => io::Error::new(io::ErrorKind::Other, format!("{}", err)),
-            })
+            saphir::server::inject_raw_with_peer_addr(req, Some(client_addr))
+                .await
+                .map_err(|err| match err {
+                    error::SaphirError::Io(err) => err,
+                    err => io::Error::new(io::ErrorKind::Other, format!("{}", err)),
+                })
         }
     }
 }


### PR DESCRIPTION
Requests injected to saphir through the `inject_raw` function were missing the peer address because it was not correctly forwarded.

This fix depends on a saphir patch which should be merged upstream at some point.