### PR TITLE
feat(jetsocat): `--timeout` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hwaddr"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,6 +1449,7 @@ dependencies = [
  "anyhow",
  "dirs-next",
  "futures-util",
+ "humantime",
  "jet-proto",
  "jmux-proxy",
  "proptest",

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -30,9 +30,10 @@ proxy_cfg = { version = "0.4.1", optional = true }
 
 # cli
 seahorse = "2.0.0"
+humantime = "2.1.0"
 
 # async
-tokio = { version = "1.17.0", features = ["io-std", "io-util", "net", "rt", "sync", "process", "rt-multi-thread", "macros"] }
+tokio = { version = "1.17.0", features = ["io-std", "io-util", "net", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
 tokio-tungstenite = "0.17.1"
 futures-util = "0.3.21"
 transport = { path = "../crates/transport" }

--- a/jetsocat/tests/socks5-to-jmux.rs
+++ b/jetsocat/tests/socks5-to-jmux.rs
@@ -168,6 +168,7 @@ async fn client_side_jmux(
         pipe_mode,
         proxy_cfg: None,
         listener_modes: vec![listener_mode],
+        timeout: None,
         jmux_cfg: jmux_proxy::JmuxConfig::client(),
     };
 
@@ -197,6 +198,7 @@ async fn server_side_jmux(port: u16, kind: TransportKind, logger: slog::Logger) 
         pipe_mode,
         proxy_cfg: None,
         listener_modes: Vec::new(),
+        timeout: None,
         jmux_cfg: JmuxConfig {
             filtering: filtering_rule,
         },


### PR DESCRIPTION
Used to define a timeout when opening pipes.

Issue: ARC-64