### PR TITLE
DGW-21: specify JMUX filtering through claims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,7 @@ dependencies = [
  "proptest",
  "reqwest",
  "ring",
+ "rstest",
  "rust-argon2",
  "saphir",
  "serde",
@@ -2639,6 +2640,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "rustc_version",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2669,15 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rusticata-macros"
@@ -2816,6 +2839,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -101,4 +101,5 @@ embed-resource = "1.6.5"
 [dev-dependencies]
 tokio-test = "0.4.2"
 proptest = "1.0.0"
+rstest = "0.12.0"
 devolutions-gateway-generators = { path = "../crates/devolutions-gateway-generators" }

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -311,6 +311,7 @@ pub struct ConfigFile {
     pub capture_path: Option<Utf8PathBuf>,
 
     // unsafe debug options for developers
+    #[serde(rename = "__debug__")]
     pub debug: DebugOptions,
 }
 
@@ -323,18 +324,15 @@ pub struct ConfigFile {
 #[derive(PartialEq, Debug, Clone, Deserialize)]
 pub struct DebugOptions {
     /// Dump received tokens using a `debug` statement
-    #[serde(rename = "DumpTokens")]
     #[serde(default)]
     pub dump_tokens: bool,
 
     /// Ignore token signature and accept as-is (any signer is accepted), expired tokens and token
     /// reuse is allowed, etc. Only restriction is to provide claims in the right format.
-    #[serde(rename = "DisableTokenValidation")]
     #[serde(default)]
     pub disable_token_validation: bool,
 
     /// Ignore KDC address provided by KDC token, and use this one instead
-    #[serde(rename = "OverrideKdc")]
     pub override_kdc: Option<TargetAddr>,
 }
 
@@ -1065,6 +1063,7 @@ impl Config {
             },
             sogar_user,
             jrl_file: Some(jrl_file),
+            debug: config_file.debug,
             ..Default::default()
         })
     }

--- a/devolutions-gateway/src/utils.rs
+++ b/devolutions-gateway/src/utils.rs
@@ -10,6 +10,7 @@ use std::hash::Hash;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
+use tap::Pipe as _;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{lookup_host, TcpStream};
 use tokio_rustls::{rustls, Connect, TlsConnector};
@@ -46,12 +47,15 @@ pub async fn resolve_url_to_socket_addr(url: &Url) -> anyhow::Result<SocketAddr>
 }
 
 pub async fn resolve_target_to_socket_addr(dest: &TargetAddr) -> anyhow::Result<SocketAddr> {
-    match &dest.host {
-        HostRepr::Domain(domain, port) => lookup_host((domain.as_str(), *port))
+    let port = dest.port();
+
+    if let Some(ip) = dest.host_ip() {
+        Ok(SocketAddr::new(ip, port))
+    } else {
+        lookup_host((dest.host(), port))
             .await?
             .next()
-            .context("host lookup yielded no result"),
-        HostRepr::Ip(addr) => Ok(*addr),
+            .context("host lookup yielded no result")
     }
 }
 
@@ -214,6 +218,7 @@ pub fn create_tls_connector(socket: TcpStream) -> Connect<TcpStream> {
 pub enum BadTargetAddr {
     HostMissing,
     PortMissing,
+    TooLong,
     BadPort { value: SmolStr },
 }
 
@@ -222,6 +227,7 @@ impl fmt::Display for BadTargetAddr {
         match self {
             BadTargetAddr::HostMissing => write!(f, "host is missing"),
             BadTargetAddr::PortMissing => write!(f, "port is missing"),
+            BadTargetAddr::TooLong => write!(f, "address representation is too long"),
             BadTargetAddr::BadPort { value } => write!(f, "bad port value: {}", value),
         }
     }
@@ -235,31 +241,63 @@ impl std::error::Error for BadTargetAddr {}
 /// Also, when parsing, default scheme is `tcp`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TargetAddr {
-    serialization: SmolStr,
-    scheme: SmolStr,
-    host: HostRepr,
+    // String representation
+    serialization: String,
+
+    // Components
+    scheme_end: u16,
+    host_start: u16,
+    host_end: u16,
+    host_internal: HostInternal,
+    port: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HostRepr {
-    Domain(SmolStr, u16),
-    Ip(SocketAddr),
-}
-
-impl fmt::Display for HostRepr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            HostRepr::Domain(domain, port) => write!(f, "{}:{}", domain, port),
-            HostRepr::Ip(ip) => ip.fmt(f),
-        }
-    }
+enum HostInternal {
+    Domain,
+    Ip(IpAddr),
 }
 
 impl TargetAddr {
     const DEFAULT_SCHEME: &'static str = "tcp";
 
+    pub fn from_components(scheme: &str, host: &str, port: u16) -> Result<Self, BadTargetAddr> {
+        let scheme_end = scheme.len();
+
+        let (host_internal, is_ipv6) = if let Ok(ip_addr) = host.parse::<IpAddr>() {
+            (HostInternal::Ip(ip_addr), ip_addr.is_ipv6())
+        } else {
+            (HostInternal::Domain, false)
+        };
+
+        let (serialization, host_start) = if is_ipv6 {
+            (format!("{scheme}://[{host}]:{port}"), scheme_end + "://[".len())
+        } else {
+            (format!("{scheme}://{host}:{port}"), scheme_end + "://".len())
+        };
+
+        let host_end = host_start + host.len();
+
+        Ok(TargetAddr {
+            serialization,
+            scheme_end: scheme_end.pipe(u16::try_from).map_err(|_| BadTargetAddr::TooLong)?,
+            host_start: host_start.pipe(u16::try_from).map_err(|_| BadTargetAddr::TooLong)?,
+            host_end: host_end.pipe(u16::try_from).map_err(|_| BadTargetAddr::TooLong)?,
+            host_internal,
+            port,
+        })
+    }
+
     pub fn parse(s: &str, default_port: impl Into<Option<u16>>) -> Result<Self, BadTargetAddr> {
-        target_addr_parse_impl(s, default_port.into())
+        target_addr_parse_impl(s, Self::DEFAULT_SCHEME, default_port.into())
+    }
+
+    pub fn parse_with_default_scheme(
+        s: &str,
+        default_scheme: &str,
+        default_port: impl Into<Option<u16>>,
+    ) -> Result<Self, BadTargetAddr> {
+        target_addr_parse_impl(s, default_scheme, default_port.into())
     }
 
     pub fn as_str(&self) -> &str {
@@ -267,11 +305,22 @@ impl TargetAddr {
     }
 
     pub fn scheme(&self) -> &str {
-        &self.scheme
+        self.h_slice(0, self.scheme_end)
     }
 
-    pub fn host_repr(&self) -> &HostRepr {
-        &self.host
+    pub fn host(&self) -> &str {
+        self.h_slice(self.host_start, self.host_end)
+    }
+
+    pub fn host_ip(&self) -> Option<IpAddr> {
+        match self.host_internal {
+            HostInternal::Domain => None,
+            HostInternal::Ip(ip) => Some(ip),
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
     }
 
     pub fn to_url(&self) -> Result<url::Url, url::ParseError> {
@@ -285,66 +334,62 @@ impl TargetAddr {
     pub fn to_uri_with_path_and_query(&self, path_and_query: &str) -> Result<http::Uri, http::uri::InvalidUri> {
         format!("{}{}", self.serialization, path_and_query).parse()
     }
+
+    #[inline]
+    fn h_slice(&self, start: u16, end: u16) -> &str {
+        &self.serialization[usize::from(start)..usize::from(end)]
+    }
 }
 
-fn target_addr_parse_impl(s: &str, default_port: Option<u16>) -> Result<TargetAddr, BadTargetAddr> {
-    let (scheme, rest) = if let Some(scheme_end_idx) = s.find("://") {
-        (SmolStr::new(&s[..scheme_end_idx]), &s[scheme_end_idx + "://".len()..])
+fn target_addr_parse_impl(
+    s: &str,
+    default_scheme: &str,
+    default_port: Option<u16>,
+) -> Result<TargetAddr, BadTargetAddr> {
+    let (scheme, rest) = if let Some(scheme_end) = s.find("://") {
+        (&s[..scheme_end], &s[scheme_end + "://".len()..])
     } else {
-        (SmolStr::new_inline(TargetAddr::DEFAULT_SCHEME), s)
+        (default_scheme, s)
     };
 
-    if let Ok(addr) = rest.parse::<SocketAddr>() {
-        Ok(TargetAddr {
-            serialization: SmolStr::from(format!("{}://{}", scheme, addr)),
-            scheme,
-            host: HostRepr::Ip(addr),
-        })
+    let is_ipv6 = matches!(rest.chars().next(), Some('['));
+
+    let port_start = if is_ipv6 {
+        rest.rfind("]:").map(|idx| idx + 2)
     } else {
-        let (domain, port) = if let Some(domain_end_idx) = rest.find(':') {
-            let domain = SmolStr::new(&rest[..domain_end_idx]);
+        rest.rfind(':').map(|idx| idx + 1)
+    };
 
-            let port = &rest[domain_end_idx + 1..];
-            let port = port
-                .parse::<u16>()
-                .map_err(|_| BadTargetAddr::BadPort { value: port.into() })?;
+    let (rest, port) = if let Some(port_start) = port_start {
+        let port = &rest[port_start..];
+        let port = port
+            .parse::<u16>()
+            .map_err(|_| BadTargetAddr::BadPort { value: port.into() })?;
 
-            (domain, port)
-        } else if let Some(default_port) = default_port {
-            (SmolStr::new(rest), default_port)
-        } else {
-            return Err(BadTargetAddr::PortMissing);
-        };
+        (&rest[..port_start - 1], port)
+    } else if let Some(default_port) = default_port {
+        (rest, default_port)
+    } else {
+        return Err(BadTargetAddr::PortMissing);
+    };
 
-        Ok(TargetAddr {
-            serialization: SmolStr::from(format!("{}://{}:{}", scheme, domain, port)),
-            scheme,
-            host: HostRepr::Domain(domain, port),
-        })
-    }
+    let host = if is_ipv6 {
+        rest.trim_start_matches('[').trim_end_matches(']')
+    } else {
+        rest
+    };
+
+    TargetAddr::from_components(scheme, host, port)
 }
 
 impl TryFrom<&url::Url> for TargetAddr {
     type Error = BadTargetAddr;
 
     fn try_from(url: &url::Url) -> Result<Self, Self::Error> {
-        let scheme = SmolStr::from(url.scheme());
-
-        let port = url.port().ok_or(BadTargetAddr::PortMissing)?;
-
-        let host = match url.host().ok_or(BadTargetAddr::HostMissing)? {
-            url::Host::Domain(domain) => HostRepr::Domain(domain.into(), port),
-            url::Host::Ipv4(ipv4) => HostRepr::Ip(SocketAddr::new(IpAddr::V4(ipv4), port)),
-            url::Host::Ipv6(ipv6) => HostRepr::Ip(SocketAddr::new(IpAddr::V6(ipv6), port)),
-        };
-
-        let serialization = SmolStr::from(format!("{}://{}", scheme, host));
-
-        Ok(Self {
-            serialization,
-            scheme,
-            host,
-        })
+        let scheme = url.scheme();
+        let port = url.port_or_known_default().ok_or(BadTargetAddr::PortMissing)?;
+        let host = url.host_str().ok_or(BadTargetAddr::HostMissing)?;
+        Self::from_components(scheme, host, port)
     }
 }
 
@@ -375,7 +420,7 @@ impl FromStr for TargetAddr {
     type Err = BadTargetAddr;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::parse(s, None)
+        target_addr_parse_impl(s, Self::DEFAULT_SCHEME, None)
     }
 }
 
@@ -402,5 +447,116 @@ impl<'de> de::Deserialize<'de> for TargetAddr {
         }
 
         deserializer.deserialize_str(V)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::fmt::Write as _;
+    use rstest::rstest;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    #[rstest]
+    #[case("localhost:80", "tcp", "localhost", None, 80)]
+    #[case(
+        "udp://127.0.0.1:8080",
+        "udp",
+        "127.0.0.1",
+        Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+        8080
+    )]
+    #[case(
+        "tcp://[2001:db8::8a2e:370:7334]:7171",
+        "tcp",
+        "2001:db8::8a2e:370:7334",
+        Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0x8a2e, 0x0370, 0x7334))),
+        7171
+    )]
+    #[case(
+        "https://[2001:0db8:0000:0000:0000:8a2e:0370:7334]:433",
+        "https",
+        "2001:0db8:0000:0000:0000:8a2e:0370:7334",
+        Some(IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0x8a2e, 0x0370, 0x7334))),
+        433
+    )]
+    #[case(
+        "ws://[::1]:2222",
+        "ws",
+        "::1",
+        Some(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1))),
+        2222
+    )]
+    fn target_addr_parsing(
+        #[case] repr: &str,
+        #[case] scheme: &str,
+        #[case] host: &str,
+        #[case] ip: Option<IpAddr>,
+        #[case] port: u16,
+    ) {
+        let addr = TargetAddr::parse(repr, None).unwrap();
+        assert_eq!(addr.scheme(), scheme);
+        assert_eq!(addr.host(), host);
+        assert_eq!(addr.host_ip(), ip);
+        assert_eq!(addr.port(), port);
+    }
+
+    #[rstest]
+    fn target_addr_with_default_port(
+        #[values("localhost", "127.0.0.1", "::1", "2001:db8::8a2e:370:7334")] host: &str,
+        #[values(None, Some(12))] port: Option<u16>,
+    ) {
+        let default_port = 8080;
+
+        let is_ipv6 = host.find(':').is_some();
+
+        let mut s = String::new();
+
+        if is_ipv6 {
+            write!(s, "[{host}]").unwrap();
+        } else {
+            write!(s, "{host}").unwrap();
+        }
+
+        if let Some(port) = port {
+            write!(s, ":{port}").unwrap();
+        }
+
+        let addr = TargetAddr::parse(&s, default_port).unwrap();
+
+        assert_eq!(addr.scheme(), "tcp");
+        assert_eq!(addr.host(), host);
+
+        if let Some(expected) = port {
+            assert_eq!(addr.port(), expected);
+        } else {
+            assert_eq!(addr.port(), default_port);
+        }
+    }
+
+    #[rstest]
+    fn target_addr_with_default_scheme(
+        #[values(None, Some("tcp"), Some("udp"))] scheme: Option<&str>,
+        #[values("tcp", "udp")] default_scheme: &str,
+    ) {
+        let mut s = String::new();
+
+        if let Some(scheme) = scheme {
+            write!(s, "{scheme}://").unwrap();
+        }
+
+        write!(s, "localhost:2222").unwrap();
+
+        let addr = TargetAddr::parse_with_default_scheme(&s, default_scheme, None).unwrap();
+
+        if let Some(expected) = scheme {
+            assert_eq!(addr.scheme(), expected);
+        } else {
+            assert_eq!(addr.scheme(), default_scheme);
+        }
+
+        assert_eq!(addr.host(), "localhost");
+        assert_eq!(addr.host_ip(), None);
+        assert_eq!(addr.port(), 2222);
     }
 }


### PR DESCRIPTION
Claims:
- `dst_hst`: destination address with optional scheme and port
- `dst_addl`: list of items as defined for `dst_hst`

Wildcards are supported similarly to [Wildcard certificates](https://en.wikipedia.org/wiki/Wildcard_certificate)