### PR TITLE
Refactor CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,30 +10,62 @@ There are three seperate workflows:
 └────┘   └─────────┘   └─────────┘
 ```
 
-## CI
+## Making a Release
+
+- Ensure that the [VERSION](../../VERSION) number and [CHANGELOG](../../CHANGELOG.md) are up-to-date.
+- Execute the [CI](#ci) workflow (either manually via the GitHub web UI or `gh`, or by creating or merging a pull request)
+
+:warning: *For releases, the CI workflow should be run from a commit on `master`. This ensures the binaries are built with the proper opimizations*
+- Find the run ID of the [CI](#ci) workflow run containing the artifacts you wish to release. You can use the GitHub web UI, or `gh` (e.g. `gh run list`)
+- Run the [Package](#package) workflow, providing the run ID obtained in the previous step (either using the GitHub web UI, or `gh`. For example:
+
+`gh workflow run package.yml -f run=123456`
+
+ - Find the run ID of the [Package](#package) workflow and use it to call the [Release](#release) workflow. For example:
+ 
+`gh workflow run release.yml -f run=654321`
+### CI
 
 The "CI" workflow builds, tests and packages `devolutions-gateway` and builds `jetsocat`, for supported platforms. The workflow is run automatically for pull requests and merges, or may be run manually.
 
 The build artifacts are **not** code-signed and not suitable for distribution.
 
-## PACKAGE
+### PACKAGE
 
-The "Package" workflow downloads the artifacts from a **CI** workflow run, codesigning and repackaging them as appropriate. The workflow should be run manually, and will require approval.
+The "Package" workflow downloads the artifacts from a [CI](#ci) workflow run, codesigning and repackaging them as appropriate. The workflow should be run manually, and will require approval.
 
 The workflow will display a notice if `run` was not built from the main branch. Artifacts from the main branch are built with specific optimizations and are suitable for distribution.
 
-### Parameters
+##### Parameters
 
-- `run` The run-id of the **CI** workflow run containing the artifacts to package
+- `run` The run-id of the [CI](#ci) workflow run containing the artifacts to package
 
-### Developer Notes
+##### Developer Notes
 
 - The `Codesign` job uses a matrix to code-sign and repackage in parallel. It's important to ensure that individual matrix jobs do not upload the same artifacts; otherwise the result may be unexpected. For example: each platform downloads the `jetsocat` artifact, which contains builds for several operating systems. The Windows job must only sign and upload the Windows builds. If it were allowed to upload the macOS builds, they will be unsigned and *may* overwrite the signed builds uploaded by the macOS job.
-- The workflow makes a checkout of the repository at the commit that `run` was built from. This ensures consistency with the **CI** workflow when repackaging. Remember that tools invoked by the workflow (e.g. [tlk.ps1](../../ci/tlk.ps1)) will be from that commit too.
+- The workflow makes a checkout of the repository at the commit that `run` was built from. This ensures consistency with the [CI](#ci) workflow when repackaging. Remember that tools invoked by the workflow (e.g. [tlk.ps1](../../ci/tlk.ps1)) will be from that commit too.
 
-### TODO
+##### TODO
 
 - `jetsocat` builds for macOS are signed, but should be notarized as well 
 - The `devolutions-gateway` PowerShell module should be signed
 
 ### RELEASE
+
+The "Release" workflow downloads the artifacts from a [Package](#package) workflow run, and executes the release. The workflow should be run manually, and will require approval.
+
+The following actions are taken:
+
+- Build containers for Devolutions Gateway and publish to Docker
+- Push the Devolutions Gateway PowerShell module to PSGallery
+- Generate a GitHub release
+
+If you run the release multiple times for the same version, the results might be unexpected:
+
+- The PowerShell module will not be re-uploaded. PSGallery does not support replacing an existing version. If you wish to replace the PowerShell module, you must increment the version number.
+
+##### Parameters
+
+- `run` The run-id of the [Package](#package) workflow run containing the artifacts to package
+- `dry-run` If selected, the workflow will only indicate the actions to be taken. No deployment will occur.
+

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,39 @@
+# devolutions-gateway ci / cd
+
+Devolutions Gateway and jetsocat are built and released using GitHub workflows.
+
+There are three seperate workflows:
+
+```
+┌────┐   ┌─────────┐   ┌─────────┐
+│ CI ├───► PACKAGE ├───► RELEASE │
+└────┘   └─────────┘   └─────────┘
+```
+
+## CI
+
+The "CI" workflow builds, tests and packages `devolutions-gateway` and builds `jetsocat`, for supported platforms. The workflow is run automatically for pull requests and merges, or may be run manually.
+
+The build artifacts are **not** code-signed and not suitable for distribution.
+
+## PACKAGE
+
+The "Package" workflow downloads the artifacts from a **CI** workflow run, codesigning and repackaging them as appropriate. The workflow should be run manually, and will require approval.
+
+The workflow will display a notice if `run` was not built from the main branch. Artifacts from the main branch are built with specific optimizations and are suitable for distribution.
+
+### Parameters
+
+- `run` The run-id of the **CI** workflow run containing the artifacts to package
+
+### Developer Notes
+
+- The `Codesign` job uses a matrix to code-sign and repackage in parallel. It's important to ensure that individual matrix jobs do not upload the same artifacts; otherwise the result may be unexpected. For example: each platform downloads the `jetsocat` artifact, which contains builds for several operating systems. The Windows job must only sign and upload the Windows builds. If it were allowed to upload the macOS builds, they will be unsigned and *may* overwrite the signed builds uploaded by the macOS job.
+- The workflow makes a checkout of the repository at the commit that `run` was built from. This ensures consistency with the **CI** workflow when repackaging. Remember that tools invoked by the workflow (e.g. [tlk.ps1](../../ci/tlk.ps1)) will be from that commit too.
+
+### TODO
+
+- `jetsocat` builds for macOS are signed, but should be notarized as well 
+- The `devolutions-gateway` PowerShell module should be signed
+
+### RELEASE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,6 @@ jobs:
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}"
             $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
-            $Env:DGATEWAY_PSMODULE_CLEAN = "1"
           }
 
           ./ci/tlk.ps1 package -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = 'jetsocat_${{ runner.os }}_$${{ needs.preflight.outputs.version }}_${{ matrix.arch }}'
+          $ExecutableFileName = 'jetsocat_${{ runner.os }}_${{ needs.preflight.outputs.version }}_${{ matrix.arch }}'
           
           if ($Env:RUNNER_OS -eq "Windows") {
             $ExecutableFileName = "$($ExecutableFileName).exe"
@@ -220,7 +220,7 @@ jobs:
           $PackageVersion = "${{ needs.preflight.outputs.version }}"
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_$PackageVersion_${{ matrix.arch }}"
+          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
 
           if ($Env:RUNNER_OS -eq "Windows") {
             $ExecutableFileName = "$($ExecutableFileName).exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# Continuous integration and deploymnent workflow for devolutions-gateway
-
 name: CI
 
 on:
@@ -66,6 +64,48 @@ jobs:
           name: version
           path: VERSION
 
+  test:
+      name: test [${{ matrix.os }} ${{ matrix.arch }}]
+      runs-on: ${{ matrix.runner }}
+      needs: preflight
+      env:
+        CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
+      strategy:
+        matrix:
+          arch: [ x86_64 ]
+          os: [ windows, linux ]
+          include:
+            - os: windows
+              runner: windows-2019
+            - os: linux
+              runner: ubuntu-18.04
+
+      steps:
+        - name: Checkout ${{ github.repository }}
+          uses: actions/checkout@v2
+
+        - name: Configure rust toolchain
+          run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
+
+        - name: Configure Linux runner
+          if: matrix.os == 'linux'
+          run: |
+            sudo apt update
+            sudo apt install python3-wget python3-setuptools libsystemd-dev
+
+        - name: Configure conan
+          run: |
+            pip3 install conan==1.40.0 --upgrade
+            conan config install --type=git -sf settings https://github.com/Devolutions/conan-public
+            conan remote clean
+            conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
+
+        - name: Test
+          shell: pwsh
+          run: ./ci/tlk.ps1 test -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+
+
   jetsocat:
     name: jetsocat [${{ matrix.os }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
@@ -74,7 +114,6 @@ jobs:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
       CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
     strategy:
-      fail-fast: false
       matrix:
         arch: [ x86, x86_64, arm64 ]
         os: [ windows, macos, linux ]
@@ -99,43 +138,21 @@ jobs:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
 
-      - name: Load dynamic variables
-        id: load-variables
-        shell: pwsh
-        run: |
-          $PackageVersion = "${{ needs.preflight.outputs.version }}"
-          $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
-          $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "jetsocat_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
-
-          if ($Env:RUNNER_OS -eq "Windows") {
-            $ExecutableFileName = "$($ExecutableFileName).exe"
-          }
-
-          $JetsocatExecutable = Join-Path $TargetOutputPath $ExecutableFileName
-          $CargoPackage = "jetsocat"
-          echo "::set-output name=staging-path::$StagingPath"
-          echo "::set-output name=target-output-path::$TargetOutputPath"
-          echo "::set-output name=jetsocat-executable::$JetsocatExecutable"
-          echo "::set-output name=cargo-package::$CargoPackage"
-
       - name: Configure rust toolchain
-        run: |
-          rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
+        run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
 
       - name: Configure Linux runner
-        if: runner.os == 'Linux'
+        if: matrix.os == 'linux'
         run: |
           sudo apt update
           sudo apt install python3-wget python3-setuptools
 
       - name: Configure Windows runner
-        if: matrix.os == 'windows'
-        run: |
-          rustup target add i686-pc-windows-msvc
+        if: matrix.os == 'windows' && matrix.arch == 'x86'
+        run: rustup target add i686-pc-windows-msvc
 
       - name: Configure macOS runner
-        if: matrix.os == 'macos'
+        if: matrix.os == 'macos' && matrix.arch == 'arm64'
         run: |
           sudo rm -rf /Library/Developer/CommandLineTools
           rustup target add aarch64-apple-darwin
@@ -148,24 +165,32 @@ jobs:
           conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
 
       - name: Build
+        id: build
         shell: pwsh
-        env:
-          TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
-          JETSOCAT_EXECUTABLE: ${{ steps.load-variables.outputs.jetsocat-executable }}
-          CARGO_PACKAGE: ${{ steps.load-variables.outputs.cargo-package }}
         run: |
+          $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
+          $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
+          $ExecutableFileName = 'jetsocat_${{ runner.os }}_$${{ needs.preflight.outputs.version }}_${{ matrix.arch }}'
+          
           if ($Env:RUNNER_OS -eq "Windows") {
+            $ExecutableFileName = "$($ExecutableFileName).exe"
             $Env:CARGO_NO_DEFAULT_FEATURES = "true"
             $Env:CARGO_FEATURES = "native-tls"
           }
 
+          $Env:TARGET_OUTPUT_PATH = $TargetOutputPath
+          $Env:JETSOCAT_EXECUTABLE = Join-Path $TargetOutputPath $ExecutableFileName
+          $Env:CARGO_PACKAGE = "jetsocat"
+
           ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+
+          echo "::set-output name=staging-path::$StagingPath"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: jetsocat
-          path: ${{ steps.load-variables.outputs.staging-path }}
+          path: ${{ steps.build.outputs.staging-path }}
 
   devolutions-gateway:
     name: devolutions-gateway [${{ matrix.os }} ${{ matrix.arch }}]
@@ -175,7 +200,6 @@ jobs:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
       CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
     strategy:
-      fail-fast: false
       matrix:
         arch: [ x86_64 ]
         os: [ windows, linux ]
@@ -211,27 +235,23 @@ jobs:
           }
 
           $DGatewayExecutable = Join-Path $TargetOutputPath $ExecutableFileName
-          $CargoPackage = "devolutions-gateway"
           echo "::set-output name=staging-path::$StagingPath"
           echo "::set-output name=target-output-path::$TargetOutputPath"
           echo "::set-output name=dgateway-executable::$DGatewayExecutable"
-          echo "::set-output name=cargo-package::$CargoPackage"
 
       - name: Configure rust toolchain
-        run: |
-          rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
+        run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
 
       - name: Configure Linux runner
-        if: runner.os == 'Linux'
+        if: matrix.os == 'linux'
         run: |
           sudo apt update
-          sudo apt install dh-make python3-wget python3-setuptools libsystemd-dev
+          sudo apt install python3-wget python3-setuptools libsystemd-dev dh-make
 
       # WiX is installed on Windows runners but not in the PATH
       - name: Configure Windows runner
-        if: runner.os == 'Windows'
-        run: |
-          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        if: matrix.os == 'windows'
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Configure conan
         run: |
@@ -245,9 +265,8 @@ jobs:
         env:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
           DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}
-          CARGO_PACKAGE: ${{ steps.load-variables.outputs.cargo-package }}
-        run: |
-          ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+          CARGO_PACKAGE: devolutions-gateway
+        run: ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
 
       - name: Build PowerShell module
         if: matrix.os == 'windows'
@@ -274,46 +293,3 @@ jobs:
         with:
           name: devolutions-gateway
           path: ${{ steps.load-variables.outputs.staging-path }}
-
-  test:
-      name: test [${{ matrix.os }} ${{ matrix.arch }}]
-      runs-on: ${{ matrix.runner }}
-      needs: preflight
-      env:
-        CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-        CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
-      strategy:
-        matrix:
-          arch: [ x86_64 ]
-          os: [ windows, linux ]
-          include:
-            - os: windows
-              runner: windows-2019
-            - os: linux
-              runner: ubuntu-18.04
-
-      steps:
-        - name: Checkout ${{ github.repository }}
-          uses: actions/checkout@v2
-
-        - name: Configure rust toolchain
-          run: |
-            rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
-
-        - name: Configure Linux runner
-          if: runner.os == 'Linux'
-          run: |
-            sudo apt update
-            sudo apt install python3-wget python3-setuptools libsystemd-dev
-
-        - name: Configure conan
-          run: |
-            pip3 install conan==1.40.0 --upgrade
-            conan config install --type=git -sf settings https://github.com/Devolutions/conan-public
-            conan remote clean
-            conan remote add artifactory https://devolutions.jfrog.io/devolutions/api/conan/conan-local
-
-        - name: Test
-          shell: pwsh
-          run: |
-            ./ci/tlk.ps1 test -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           $PackageVersion = "${{ needs.preflight.outputs.version }}"
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
+          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_$PackageVersion_${{ matrix.arch }}"
 
           if ($Env:RUNNER_OS -eq "Windows") {
             $ExecutableFileName = "$($ExecutableFileName).exe"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
-          $RunJson = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/${{ github.event.inputs.run-id }}
+          $RunJson = gh api "/repos/$Env:GITHUB_REPOSITORY/actions/runs/${{ github.event.inputs.run-id }}"
           $Run = $RunJson | ConvertFrom-Json
 
           if ($($Run.head_branch) -Ne "master") {

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,8 +7,6 @@ on:
         description: 'The CI workflow run to package'
         required: true
 
-concurrency: gateway-package
-
 jobs:
   preflight:
     name: Preflight
@@ -35,6 +33,17 @@ jobs:
 
           echo "::set-output name=commit::$($Run.head_sha)"
           echo "::notice::Packaging artifacts built from commit $($Run.head_sha) in run ${{ github.event.inputs.run }}"
+
+      - name: Download artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+        run: gh run download ${{ github.event.inputs.run }} -n version
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: version
+          path: VERSION
 
   codesign:
     name: Codesign

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,6 +93,7 @@ jobs:
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
+          $Env:DGATEWAY_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.exe' | Select -First 1
           $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_PSMODULE_CLEAN = "1"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
           CI_RUN: ${{ github.event.inputs.run-id }}
         run: |
-          GetRunsCmd = @('gh', 'api', "/repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN")
+          $GetRunsCmd = @('gh', 'api', "/repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN")
           $RunJson = Invoke-Expression ($GetRunsCmd -Join ' ')
           $Run = $RunJson | ConvertFrom-Json
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -125,7 +125,7 @@ jobs:
         shell: pwsh
         run: |
           $Pattern = switch ('${{ matrix.project }}') {
-            'devolutions-gateway' { 'DevolutionsGateway_.exe' }
+            'devolutions-gateway' { 'DevolutionsGateway_*.exe' }
             'jetsocat' { 'jetsocat_*' }
           }
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include "$Pattern" | % {

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,9 +93,7 @@ jobs:
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
-          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse | 
-            Where-Object { $_.Name -Match '*DevolutionsGateway*.msi' } | 
-            Select -First 1
+          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_PSMODULE_CLEAN = "1"
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,10 +45,15 @@ jobs:
       max-parallel: 1
       matrix:
         project: [ jetsocat, devolutions-gateway ]
-        runner: [ windows-2019, macos-10.15 ]
+        os: [ windows, macos ]
+        include:
+          - os: windows
+            runner: windows-2019
+          - os: macos
+            runner: macos-10.15
         exclude:
           - project: devolutions-gateway
-            runner: macos-10.15
+            os: macos
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -60,10 +65,15 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n ${{ matrix.project }} -D $(Join-Path ${{ runner.temp }} ${{ matrix.project }})
+        run: |
+          $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
+          gh run download ${{ github.event.inputs.run }} -n ${{ matrix.project }} -D "$Destination"
+          if ("${{ matrix.project" -Eq 'jetsocat') {
+            Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse 
+          }
 
       - name: Configure certificates (Windows)
-        if: matrix.os == 'Windows'
+        if: matrix.os == 'windows'
         env:
           CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
           CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
@@ -73,8 +83,27 @@ jobs:
           $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
           Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
 
+      - name: Configure certificates (macOS)
+        if: matrix.os == 'macos'
+        env:
+          DEVELOPER_ID_CERTIFICATE: ${{ secrets.APPLE_APP_DEV_ID_APP_CERTIFICATE }}
+          DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_APP_DEV_ID_APP_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=Price2011
+
+          DEVELOPER_ID_CERTIFICATE_PATH=$RUNNER_TEMP/dev_id_cert.p12
+          echo -n "$DEVELOPER_ID_CERTIFICATE" | base64 --decode --output $DEVELOPER_ID_CERTIFICATE_PATH
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          security import $DEVELOPER_ID_CERTIFICATE_PATH -P "$DEVELOPER_ID_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
       - name: Configure runner (Windows)
-        if: matrix.os == 'Windows'
+        if: matrix.os == 'windows'
         run: |
           echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -99,7 +128,13 @@ jobs:
                 $_.FullName
               )) -Join ' '
             } else {
-              $SignCmd = 'Write-Host "hello world"'
+              $SignCmd = $(@(
+                'codesign', 
+                '--timestamp', 
+                '-s', 'Developer ID Application: Devolutions inc. (N592S9ASDB)',
+                '-v', 
+                $_.FullName
+              )) -Join ' '
             }
 
             Write-Host $SignCmd

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Download artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n version
+        run: gh run download ${{ github.event.inputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: | 
           gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -D (Join-Path ${{ runner.temp }} devolutions-gateway)
-          Get-ChildItem -Path ${{ runner.temp }} -recurse
+          Get-ChildItem -Path ${{ runner.temp }} -Recurse
 
       # - name: Configure certificates
       #   env:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,17 +24,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
           CI_RUN: ${{ github.event.inputs.run }}
         run: |
-          $GetRunsCmd = @('gh', 'api', "/repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN")
-          $RunJson = Invoke-Expression ($GetRunsCmd -Join ' ')
-          $Run = $RunJson | ConvertFrom-Json
-
+          $Run = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN | ConvertFrom-Json
           if ($($Run.head_branch) -Ne "master") {
-            echo "::error::specified run is not on master, exiting..."
-            exit 1
+            echo "::notice::specified run is not on master"
           }
-
           if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
-            echo "::error::specified run is either not complete or not successful, exiting..."            
+            echo "::error::specified run is either not complete or not successful"            
             exit 1
           }
 
@@ -44,7 +39,7 @@ jobs:
   codesign:
     name: Codesign
     runs-on: windows-2019
-    environment: build-and-publish
+    # environment: build-and-publish
     needs: preflight
 
     steps:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -86,9 +86,8 @@ jobs:
             "devolutions-gateway" { 'DevolutionsGateway_.exe' }
             "jetsocat" { 'jetsocat_*'' }
           }
-          $Executables = Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include $Patterm
-          foreach ($Executable in $Executables) {
-            if ("$Env:RUNNER_OS" -Eq 'Windows') {
+          Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include "$Pattern" | % {
+            if ($Env:RUNNER_OS -Eq 'Windows') {
               $SignCmd = $(@(
                 'signtool', 
                 'sign', 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,7 @@ jobs:
             echo "::notice::specified run is not on master"
           }
           if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
-            echo "::error::specified run is either not complete or not successful"            
+            echo "::error::specified run is either not complete or not successful"
             exit 1
           }
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
           }
 
           echo "::set-output name=commit::$($Run.head_sha)"
-          echo "::notice::Packaging commit ${{ steps.get-commit.outputs.commit }} from run ${{ github.event.inputs.run }}"
+          echo "::notice::Packaging commit $($Run.head_sha) from run ${{ github.event.inputs.run }}"
 
   codesign:
     name: Codesign
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: | 
-          gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -D (Join-Path ${{ runner.temp }} devolutions-gateway)
+          gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -n jetsocat -D (Join-Path ${{ runner.temp }} devolutions-gateway)
           Get-ChildItem -Path ${{ runner.temp }} -Recurse
 
       # - name: Configure certificates
@@ -65,6 +65,11 @@ jobs:
       #     [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
       #     $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
       #     Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+
+      - name: Sign executables
+        shell: pwsh
+        run: |
+            
 
       # - name: Configure runner
       #   run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,16 +34,22 @@ jobs:
           echo "::set-output name=commit::$($Run.head_sha)"
           echo "::notice::Packaging artifacts built from commit $($Run.head_sha) in run ${{ github.event.inputs.run }}"
 
-      - name: Download artifacts
-        env:
-          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n version --repo $GITHUB_REPOSITORY
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.get-commit.outputs.commit }}
 
-      - name: Upload artifacts
+      - name: Upload version artifact
         uses: actions/upload-artifact@v2
         with:
           name: version
           path: VERSION
+
+      - name: Upload docker file artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: docker
+          path: package/**/Dockerfile
 
   codesign:
     name: Codesign
@@ -70,8 +76,8 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
-        # with:
-        #   ref: ${{ needs.preflight.outputs.commit }}
+        with:
+          ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Download artifacts
         shell: pwsh
@@ -202,7 +208,7 @@ jobs:
           $RootPath = Join-Path ${{ runner.temp }} ${{ matrix.project }} ${{ matrix.os }}
           if ('${{ matrix.os }}' -Eq 'windows') {
             Get-ChildItem -Path $RootPath -Recurse -Include ('*.exe', '*.msi') | % { 
-              signtool verify /pa "$_.FullName"
+              signtool verify /pa "$($_.FullName)"
               if ($LastExitCode -Ne 0) {
                 echo "::error::failed to verify the signature of $($_.FullName)" 
                 exit 1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,6 +66,10 @@ jobs:
           $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
           Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
 
+      - name: Configure runner
+        run: |
+          echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Sign executables
         shell: pwsh
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
           }
 
           echo "::set-output name=commit::$($Run.head_sha)"
-          echo "::notice::Packaging commit $($Run.head_sha) from run ${{ github.event.inputs.run }}"
+          echo "::notice::Packaging artifacts built from commit $($Run.head_sha) in run ${{ github.event.inputs.run }}"
 
   codesign:
     name: Codesign
@@ -44,15 +44,19 @@ jobs:
     strategy:
       matrix:
         project: [ jetsocat, devolutions-gateway ]
-        os: [ windows, macos ]
+        os: [ windows, macos, linux ]
         include:
           - os: windows
             runner: windows-2019
           - os: macos
             runner: macos-10.15
+          - os: linux
+            runner: ubuntu-18.04
         exclude:
           - project: devolutions-gateway
             os: macos
+          - project: devolutions-gateway
+            os: linux
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -108,6 +112,7 @@ jobs:
           echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Sign executables
+        if: matrix.os == 'windows' || matrix.os == 'macos'
         shell: pwsh
         run: |
           $Pattern = switch ('${{ matrix.project }}') {
@@ -126,7 +131,7 @@ jobs:
                 '/td', 'sha256',
                 $_.FullName
               )) -Join ' '
-            } else {
+            } else if ('${{ matrix.os }}' -Eq 'macos') {
               $SignCmd = $(@(
                 'codesign', 
                 '--timestamp', 
@@ -134,10 +139,14 @@ jobs:
                 '-v', 
                 $_.FullName
               )) -Join ' '
+            } else {
+              echo "::debug::nothing to do for ${{ matrix.os }}"
             }
 
-            Write-Host $SignCmd
-            Invoke-Expression $SignCmd
+            if ($SignCmd) {
+              Write-Host $SignCmd
+              Invoke-Expression $SignCmd            
+            }
           }
 
       - name: Repackage

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-          CI_RUN: ${{ github.event.inputs.run-id }}
+          CI_RUN: ${{ github.event.inputs.run }}
         run: |
           $GetRunsCmd = @('gh', 'api', "/repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN")
           $RunJson = Invoke-Expression ($GetRunsCmd -Join ' ')

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -51,6 +51,12 @@ jobs:
           name: docker
           path: package/**/Dockerfile
 
+      - name: Changelog artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: changelog
+          path: CHANGELOG.md
+
   codesign:
     name: Codesign
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -102,7 +102,7 @@ jobs:
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_PSMODULE_CLEAN = "1"
 
-          Get-ChildItem -Path (Join-Path $PackageRoot PowerShell "*.zip" -Recurse | % {
+          Get-ChildItem -Path (Join-Path $PackageRoot PowerShell "*.zip") -Recurse | % {
             Remove-Item $_.FullName -Force
           }
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
           gh run download ${{ github.event.inputs.run }} -n ${{ matrix.project }} -D "$Destination"
-          if ("${{ matrix.project" -Eq 'jetsocat') {
+          if ('${{ matrix.project }}' -Eq 'jetsocat') {
             Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse 
           }
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -102,6 +102,10 @@ jobs:
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_PSMODULE_CLEAN = "1"
 
+          Get-ChildItem -Path (Join-Path $PackageRoot PowerShell "*.zip" -Recurse | % {
+            Remove-Item $_.FullName -Force
+          }
+
           ./ci/tlk.ps1 package
 
       - name: Sign packages

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: | 
-          gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -n jetsocat -D (Join-Path ${{ runner.temp }} devolutions-gateway)
+          gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -n jetsocat -D ${{ runner.temp }}
           Get-ChildItem -Path ${{ runner.temp }} -Recurse
 
       - name: Configure certificates

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -70,19 +70,20 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*DevolutionsGateway*.exe', '*jetsocat*.exe' | % { 
-          $SignCmd = $(@(
-            'signtool', 
-            'sign', 
-            '/fd', 'SHA256', 
-            '/v', 
-            '/n', 'Devolutions', 
-            '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-            '/td', 'sha256',
-            $_.FullName
-          )) -Join ' '
+            $SignCmd = $(@(
+              'signtool', 
+              'sign', 
+              '/fd', 'SHA256', 
+              '/v', 
+              '/n', 'Devolutions', 
+              '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+              '/td', 'sha256',
+              $_.FullName
+            )) -Join ' '
 
-          Write-Host $SignCmd
-          Invoke-Expression $SignCmd
+            Write-Host $SignCmd
+            Invoke-Expression $SignCmd
+          }
 
       - name: Repackage
         shell: pwsh
@@ -100,19 +101,20 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*.msi' | % { 
-          $SignCmd = $(@(
-            'signtool', 
-            'sign', 
-            '/fd', 'SHA256', 
-            '/v', 
-            '/n', 'Devolutions', 
-            '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-            '/td', 'sha256',
-            $_.FullName
-          )) -Join ' '
+            $SignCmd = $(@(
+              'signtool', 
+              'sign', 
+              '/fd', 'SHA256', 
+              '/v', 
+              '/n', 'Devolutions', 
+              '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+              '/td', 'sha256',
+              $_.FullName
+            )) -Join ' '
 
-          Write-Host $SignCmd
-          Invoke-Expression $SignCmd
+            Write-Host $SignCmd
+            Invoke-Expression $SignCmd
+          }
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Download artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ github.event.inputs.run }} -n version --repo $GITHUB_REPOSITORY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -195,6 +195,29 @@ jobs:
             Invoke-Expression $SignCmd
           }
 
+      - name: Verification
+        if: matrix.os == 'windows' || matrix.os == 'macos'
+        shell: pwsh
+        run: |
+          $RootPath = Join-Path ${{ runner.temp }} ${{ matrix.project }} ${{ matrix.os }}
+          if ('${{ matrix.os }}' -Eq 'windows') {
+            Get-ChildItem -Path $RootPath -Recurse -Include ('*.exe', '*.msi') | % { 
+              signtool verify /pa "$_.FullName"
+              if ($LastExitCode -Ne 0) {
+                echo "::error::failed to verify the signature of $($_.FullName)" 
+                exit 1
+              }
+            }
+          } elseif ('${{ matrix.os }}' -Eq 'macos') {
+            Get-ChildItem -Path $RootPath -Recurse -Include 'jetsocat_*' | % { 
+              codesign -dvvv "$($_.FullName)"
+              if ($LastExitCode -Ne 0) {
+                echo "::error::failed to verify the signature of $($_.FullName)" 
+                exit 1
+              }
+            }
+          }
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -112,8 +112,8 @@ jobs:
         shell: pwsh
         run: |
           $Pattern = switch ('${{ matrix.project }}') {
-            "devolutions-gateway" { 'DevolutionsGateway_.exe' }
-            "jetsocat" { 'jetsocat_*'' }
+            'devolutions-gateway' { 'DevolutionsGateway_.exe' }
+            'jetsocat' { 'jetsocat_*' }
           }
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include "$Pattern" | % {
             if ('${{ matrix.os }}' -Eq 'windows') {

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -45,8 +45,8 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
-        with:
-          ref: ${{ needs.preflight.outputs.commit }}
+        # with:
+        #   ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Download artifacts
         shell: pwsh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -88,7 +88,7 @@ jobs:
           }
           $Executables = Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include $Patterm
           foreach ($Executable in $Executables) {
-            if ('Env:RUNNER_OS' -Eq 'Windows') {
+            if ("$Env:RUNNER_OS" -Eq 'Windows') {
               $SignCmd = $(@(
                 'signtool', 
                 'sign', 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,9 +38,17 @@ jobs:
 
   codesign:
     name: Codesign
-    runs-on: windows-2019
+    runs-on: ${{ matrix.runner }}
     environment: build-and-publish
     needs: preflight
+    strategy:
+      max-parallel: 1
+      matrix:
+        project: [ jetsocat, devolutions-gateway ]
+        runner: [ windows-2019, macos-10.15 ]
+        exclude:
+          - arch: devolutions-gateway
+            runner: macos-10.15
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -52,11 +60,10 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: | 
-          gh run download ${{ github.event.inputs.run }} -n devolutions-gateway -n jetsocat -D ${{ runner.temp }}
-          Get-ChildItem -Path ${{ runner.temp }} -Recurse
+        run: gh run download ${{ github.event.inputs.run }} -n ${{ matrix.project }} -D $(Join-Path ${{ runner.temp }} ${{ matrix.project }})
 
-      - name: Configure certificates
+      - name: Configure certificates (Windows)
+        if: matrix.os == 'Windows'
         env:
           CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
           CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
@@ -66,34 +73,42 @@ jobs:
           $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
           Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
 
-      - name: Configure runner
+      - name: Configure runner (Windows)
+        if: matrix.os == 'Windows'
         run: |
           echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      # WiX is installed on Windows runners but not in the PATH
-      - name: Configure runner
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Sign executables
         shell: pwsh
         run: |
-          Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*DevolutionsGateway*.exe', '*jetsocat*.exe' | % { 
-            $SignCmd = $(@(
-              'signtool', 
-              'sign', 
-              '/fd', 'SHA256', 
-              '/v', 
-              '/n', 'Devolutions', 
-              '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-              '/td', 'sha256',
-              $_.FullName
-            )) -Join ' '
+          $Pattern = switch ('${{ matrix.project }}') {
+            "devolutions-gateway" { 'DevolutionsGateway_.exe' }
+            "jetsocat" { 'jetsocat_*'' }
+          }
+          $Executables = Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include $Patterm
+          foreach ($Executable in $Executables) {
+            if ('Env:RUNNER_OS' -Eq 'Windows') {
+              $SignCmd = $(@(
+                'signtool', 
+                'sign', 
+                '/fd', 'SHA256', 
+                '/v', 
+                '/n', 'Devolutions', 
+                '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+                '/td', 'sha256',
+                $_.FullName
+              )) -Join ' '
+            } else {
+              $SignCmd = 'Write-Host "hello world"'
+            }
 
             Write-Host $SignCmd
             Invoke-Expression $SignCmd
           }
 
       - name: Repackage
+        if: matrix.project == 'devolutions-gateway'
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
@@ -109,6 +124,7 @@ jobs:
           ./ci/tlk.ps1 package
 
       - name: Sign packages
+        if: matrix.project == 'devolutions-gateway'
         shell: pwsh
         run: |
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*.msi' | % { 
@@ -119,6 +135,7 @@ jobs:
               '/v', 
               '/n', 'Devolutions', 
               '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+              '/d', '"Devolutions Gateway"',
               '/td', 'sha256',
               $_.FullName
             )) -Join ' '
@@ -127,18 +144,10 @@ jobs:
             Invoke-Expression $SignCmd
           }
 
-      - name: Upload artifacts
+      - name: Upload move-artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: devolutions-gateway
-          path: ${{ runner.temp }}/devolutions-gateway
+          name: ${{ matrix.project }}
+          path: ${{ runner.temp }}/{{ matrix.project }}
           if-no-files-found: error
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: jetsocat
-          path: ${{ runner.temp }}/jetsocat
-          if-no-files-found: error
-
-  
+ 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -42,7 +42,6 @@ jobs:
     environment: build-and-publish
     needs: preflight
     strategy:
-      max-parallel: 1
       matrix:
         project: [ jetsocat, devolutions-gateway ]
         os: [ windows, macos ]
@@ -131,7 +130,7 @@ jobs:
               $SignCmd = $(@(
                 'codesign', 
                 '--timestamp', 
-                '-s', 'Developer ID Application: Devolutions inc. (N592S9ASDB)',
+                '-s', '"Developer ID Application: Devolutions inc. (N592S9ASDB)"',
                 '-v', 
                 $_.FullName
               )) -Join ' '

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,7 +39,7 @@ jobs:
   codesign:
     name: Codesign
     runs-on: windows-2019
-    # environment: build-and-publish
+    environment: build-and-publish
     needs: preflight
 
     steps:
@@ -56,53 +56,76 @@ jobs:
           gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -n jetsocat -D (Join-Path ${{ runner.temp }} devolutions-gateway)
           Get-ChildItem -Path ${{ runner.temp }} -Recurse
 
-      # - name: Configure certificates
-      #   env:
-      #     CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
-      #     CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
-      #   run: |
-      #     $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
-      #     [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
-      #     $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
-      #     Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+      - name: Configure certificates
+        env:
+          CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
+          CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
+        run: |
+          $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
+          [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
+          $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
+          Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
 
       - name: Sign executables
         shell: pwsh
         run: |
-            
+          Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*DevolutionsGateway*.exe', '*jetsocat*.exe' | % { 
+          $SignCmd = $(@(
+            'signtool', 
+            'sign', 
+            '/fd', 'SHA256', 
+            '/v', 
+            '/n', 'Devolutions', 
+            '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+            '/td', 'sha256',
+            $_.FullName
+          )) -Join ' '
 
-      # - name: Configure runner
-      #   run: |
-      #     echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Host $SignCmd
+          Invoke-Expression $SignCmd
 
-      # - name: Sign executables
-      #   run: |
-      #     Get-ChildItem -Path devolutions-gateway -Recurse -Include "*.exe", "*.msi" | % { 
-      #       Write-Host "Signing $_.FullName"
-      #       $SignCmd = $(@(
-      #         'signtool', 
-      #         'sign', 
-      #         '/fd', 'SHA256', 
-      #         '/v', 
-      #         '/n', 'Devolutions', 
-      #         '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-      #         '/td', 'sha256',
-      #         $_.FullName
-      #       )) -Join ' '
+      - name: Repackage
+        shell: pwsh
+        run: |
+          $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
+          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse | 
+            Where-Object { $_.Name -Match '*DevolutionsGateway*.msi' } | 
+            Select -First 1
+          $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
+          $Env:DGATEWAY_PSMODULE_CLEAN = "1"
 
-      #       Invoke-Expression $SignCmd
-      #     }
+          ./ci/tlk.ps1 package
 
-      # - name: Upload artifacts
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: devolutions-gateway
-      #     path: devolutions-gateway
+      - name: Sign packages
+        shell: pwsh
+        run: |
+          Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*.msi' | % { 
+          $SignCmd = $(@(
+            'signtool', 
+            'sign', 
+            '/fd', 'SHA256', 
+            '/v', 
+            '/n', 'Devolutions', 
+            '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+            '/td', 'sha256',
+            $_.FullName
+          )) -Join ' '
 
-      # - name: Upload artifacts
-      #   uses: actions/upload-artifact@v2
-      #   with:
-      #     name: jetsocat
-      #     path: jetsocat
+          Write-Host $SignCmd
+          Invoke-Expression $SignCmd
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: devolutions-gateway
+          path: ${{ runner.temp }}/devolutions-gateway
+          if-no-files-found: error
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: jetsocat
+          path: ${{ runner.temp }}/jetsocat
+          if-no-files-found: error
 
   

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,8 +22,10 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+          CI_RUN: ${{ github.event.inputs.run-id }}
         run: |
-          $RunJson = gh api "/repos/$Env:GITHUB_REPOSITORY/actions/runs/${{ github.event.inputs.run-id }}"
+          GetRunsCmd = @('gh', 'api', "/repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN")
+          $RunJson = Invoke-Expression ($GetRunsCmd -Join ' ')
           $Run = $RunJson | ConvertFrom-Json
 
           if ($($Run.head_branch) -Ne "master") {

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      # WiX is installed on Windows runners but not in the PATH
+      - name: Configure runner
+        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
       - name: Sign executables
         shell: pwsh
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: | 
-          gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -n jetsocat -D ${{ runner.temp }}
+          gh run download ${{ github.event.inputs.run }} -n devolutions-gateway -n jetsocat -D ${{ runner.temp }}
           Get-ChildItem -Path ${{ runner.temp }} -Recurse
 
       - name: Configure certificates

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -131,7 +131,7 @@ jobs:
                 '/td', 'sha256',
                 $_.FullName
               )) -Join ' '
-            } else if ('${{ matrix.os }}' -Eq 'macos') {
+            } elseif ('${{ matrix.os }}' -Eq 'macos') {
               $SignCmd = $(@(
                 'codesign', 
                 '--timestamp', 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -178,10 +178,10 @@ jobs:
             Invoke-Expression $SignCmd
           }
 
-      - name: Upload move-artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.project }}
-          path: ${{ runner.temp }}/{{ matrix.project }}
+          path: ${{ runner.temp }}/${{ matrix.project }}
           if-no-files-found: error
  

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -116,7 +116,7 @@ jobs:
             "jetsocat" { 'jetsocat_*'' }
           }
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include "$Pattern" | % {
-            if ($Env:RUNNER_OS -Eq 'Windows') {
+            if ('${{ matrix.os }}' -Eq 'windows') {
               $SignCmd = $(@(
                 'signtool', 
                 'sign', 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,7 +47,7 @@ jobs:
         project: [ jetsocat, devolutions-gateway ]
         runner: [ windows-2019, macos-10.15 ]
         exclude:
-          - arch: devolutions-gateway
+          - project: devolutions-gateway
             runner: macos-10.15
 
     steps:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,106 @@
+name: Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      run:
+        description: 'The CI workflow run to package'
+        required: true
+
+concurrency: gateway-package
+
+jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-18.04
+    outputs: 
+      commit: ${{ steps.get-commit.outputs.commit }}
+
+    steps:
+      - name: Get commit
+        id: get-commit
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+        run: |
+          $RunJson = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/${{ github.event.inputs.run-id }}
+          $Run = $RunJson | ConvertFrom-Json
+
+          if ($($Run.head_branch) -Ne "master") {
+            echo "::error::specified run is not on master, exiting..."
+            exit 1
+          }
+
+          if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
+            echo "::error::specified run is either not complete or not successful, exiting..."            
+            exit 1
+          }
+
+          echo "::set-output name=commit::$($Run.head_sha)"
+          echo "::notice::Packaging commit ${{ steps.get-commit.outputs.commit }} from run ${{ github.event.inputs.run }}"
+
+  codesign:
+    name: Codesign
+    runs-on: windows-2019
+    environment: build-and-publish
+    needs: preflight
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.preflight.outputs.commit }}
+
+      - name: Download artifacts
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+        run: | 
+          gh run download ${{ github.event.inputs.run-id }} -n devolutions-gateway -D (Join-Path ${{ runner.temp }} devolutions-gateway)
+          Get-ChildItem -Path ${{ runner.temp }} -recurse
+
+      # - name: Configure certificates
+      #   env:
+      #     CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
+      #     CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
+      #   run: |
+      #     $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
+      #     [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
+      #     $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
+      #     Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+
+      # - name: Configure runner
+      #   run: |
+      #     echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      # - name: Sign executables
+      #   run: |
+      #     Get-ChildItem -Path devolutions-gateway -Recurse -Include "*.exe", "*.msi" | % { 
+      #       Write-Host "Signing $_.FullName"
+      #       $SignCmd = $(@(
+      #         'signtool', 
+      #         'sign', 
+      #         '/fd', 'SHA256', 
+      #         '/v', 
+      #         '/n', 'Devolutions', 
+      #         '/tr', 'http://timestamp.comodoca.com/?td=sha256',
+      #         '/td', 'sha256',
+      #         $_.FullName
+      #       )) -Join ' '
+
+      #       Invoke-Expression $SignCmd
+      #     }
+
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: devolutions-gateway
+      #     path: devolutions-gateway
+
+      # - name: Upload artifacts
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: jetsocat
+      #     path: jetsocat
+
+  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,10 @@ jobs:
 
     steps:
       - name: Download artifacts
-        id: download
-        uses: actions/download-artifact@v2
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+        run: gh run download ${{ github.event.inputs.run }} -n jetsocat -n devolutions-gateway -n version --repo $Env:GITHUB_REPOSITORY
 
       - name: Create GitHub release
         shell: pwsh
@@ -131,9 +133,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
           $Version = "${{ needs.preflight.outputs.version }}"
-          $StagingPath = "${{ steps.download.outputs.download-path }}"
-          $HashPath = Join-Path $StagingPath checksums
-          $Files = Get-ChildItem -Path $StagingPath -Recurse -File | % { Get-FileHash -Algorithm SHA256 $_.FullName }
+          $HashPath = 'checksums'
+          $Files = Get-ChildItem -Recurse -File | % { Get-FileHash -Algorithm SHA256 $_.FullName }
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
@@ -150,20 +151,19 @@ jobs:
 
     steps:
       - name: Download artifacts
-        id: download
-        uses: actions/download-artifact@v2
-        with:
-          name: devolutions-gateway
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+        run: gh run download ${{ github.event.inputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
+
 
       - name: Publish PowerShell module
         shell: pwsh
         run: |
-          $StagingPath = "${{ steps.download.outputs.download-path }}"
-          $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File -Path $StagingPath
-          $Module = Join-Path $StagingPath PowerShell
-          Expand-Archive -Path $Archive -DestinationPath $Module
+          $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File
+          Expand-Archive -Path $Archive -DestinationPath 'PowerShell'
 
-          $PublishCmd = @('Publish-Module', '-Force', '-Path', (Join-Path $Module DevolutionsGateway), '-NugetApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
+          $PublishCmd = @('Publish-Module', '-Force', '-Path', (Join-Path PowerShell DevolutionsGateway), '-NugetApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
           if ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')) {
             $PublishCmd += '-WhatIf'
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,14 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      run-id:
-        description: 'The CI workflow run ID with the artifacts to release'
+      run:
+        description: 'The Package workflow run to release'
         required: true
+      dry-run:
+        description: 'If true, the workflow only indicates which artifacts would be uploaded'
+        required: true
+        type: boolean
+        default: 'true'
 
 concurrency: gateway-release
 
@@ -14,112 +19,28 @@ jobs:
     name: Preflight
     runs-on: ubuntu-18.04
     outputs: 
-      commit: ${{ steps.get-commit.outputs.commit }}
       version: ${{ steps.get-version.outputs.version }}
 
     steps:
-      - name: Get commit
-        id: get-commit
+      - name: Get version
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
-          $RunJson = gh api /repos/devolutions/devolutions-gateway/actions/runs/${{ github.event.inputs.run-id }}
-          $Run = $RunJson | ConvertFrom-Json
-
-          if ($($Run.head_branch) -Ne "master") {
-            echo "::error::specified run is not on master, exiting..."
-            exit 1
-          }
-
-          if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
-            echo "::error::specified run is either not complete or not successful, exiting..."            
-            exit 1
-          }
-
-          echo "::set-output name=commit::$($Run.head_sha)"
-
-      - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ steps.get-commit.outputs.commit }}
-
-      - name: Get version
-        id: get-version
-        shell: pwsh
-        run: |
+          gh run download ${{ github.event.inputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
           $Version = Get-Content VERSION -TotalCount 1
           echo "::set-output name=version::$Version"
 
       - name: Print output
         shell: pwsh
-        run: Write-Host Version ${{ steps.get-version.outputs.version }} - Run ${{ github.event.inputs.run-id }} - Commit ${{ steps.get-commit.outputs.commit }}
-
-  # TODO: code sign (and notarize?) jetsocat on macOS
-  codesign:
-    name: Codesign
-    runs-on: windows-2019
-    environment: build-and-publish
-    needs: preflight
-
-    steps:
-      - name: Configure certificates
-        env:
-          CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
-          CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
-        run: |
-          $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
-          [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
-          $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
-          Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
-
-      - name: Configure runner
-        run: |
-          echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Download artifacts
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run-id }} --repo Devolutions/devolutions-gateway
-
-      - name: Sign executables
-        run: |
-          Get-ChildItem -Path devolutions-gateway -Recurse -Include "*.exe", "*.msi" | % { 
-            Write-Host "Signing $_.FullName"
-            $SignCmd = $(@(
-              'signtool', 
-              'sign', 
-              '/fd', 'SHA256', 
-              '/v', 
-              '/n', 'Devolutions', 
-              '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-              '/td', 'sha256',
-              $_.FullName
-            )) -Join ' '
-
-            Invoke-Expression $SignCmd
-          }
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: devolutions-gateway
-          path: devolutions-gateway
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: jetsocat
-          path: jetsocat
+        run: echo "::notice::Releasing artifacts for version ${{ steps.get-version.outputs.version }} from run ${{ github.event.inputs.run }}"
 
   containers:
     name: Containers [${{ matrix.os }} ${{ matrix.base-image }}]
     runs-on: ${{ matrix.runner }}
     environment: build-and-publish
-    needs: [preflight, codesign]
+    needs: [preflight]
     strategy:
-      fail-fast: true
       matrix:
         arch: [ x86_64 ]
         os: [ windows, linux ]
@@ -139,21 +60,17 @@ jobs:
             base-image: nanoserver-1809
 
     steps:
-      - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
-
       - name: Download artifacts
-        id: download
-        uses: actions/download-artifact@v2
-        with:
-          name: devolutions-gateway
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+        run: gh run download ${{ github.event.inputs.run }} -n docker -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
 
-      # Copy the built and signed Devolutions Gateway binary into the packaging location
-      - name: Move artifacts
-        id: move-artifacts
+      - name: Prepare artifacts
+        id: prepare-artifacts
         shell: pwsh
         run: |
-          $PkgDir = Join-Path $pwd package $Env:RUNNER_OS # RUNNER_OS is camelcase
+          $PkgDir = Join-Path docker $Env:RUNNER_OS # RUNNER_OS is camelcase
           echo "::set-output name=package-path::$PkgDir"
           
           $SourceFileName = "DevolutionsGateway_$($Env:RUNNER_OS)_${{ needs.preflight.outputs.version }}_${{ matrix.arch }}"
@@ -165,7 +82,7 @@ jobs:
             $TargetFileName = "devolutions-gateway"
           }
 
-          $SourcePath = Get-ChildItem -Recurse -Filter $SourceFileName -File -Path ${{ steps.download.outputs.download-path }}
+          $SourcePath = Get-ChildItem -Recurse -Filter $SourceFileName -File -Path devolutions-gateway
           $TargetPath = Join-Path $PkgDir $TargetFileName
           Copy-Item $SourcePath $TargetPath
 
@@ -176,7 +93,7 @@ jobs:
       - name: Build container
         id: build-container
         shell: pwsh
-        working-directory: ${{ steps.move-artifacts.outputs.package-path }}
+        working-directory: ${{ steps.prepare-artifacts.outputs.package-path }}
         run: |
           $ImageName = "devolutions/devolutions-gateway:${{ needs.preflight.outputs.version }}-${{ matrix.base-image }}"
           if ("${{ matrix.base-image }}" -Eq "nanoserver-1809") {
@@ -188,16 +105,20 @@ jobs:
 
       - name: Push container
         shell: pwsh
-        working-directory: ${{ steps.move-artifacts.outputs.package-path }}
+        working-directory: ${{ steps.prepare-artifacts.outputs.package-path }}
         run: |
           echo ${{ secrets.DOCKER_HUB_BOT_PASSWORD }} | docker login -u devolutionsbot --password-stdin
-          docker push ${{ steps.build-container.outputs.image-name }}
+          $DockerPushCmd = 'docker push ${{ steps.build-container.outputs.image-name }}'
+          Write-Host $DockerPushCmd
+          if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
+            Invoke-Expression $DockerPushCmd
+          }
 
   github-release:
     name: GitHub release
     runs-on: ubuntu-18.04
     environment: build-and-publish
-    needs: [preflight, codesign]
+    needs: [preflight]
 
     steps:
       - name: Download artifacts
@@ -217,13 +138,15 @@ jobs:
 
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
-          Invoke-Expression $GhCmd
+          if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
+            Invoke-Expression $GhCmd
+          }
 
   psgallery-release:
     name: PowerShell release
     runs-on: ubuntu-18.04
     environment: build-and-publish
-    needs: codesign
+    needs: preflight
 
     steps:
       - name: Download artifacts
@@ -239,8 +162,16 @@ jobs:
           $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File -Path $StagingPath
           $Module = Join-Path $StagingPath PowerShell
           Expand-Archive -Path $Archive -DestinationPath $Module
+
+          $PublishCmd = @('Publish-Module', '-Force', '-Path', (Join-Path $Module DevolutionsGateway), '-NugetApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
+          if ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')) {
+            $PublishCmd += '-WhatIf'
+          }
+          $PublishCmd = $PublishCmd -Join ' '
+          Write-Host $PublishCmd
+
           try {
-            Publish-Module -Force -Path (Join-Path $Module DevolutionsGateway) -NugetApiKey "${{ secrets.PS_GALLERY_NUGET_API_KEY }}"
+            Invoke-Expression $PublishCmd
           }
           catch {
             if ($_.Exception.Message -ilike "*cannot be published as the current version*is already available in the repository*") {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,10 +31,7 @@ jobs:
           gh run download ${{ github.event.inputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
           $Version = Get-Content VERSION -TotalCount 1
           echo "::set-output name=version::$Version"
-
-      - name: Print output
-        shell: pwsh
-        run: echo "::notice::Releasing artifacts for version ${{ steps.get-version.outputs.version }} from run ${{ github.event.inputs.run }}"
+          echo "::notice::Releasing artifacts for version ${{ steps.get-version.outputs.version }} from run ${{ github.event.inputs.run }}"
 
   containers:
     name: Containers [${{ matrix.os }} ${{ matrix.base-image }}]
@@ -103,6 +100,7 @@ jobs:
             docker build -t "$ImageName" .
           }
           echo "::set-output name=image-name::$ImageName"
+          Get-ChildItem -Recurse
 
       - name: Push container
         shell: pwsh
@@ -138,6 +136,8 @@ jobs:
           $Files = Get-ChildItem -Recurse -File | % { Get-FileHash -Algorithm SHA256 $_.FullName }
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
+          Get-Content $HashPath
+
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
           if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
@@ -156,7 +156,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ github.event.inputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
-
 
       - name: Publish PowerShell module
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           echo "::endgroup::"
 
           $ChangesPath = 'changes'
-          parse-changelog CHANGELOG.md $Version | Out-File -Encoding UTF8NoBOM $ChangesPath
+          parse-changelog $(Join-Path changelog CHANGELOG.md) $Version | Out-File -Encoding UTF8NoBOM $ChangesPath
 
           echo "::group::changes"
           Get-Content $ChangesPath

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - name: Get version
+        id: get-version
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           Get-Content $ChangesPath
           echo "::endgroup::"
 
-          $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo",  "--notes-file", $ChangesPath, "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
+          $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", $Env:GITHUB_REPOSITORY, "--notes-file", $ChangesPath, $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
           if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
             Invoke-Expression $GhCmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,11 +120,14 @@ jobs:
     needs: [preflight]
 
     steps:
+      - name: Configure runner
+        run: cargo install parse-changelog
+
       - name: Download artifacts
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n jetsocat -n devolutions-gateway -n version --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ github.event.inputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
 
       - name: Create GitHub release
         shell: pwsh
@@ -133,12 +136,21 @@ jobs:
         run: |
           $Version = "${{ needs.preflight.outputs.version }}"
           $HashPath = 'checksums'
-          $Files = Get-ChildItem -Recurse -File | % { Get-FileHash -Algorithm SHA256 $_.FullName }
+          $Files = Get-ChildItem -Recurse -File -Exclude 'CHANGELOG.md' | % { Get-FileHash -Algorithm SHA256 $_.FullName }
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
+          echo "::group::checksums"
           Get-Content $HashPath
+          echo "::endgroup::"
 
-          $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
+          $ChangesPath = 'changes'
+          parse-changelog CHANGELOG.md $Version | Out-File -Encoding UTF8NoBOM $ChangesPath
+
+          echo "::group::changes"
+          Get-Content $ChangesPath
+          echo "::endgroup::"
+
+          $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo",  "--notes-file", $ChangesPath, "Devolutions/devolutions-gateway", $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
           if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
             Invoke-Expression $GhCmd

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -241,7 +241,6 @@ class TlkRecipe
 
     [void] Init() {
         $this.SourcePath = $($PSScriptRoot | Get-Item).Parent.FullName
-        Write-Host $this.SourcePath
         $this.PackageName = "DevolutionsGateway"
         $this.Version = $(Get-Content -Path "$($this.SourcePath)/VERSION").Trim()
         $this.Verbose = $true
@@ -254,7 +253,6 @@ class TlkRecipe
         $ConanProfile = "$($this.Target.Platform)-$($this.Target.Architecture)"
 
         Write-Host "conan profile: $ConanProfile"
-
 
         & 'conan' 'install' $ConanPackage '-g' 'virtualenv' '-pr' $ConanProfile '-s' 'build_type=Release'
         $dotenv = Get-DotEnvFile ".\environment.sh.env"
@@ -269,10 +267,7 @@ class TlkRecipe
 
     [void] Cargo([string[]]$CargoArgs) {
         $CargoTarget = $this.Target.CargoTarget()
-        Write-Host "CargoTarget: $CargoTarget"
-
         $CargoProfile = $this.Target.CargoProfile
-        Write-Host "CargoProfile: $CargoProfile"
 
         $CargoArgs += @('--profile', $CargoProfile)
         $CargoArgs += @('--target', $CargoTarget)
@@ -314,10 +309,7 @@ class TlkRecipe
         Set-Location -Path $CargoPackage
 
         $CargoTarget = $this.Target.CargoTarget()
-        Write-Host "CargoTarget: $CargoTarget"
-
         $CargoProfile = $this.Target.CargoProfile
-        Write-Host "CargoProfile: $CargoProfile"
 
         $this.Cargo(@('build'))
 
@@ -377,12 +369,8 @@ class TlkRecipe
         } else {
             throw ("Specify DGATEWAY_PSMODULE_PATH environment variable")
         }
-        
-        Write-Host $DGatewayExecutable
-        Write-Host $DGatewayPSModulePath
 
         $PSManifestFile = $(@(Get-ChildItem -Path $DGatewayPSModulePath -Depth 1 -Filter "*.psd1")[0]).FullName
-        Write-Host $PSManifestFile
         $PSManifest = Import-PowerShellDataFile -Path $PSManifestFile
         $PSModuleName = $(Get-Item $PSManifestFile).BaseName
         $PSModuleVersion = $PSManifest.ModuleVersion
@@ -606,10 +594,7 @@ class TlkRecipe
         }
 
         $CargoTarget = $this.Target.CargoTarget()
-        Write-Host "CargoTarget: $CargoTarget"
-
         $CargoProfile = $this.Target.CargoProfile
-        Write-Host "CargoProfile: $CargoProfile"
 
         $this.Cargo($CargoArgs)
 
@@ -642,8 +627,6 @@ function Invoke-TlkStep {
         $CargoProfile = 'release'
     }
 
-    Write-Host $PSScriptRoot
-    Write-Host (Split-Path -Parent $PSScriptRoot)
     $RootPath = Split-Path -Parent $PSScriptRoot
 
     $tlk = [TlkRecipe]::new()

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -377,7 +377,11 @@ class TlkRecipe
             throw ("Specify DGATEWAY_PSMODULE_PATH environment variable")
         }
         
+        Write-Host $DGatewayExecutable
+        Write-Host $DGatewayPSModulePath
+
         $PSManifestFile = $(@(Get-ChildItem -Path $DGatewayPSModulePath -Depth 1 -Filter "*.psd1")[0]).FullName
+        Write-Host $PSManifestFile
         $PSManifest = Import-PowerShellDataFile -Path $PSManifestFile
         $PSModuleName = $(Get-Item $PSManifestFile).BaseName
         $PSModuleVersion = $PSManifest.ModuleVersion

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -643,6 +643,9 @@ function Invoke-TlkStep {
         $CargoProfile = 'release'
     }
 
+    Write-Host >>>>>>>>
+    Write-Host $PSScriptRoot
+    Write-Host (Split-Path -Parent $PSScriptRoot)
     $RootPath = Split-Path -Parent $PSScriptRoot
 
     $tlk = [TlkRecipe]::new()

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -241,7 +241,6 @@ class TlkRecipe
 
     [void] Init() {
         $this.SourcePath = $($PSScriptRoot | Get-Item).Parent.FullName
-        Write-Host >>>>>>
         Write-Host $this.SourcePath
         $this.PackageName = "DevolutionsGateway"
         $this.Version = $(Get-Content -Path "$($this.SourcePath)/VERSION").Trim()
@@ -643,7 +642,6 @@ function Invoke-TlkStep {
         $CargoProfile = 'release'
     }
 
-    Write-Host >>>>>>>>
     Write-Host $PSScriptRoot
     Write-Host (Split-Path -Parent $PSScriptRoot)
     $RootPath = Split-Path -Parent $PSScriptRoot

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -241,6 +241,8 @@ class TlkRecipe
 
     [void] Init() {
         $this.SourcePath = $($PSScriptRoot | Get-Item).Parent.FullName
+        Write-Host >>>>>>
+        Write-Host $this.SourcePath
         $this.PackageName = "DevolutionsGateway"
         $this.Version = $(Get-Content -Path "$($this.SourcePath)/VERSION").Trim()
         $this.Verbose = $true


### PR DESCRIPTION
A large (and hopefully final) refactor of the CI and release.

The previous setup performed the build, test and packaging inside the CI workflow. The release workflow code-signed the artifacts, then built the docker containers (the `servercore-ltsc2019` container is too large to be a build artifact) and published them, created a GitHub release and published the PowerShell module.

However, although the Windows Gateway .msi was code-signed; the executable it installed was not: since the packaging happened in the CI workflow. It's not preferable to code-sign inside the CI workflow since it requires approval to access the signing certificates. Unsigned builds are fine for dev; but we might want to create a fully signed build independently of a release.

The PR splits everything into 3 workflows.

##### CI
Build and package Devolutions Gateway, build jetsocat; no code-signing

##### Package

Download *CI* artifacts and sign the Devolutions Gateway executable, rebuild the .msi and sign it. Sign the jetsocat binaries.

##### Release

Download the *Package* artifacts and generate the releases (build and publish the docker containers, publish the release to GitHub and PSGallery)

There's some complexity added but it's the most flexible solution. I added a comprehensive readme for the workflows.

Finally, I made the following improvements:

- `jetsocat` builds for macOS are now signed
- The *Release* workflow has a `dry-run` parameter; this allows running the workflow without actually publishing anything
- The *Release* workflow now parses CHANGELOG.md and adds the proper release notes on GitHub
- The Devolutions Gateway installer now properly displays the application name in the installer UAC prompt (instead of a temporary random name - caused by running `signtool` without the `/d' parameter)
- The CI workflow has some micro-optimization. I'm hesitant to optimize it further right now in order to maintain flexbility.