### PR TITLE
Enable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
           $Files = Get-ChildItem -Path $StagingPath -Recurse -File | % { Get-FileHash -Algorithm SHA256 $_.FullName }
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
-          $GhCmd = $(@('gh', 'release', 'create', "v$Version", $HashPath) + $Files.Path) -Join ' '
+          $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
           Invoke-Expression $GhCmd
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,8 @@ jobs:
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", $HashPath) + $Files.Path) -Join ' '
-          Invoke-Expression @GhCmd
+          Write-Host $GhCmd
+          Invoke-Expression $GhCmd
 
   psgallery-release:
     name: PowerShell release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,8 @@ jobs:
 
       - name: Create GitHub release
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
           $Version = "${{ needs.preflight.outputs.version }}"
           $StagingPath = "${{ steps.download.outputs.download-path }}"
@@ -237,4 +239,14 @@ jobs:
           $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File -Path $StagingPath
           $Module = Join-Path $StagingPath PowerShell
           Expand-Archive -Path $Archive -DestinationPath $Module
-          Publish-Module -Force -Path (Join-Path $Module DevolutionsGateway) -NugetApiKey "${{ secrets.PS_GALLERY_NUGET_API_KEY }}"
+          try {
+            Publish-Module -Force -Path (Join-Path $Module DevolutionsGateway) -NugetApiKey "${{ secrets.PS_GALLERY_NUGET_API_KEY }}"
+          }
+          catch {
+            if ($_.Exception.Message -ilike "*cannot be published as the current version*is already available in the repository*") {
+              echo "::warning::PowerShell module not published; this version is already listed on PSGallery"
+            } else {
+              Write-Error $_
+              exit 1
+            }
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,17 @@ jobs:
         run: |
           $RunJson = gh api /repos/devolutions/devolutions-gateway/actions/runs/${{ github.event.inputs.run-id }}
           $Run = $RunJson | ConvertFrom-Json
+
+          if ($($Run.head_branch) -Ne "master") {
+            echo "::error::specified run is not on master, exiting..."
+            exit 1
+          }
+
+          if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
+            echo "::error::specified run is either not complete or not successful, exiting..."            
+            exit 1
+          }
+
           echo "::set-output name=commit::$($Run.head_sha)"
 
       - name: Checkout ${{ github.repository }}
@@ -180,7 +191,7 @@ jobs:
         working-directory: ${{ steps.move-artifacts.outputs.package-path }}
         run: |
           echo ${{ secrets.DOCKER_HUB_BOT_PASSWORD }} | docker login -u devolutionsbot --password-stdin
-          # docker push ${{ steps.build-container.outputs.image-name }}
+          docker push ${{ steps.build-container.outputs.image-name }}
 
   github-release:
     name: GitHub release
@@ -203,7 +214,7 @@ jobs:
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", $HashPath) + $Files.Path) -Join ' '
-          # Invoke-Expression @GhCmd
+          Invoke-Expression @GhCmd
 
   psgallery-release:
     name: PowerShell release
@@ -225,4 +236,4 @@ jobs:
           $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File -Path $StagingPath
           $Module = Join-Path $StagingPath PowerShell
           Expand-Archive -Path $Archive -DestinationPath $Module
-          # Publish-Module -Force -Path (Join-Path $Module DevolutionsGateway) -NugetApiKey "${{ secrets.PS_GALLERY_NUGET_API_KEY }}"
+          Publish-Module -Force -Path (Join-Path $Module DevolutionsGateway) -NugetApiKey "${{ secrets.PS_GALLERY_NUGET_API_KEY }}"

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -293,7 +293,7 @@ class TlkRecipe
         Write-Host "CargoTarget: $CargoTarget"
 
         $CargoProfile = $this.Target.CargoProfile
-        Write-Host "CargoProfile": $CargoProfile
+        Write-Host "CargoProfile: $CargoProfile"
 
         $CargoArgs = @('build', '--profile', $CargoProfile)
         $CargoArgs += @('--target', $CargoTarget)


### PR DESCRIPTION
Fix issues with the release workflow:
- Uncomment the final steps of the release pipeline to actually allow the release
- Fix the syntax and auth of the `gh release create` command
- Don't run the workflow if the specified run isn't from master, or it didn't complete successfully
- Don't fail the workflow if the PS module version is already published
