### PR TITLE
feat(jetsocat): process watcher option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
+ "sysinfo",
  "test-utils",
  "tokio",
  "tokio-tungstenite",
@@ -3361,6 +3362,20 @@ dependencies = [
  "quote 1.0.15",
  "syn 1.0.86",
  "unicode-xid 0.2.2",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.23.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3977ec2e0520829be45c8a2df70db2bf364714d8a748316a10c3c35d4d2b01c9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -49,6 +49,9 @@ anyhow = "1.0.55"
 # location of special directories
 dirs-next = "2.0.0"
 
+# find parent process / watch process 
+sysinfo = { version = "0.23.13", default-features = false }
+
 [dev-dependencies]
 test-utils = { path = "../crates/test-utils" }
 tokio = { version = "1.17.0", features = ["time"] }

--- a/jetsocat/src/lib.rs
+++ b/jetsocat/src/lib.rs
@@ -15,7 +15,7 @@ pub struct ForwardCfg {
     pub pipe_a_mode: pipe::PipeMode,
     pub pipe_b_mode: pipe::PipeMode,
     pub repeat_count: usize,
-    pub timeout: Option<Duration>,
+    pub pipe_timeout: Option<Duration>,
     pub proxy_cfg: Option<proxy::ProxyConfig>,
 }
 
@@ -30,7 +30,7 @@ pub async fn forward(cfg: ForwardCfg, log: Logger) -> anyhow::Result<()> {
 
         let pipe_a_log = log.new(o!("open pipe" => "A"));
         let pipe_a = utils::timeout(
-            cfg.timeout,
+            cfg.pipe_timeout,
             open_pipe(cfg.pipe_a_mode.clone(), cfg.proxy_cfg.clone(), pipe_a_log),
         )
         .await
@@ -38,7 +38,7 @@ pub async fn forward(cfg: ForwardCfg, log: Logger) -> anyhow::Result<()> {
 
         let pipe_b_log = log.new(o!("open pipe" => "B"));
         let pipe_b = utils::timeout(
-            cfg.timeout,
+            cfg.pipe_timeout,
             open_pipe(cfg.pipe_b_mode.clone(), cfg.proxy_cfg.clone(), pipe_b_log),
         )
         .await
@@ -55,7 +55,7 @@ pub struct JmuxProxyCfg {
     pub pipe_mode: pipe::PipeMode,
     pub proxy_cfg: Option<proxy::ProxyConfig>,
     pub listener_modes: Vec<self::listener::ListenerMode>,
-    pub timeout: Option<Duration>,
+    pub pipe_timeout: Option<Duration>,
     pub jmux_cfg: JmuxConfig,
 }
 
@@ -108,7 +108,7 @@ pub async fn jmux_proxy(cfg: JmuxProxyCfg, log: Logger) -> anyhow::Result<()> {
 
     // Open generic pipe to exchange JMUX channel messages on
     let pipe_log = log.new(o!("open pipe" => "JMUX pipe"));
-    let pipe = utils::timeout(cfg.timeout, open_pipe(cfg.pipe_mode, cfg.proxy_cfg, pipe_log))
+    let pipe = utils::timeout(cfg.pipe_timeout, open_pipe(cfg.pipe_mode, cfg.proxy_cfg, pipe_log))
         .await
         .context("Couldn't open pipe")?;
 

--- a/jetsocat/src/listener.rs
+++ b/jetsocat/src/listener.rs
@@ -20,78 +20,60 @@ pub async fn tcp_listener_task(
     destination_url: String,
     log: Logger,
 ) -> anyhow::Result<()> {
-    use anyhow::Context as _;
-    use tokio::net::TcpListener;
-
     let destination_url = format!("tcp://{}", destination_url);
 
-    let listener = TcpListener::bind(&bind_addr)
-        .await
-        .with_context(|| format!("Couldn’t bind listener to {}", bind_addr))?;
+    let processor = |stream, log: Logger| {
+        let api_request_tx = api_request_tx.clone();
+        let destination_url = destination_url.clone();
 
-    info!(log, "Started listening on {}", bind_addr);
+        tokio::spawn(async move {
+            debug!(log, "Request {}", destination_url);
 
-    loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                let log = log.new(o!("addr" => addr));
-                let api_request_tx = api_request_tx.clone();
-                let destination_url = destination_url.clone();
+            let destination_url = match DestinationUrl::parse_str(&destination_url) {
+                Ok(url) => url,
+                Err(e) => {
+                    debug!(log, "Bad request: {}", e);
+                    return;
+                }
+            };
 
-                tokio::spawn(async move {
-                    debug!(log, "Request {}", destination_url);
+            let (sender, receiver) = oneshot::channel();
 
-                    let destination_url = match DestinationUrl::parse_str(&destination_url) {
-                        Ok(url) => url,
-                        Err(e) => {
-                            debug!(log, "Bad request: {}", e);
-                            return;
-                        }
-                    };
+            match api_request_tx
+                .send(JmuxApiRequest::OpenChannel {
+                    destination_url,
+                    api_response_tx: sender,
+                })
+                .await
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    warn!(log, "Couldn’t send JMUX API request: {}", e);
+                    return;
+                }
+            }
 
-                    let (sender, receiver) = oneshot::channel();
-
-                    match api_request_tx
-                        .send(JmuxApiRequest::OpenChannel {
-                            destination_url,
-                            api_response_tx: sender,
+            match receiver.await {
+                Ok(JmuxApiResponse::Success { id }) => {
+                    let _ = api_request_tx
+                        .send(JmuxApiRequest::Start {
+                            id,
+                            stream,
+                            leftover: None,
                         })
-                        .await
-                    {
-                        Ok(()) => {}
-                        Err(e) => {
-                            warn!(log, "Couldn’t send JMUX API request: {}", e);
-                            return;
-                        }
-                    }
-
-                    match receiver.await {
-                        Ok(JmuxApiResponse::Success { id }) => {
-                            let _ = api_request_tx
-                                .send(JmuxApiRequest::Start {
-                                    id,
-                                    stream,
-                                    leftover: None,
-                                })
-                                .await;
-                        }
-                        Ok(JmuxApiResponse::Failure { id, reason_code }) => {
-                            debug!(log, "Channel {} failure: {}", id, reason_code);
-                        }
-                        Err(e) => {
-                            debug!(log, "Couldn't receive API response: {}", e);
-                        }
-                    }
-                });
+                        .await;
+                }
+                Ok(JmuxApiResponse::Failure { id, reason_code }) => {
+                    debug!(log, "Channel {} failure: {}", id, reason_code);
+                }
+                Err(e) => {
+                    debug!(log, "Couldn't receive API response: {}", e);
+                }
             }
-            Err(e) => {
-                error!(log, "Couldn’t accept next TCP stream: {}", e);
-                break;
-            }
-        }
-    }
+        });
+    };
 
-    Ok(())
+    listener_task_impl(processor, bind_addr, log).await
 }
 
 pub async fn socks5_listener_task(
@@ -99,40 +81,22 @@ pub async fn socks5_listener_task(
     bind_addr: String,
     log: Logger,
 ) -> anyhow::Result<()> {
-    use anyhow::Context as _;
-    use tokio::net::TcpListener;
-
-    let listener = TcpListener::bind(&bind_addr)
-        .await
-        .with_context(|| format!("Couldn’t bind listener to {}", bind_addr))?;
-
-    info!(log, "Started listening on {}", bind_addr);
-
     let conf = Arc::new(Socks5AcceptorConfig {
         no_auth_required: true,
         users: None,
     });
 
-    loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                let api_request_sender = api_request_tx.clone();
-                let log = log.new(o!("addr" => addr));
-                let conf = Arc::clone(&conf);
-                tokio::spawn(async move {
-                    if let Err(e) = socks5_process_socket(api_request_sender, stream, conf, log.clone()).await {
-                        debug!(log, "SOCKS5 packet processing failed: {:?}", e);
-                    }
-                });
+    let processor = |stream, log: Logger| {
+        let api_request_tx = api_request_tx.clone();
+        let conf = Arc::clone(&conf);
+        tokio::spawn(async move {
+            if let Err(e) = socks5_process_socket(api_request_tx, stream, conf, log.clone()).await {
+                debug!(log, "SOCKS5 packet processing failed: {:#}", e);
             }
-            Err(e) => {
-                error!(log, "Couldn’t accept next TCP stream: {}", e);
-                break;
-            }
-        }
-    }
+        });
+    };
 
-    Ok(())
+    listener_task_impl(processor, bind_addr, log).await
 }
 
 async fn socks5_process_socket(
@@ -200,34 +164,16 @@ pub async fn https_listener_task(
     bind_addr: String,
     log: Logger,
 ) -> anyhow::Result<()> {
-    use anyhow::Context as _;
-    use tokio::net::TcpListener;
-
-    let listener = TcpListener::bind(&bind_addr)
-        .await
-        .with_context(|| format!("Couldn’t bind listener to {}", bind_addr))?;
-
-    info!(log, "Started listening on {}", bind_addr);
-
-    loop {
-        match listener.accept().await {
-            Ok((stream, addr)) => {
-                let api_request_sender = api_request_tx.clone();
-                let log = log.new(o!("addr" => addr));
-                tokio::spawn(async move {
-                    if let Err(e) = https_process_socket(api_request_sender, stream, log.clone()).await {
-                        debug!(log, "HTTPS proxy packet processing failed: {:?}", e);
-                    }
-                });
+    let processor = |stream, log: Logger| {
+        let api_request_tx = api_request_tx.clone();
+        tokio::spawn(async move {
+            if let Err(e) = https_process_socket(api_request_tx, stream, log.clone()).await {
+                debug!(log, "HTTPS proxy packet processing failed: {:?}", e);
             }
-            Err(e) => {
-                error!(log, "Couldn’t accept next TCP stream: {}", e);
-                break;
-            }
-        }
-    }
+        });
+    };
 
-    Ok(())
+    listener_task_impl(processor, bind_addr, log).await
 }
 
 async fn https_process_socket(
@@ -291,4 +237,33 @@ fn dest_addr_to_url(dest_addr: &proxy_types::DestAddr) -> DestinationUrl {
         }
         proxy_types::DestAddr::Domain(domain, port) => DestinationUrl::new("tcp", domain, *port),
     }
+}
+
+async fn listener_task_impl<F>(mut processor: F, bind_addr: String, log: Logger) -> anyhow::Result<()>
+where
+    F: FnMut(TcpStream, Logger),
+{
+    use anyhow::Context as _;
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind(&bind_addr)
+        .await
+        .with_context(|| format!("Couldn’t bind listener to {}", bind_addr))?;
+
+    info!(log, "Started listening on {}", bind_addr);
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, addr)) => {
+                let log = log.new(o!("addr" => addr));
+                processor(stream, log.clone());
+            }
+            Err(e) => {
+                error!(log, "Couldn’t accept next TCP stream: {}", e);
+                break;
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -141,7 +141,7 @@ pub fn forward_action(c: &Context) {
             pipe_a_mode: args.pipe_a_mode,
             pipe_b_mode: args.pipe_b_mode,
             repeat_count: args.repeat_count,
-            timeout: args.common.timeout,
+            pipe_timeout: args.common.pipe_timeout,
             proxy_cfg: args.common.proxy_cfg,
         };
 
@@ -200,7 +200,7 @@ pub fn jmux_proxy_action(c: &Context) {
             pipe_mode: args.pipe_mode,
             proxy_cfg: args.common.proxy_cfg,
             listener_modes: args.listener_modes,
-            timeout: args.common.timeout,
+            pipe_timeout: args.common.pipe_timeout,
             jmux_cfg: args.jmux_cfg,
         };
 
@@ -253,7 +253,7 @@ fn parse_env_variable_as_args(env_var_str: &str) -> Vec<String> {
 fn apply_common_flags(cmd: Command) -> Command {
     cmd.flag(Flag::new("log-file", FlagType::String).description("Specify filepath for log file"))
         .flag(Flag::new("log-term", FlagType::Bool).description("Print logs to stdout instead of log file"))
-        .flag(Flag::new("timeout", FlagType::String).description("Timeout when opening pipes"))
+        .flag(Flag::new("pipe-timeout", FlagType::String).description("Timeout when opening pipes"))
         .flag(Flag::new("no-proxy", FlagType::Bool).description("Disable any form of proxy auto-detection"))
         .flag(Flag::new("socks4", FlagType::String).description("Use specified address:port as SOCKS4 proxy"))
         .flag(Flag::new("socks5", FlagType::String).description("Use specified address:port as SOCKS5 proxy"))
@@ -268,7 +268,7 @@ enum Logging {
 struct CommonArgs {
     logging: Logging,
     proxy_cfg: Option<ProxyConfig>,
-    timeout: Option<core::time::Duration>,
+    pipe_timeout: Option<core::time::Duration>,
 }
 
 impl CommonArgs {
@@ -314,7 +314,7 @@ impl CommonArgs {
             detect_proxy()
         };
 
-        let timeout = if let Ok(timeout) = c.string_flag("timeout") {
+        let pipe_timeout = if let Ok(timeout) = c.string_flag("pipe-timeout") {
             let timeout = humantime::parse_duration(&timeout).context("Invalid value for timeout")?;
             Some(timeout)
         } else {
@@ -324,7 +324,7 @@ impl CommonArgs {
         Ok(Self {
             logging,
             proxy_cfg,
-            timeout,
+            pipe_timeout,
         })
     }
 }

--- a/jetsocat/src/process_watcher.rs
+++ b/jetsocat/src/process_watcher.rs
@@ -1,0 +1,15 @@
+use sysinfo::{Pid, ProcessRefreshKind, RefreshKind, System, SystemExt as _};
+use tokio::time::{sleep, Duration};
+
+pub async fn watch_process(pid: Pid) {
+    let mut system = System::new_with_specifics(RefreshKind::new());
+    let process_refresh_kind = ProcessRefreshKind::new();
+
+    loop {
+        if !system.refresh_process_specifics(pid, process_refresh_kind) {
+            return;
+        }
+
+        sleep(Duration::from_secs(60)).await;
+    }
+}

--- a/jetsocat/tests/socks5-to-jmux.rs
+++ b/jetsocat/tests/socks5-to-jmux.rs
@@ -169,6 +169,7 @@ async fn client_side_jmux(
         proxy_cfg: None,
         listener_modes: vec![listener_mode],
         pipe_timeout: None,
+        watch_process: None,
         jmux_cfg: jmux_proxy::JmuxConfig::client(),
     };
 
@@ -199,6 +200,7 @@ async fn server_side_jmux(port: u16, kind: TransportKind, logger: slog::Logger) 
         proxy_cfg: None,
         listener_modes: Vec::new(),
         pipe_timeout: None,
+        watch_process: None,
         jmux_cfg: JmuxConfig {
             filtering: filtering_rule,
         },

--- a/jetsocat/tests/socks5-to-jmux.rs
+++ b/jetsocat/tests/socks5-to-jmux.rs
@@ -168,7 +168,7 @@ async fn client_side_jmux(
         pipe_mode,
         proxy_cfg: None,
         listener_modes: vec![listener_mode],
-        timeout: None,
+        pipe_timeout: None,
         jmux_cfg: jmux_proxy::JmuxConfig::client(),
     };
 
@@ -198,7 +198,7 @@ async fn server_side_jmux(port: u16, kind: TransportKind, logger: slog::Logger) 
         pipe_mode,
         proxy_cfg: None,
         listener_modes: Vec::new(),
-        timeout: None,
+        pipe_timeout: None,
         jmux_cfg: JmuxConfig {
             filtering: filtering_rule,
         },


### PR DESCRIPTION
Add `--watch-parent` and `--watch-process` CLI options.
Jetsocat will close itself automatically when watched process is not running anymore.

Issue: ARC-68