### PR TITLE
DGW-18: parse query parameters to retrieve token

### DIFF
--- a/devolutions-gateway/src/http/http_server.rs
+++ b/devolutions-gateway/src/http/http_server.rs
@@ -33,13 +33,7 @@ pub fn configure_http_server(
                 .apply(
                     AuthMiddleware::new(config.clone(), token_cache, jrl.clone()),
                     vec!["/"],
-                    vec![
-                        "/registry",
-                        "/health",
-                        "/jet/health",
-                        "/KdcProxy",
-                        "/jet/diagnostics/clock",
-                    ],
+                    vec!["/registry", "/health", "/jet/health", "/jet/diagnostics/clock"],
                 )
                 .apply(
                     SogarAuthMiddleware::new(config.clone()),

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -365,7 +365,7 @@ impl<'de> de::Deserialize<'de> for KdcTokenClaims {
 
         // Validate krb_realm value
 
-        if !claims.krb_realm.chars().all(char::is_lowercase) {
+        if claims.krb_realm.chars().any(char::is_uppercase) {
             return Err(de::Error::custom("krb_realm field contains uppercases"));
         }
 


### PR DESCRIPTION
Check for JWT in requests with the shape `/route?token=<JWT>`.
This allow configuring KDC client to use `/KdcProxy?token=<JWT>` to identify itself.