### PR TITLE
feat(dgw): `*` in JMUX token for "allow all" rule

### DIFF
--- a/devolutions-gateway/src/websocket_client.rs
+++ b/devolutions-gateway/src/websocket_client.rs
@@ -560,7 +560,12 @@ async fn handle_jmux(
                     .hosts
                     .into_iter()
                     .map(|addr| {
-                        FilteringRule::wildcard_host(addr.host().to_owned()).and(FilteringRule::port(addr.port()))
+                        if addr.host() == "*" {
+                            // Basically allow all
+                            FilteringRule::Allow
+                        } else {
+                            FilteringRule::wildcard_host(addr.host().to_owned()).and(FilteringRule::port(addr.port()))
+                        }
                     })
                     .collect(),
             ),


### PR DESCRIPTION
If any host is specified as `*`, the JMUX proxy should be in allow all mode.