### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,6 +13,17 @@ There are three seperate workflows:
 ## Making a Release
 
 - Ensure that the [VERSION](../../VERSION) number and [CHANGELOG](../../CHANGELOG.md) are up-to-date.
+
+Use the [Create New Release](create-new-release.yml) to run a full build and test, package the artifacts and release to GitHub, PSGallery and Docker Hub.
+
+##### Parameters
+
+- `ref` Optional SHA value of the commit to release.
+
+## Making a Release (manual)
+
+It's possible to run the individual workflows and generate a release manually.
+
 - Execute the [CI](#ci) workflow (either manually via the GitHub web UI or `gh`, or by creating or merging a pull request)
 
 :warning: *For releases, the CI workflow should be run from a commit on `master`. This ensures the binaries are built with the proper opimizations*
@@ -60,12 +71,16 @@ The following actions are taken:
 - Push the Devolutions Gateway PowerShell module to PSGallery
 - Generate a GitHub release
 
-If you run the release multiple times for the same version, the results might be unexpected:
-
-- The PowerShell module will not be re-uploaded. PSGallery does not support replacing an existing version. If you wish to replace the PowerShell module, you must increment the version number.
+Re-releasing the same version multiple times is not supported. The "Release" workflow checks for an existing GitHub release with the specified version and will not proceed if found.
 
 ##### Parameters
 
 - `run` The run-id of the [Package](#package) workflow run containing the artifacts to package
 - `dry-run` If selected, the workflow will only indicate the actions to be taken. No deployment will occur.
 
+### JETSOCAT NUGET
+
+A seperate workflow (Release jetsocat nuget package) is provided to generate the nuget package for jetsocat. It will retrieve the jetsocat binaries from the latest GitHub release, wrap them in a nuget package and deploy to Artifactory.
+##### Parameters
+
+- `version` The version for the nuget package. Note that this is distinct from the jetsocat binary version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,6 @@ on:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
   workflow_call:
-    outputs:
-      run-id:
-        description: "The workflow run id"
-        value: ${{ github.run_id }}
 
 env:
   conan-version: 1.43.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           echo "::set-output name=ref::$Ref"
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.get-commit.outputs.ref }}
 
@@ -106,7 +106,7 @@ jobs:
 
       steps:
         - name: Checkout ${{ github.repository }}
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
           with:
             ref: ${{ needs.preflight.outputs.ref }}
 
@@ -161,7 +161,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 
@@ -238,7 +238,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.preflight.outputs.ref }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
 
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
-        ref: ${{ steps.get-commit.outputs.ref }}
+        with:
+          ref: ${{ steps.get-commit.outputs.ref }}
 
       - name: Get version
         id: get-version
@@ -105,7 +106,8 @@ jobs:
       steps:
         - name: Checkout ${{ github.repository }}
           uses: actions/checkout@v2
-          ref: ${{ needs.preflight.outputs.ref }}
+          with:
+            ref: ${{ needs.preflight.outputs.ref }}
 
         - name: Configure rust toolchain
           run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
@@ -159,7 +161,8 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
-        ref: ${{ needs.preflight.outputs.ref }}
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Configure rust toolchain
         run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
@@ -235,7 +238,8 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
-        ref: ${{ needs.preflight.outputs.ref }}
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Load dynamic variables
         id: load-variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       rust-profile: ${{ steps.rust-profile.outputs.rust-profile }}
 
     steps:
+      ## The SHA to build might be passed via workflow_call, otherwise the current commit is used
       - name: Get commit
         id: get-commit
         shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
   workflow_call:
+    inputs:
+      ref:
+        description: "The commit SHA to build"
+        required: false
+        type: string
 
 env:
   conan-version: 1.43.4
@@ -18,13 +23,25 @@ jobs:
     name: preflight
     runs-on: ubuntu-18.04
     outputs:
+      ref: ${{ steps.get-commit.outputs.ref }}
       version: ${{ steps.get-version.outputs.version }}
       rust-channel: ${{ steps.rust-toolchain.outputs.rust-channel }}
       rust-profile: ${{ steps.rust-profile.outputs.rust-profile }}
 
     steps:
+      - name: Get commit
+        id: get-commit
+        shell: pwsh
+        run: |
+          $Ref = '${{ inputs.ref }}'
+          if (-Not $Ref) {
+            $Ref = '${{ github.sha }}'
+          }
+          echo "::set-output name=ref::$Ref"
+
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
+        ref: ${{ steps.get-commit.outputs.ref }}
 
       - name: Get version
         id: get-version
@@ -88,6 +105,7 @@ jobs:
       steps:
         - name: Checkout ${{ github.repository }}
           uses: actions/checkout@v2
+          ref: ${{ needs.preflight.outputs.ref }}
 
         - name: Configure rust toolchain
           run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
@@ -141,6 +159,7 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
+        ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Configure rust toolchain
         run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
@@ -216,6 +235,7 @@ jobs:
     steps:
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
+        ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Load dynamic variables
         id: load-variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
   workflow_dispatch:
+  workflow_call:
+    outputs:
+      run-id:
+        description: "The workflow run id"
+        value: ${{ github.run_id }}
 
 env:
   conan-version: 1.43.4

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -19,8 +19,12 @@ jobs:
     uses: ./.github/workflows/package.yml
     secrets: inherit
     needs: [ call-ci-workflow ]
+    with:
+      ref: ${{ github.event.inputs.ref }}
 
   call-release-workflow:
+    ## Only builds from master enable LTO
+    if: github.ref == 'refs/heads/master'
     uses: ./.github/workflows/release.yml
     secrets: inherit
     needs: [ call-package-workflow ]

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,0 +1,26 @@
+name: Create new release
+
+on:
+  workflow_dispatch:
+      dry-run:
+        description: 'If true, the workflow only indicates which artifacts would be uploaded'
+        required: true
+        type: boolean
+        default: 'true'
+
+jobs:
+  call-ci-workflow:
+    uses: Devolutions/devolutions-gateway/.github/workflows/ci.yml
+
+  job2:
+    runs-on: ubuntu-latest
+    needs: call-ci-workflow
+    steps:
+      - run: echo ${{ needs.call-ci-workflow.outputs.run-id }} 
+
+  # call-workflow-passing-data:
+  #   uses: octo-org/example-repo/.github/workflows/workflow-B.yml@main
+  #   with:
+  #     username: mona
+  #   secrets:
+  #     token: ${{ secrets.TOKEN }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-ci-workflow:
-    uses: .github/workflows/ci.yml
+    uses: ./.github/workflows/ci.yml
 
   job2:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -15,14 +15,14 @@ jobs:
     secrets: inherit
 
   call-package-workflow:
-    uses: ./.github/workflows/ci.yml
+    uses: ./.github/workflows/package.yml
     secrets: inherit
     needs: [ call-ci-workflow ]
     with:
       run: ${{ github.run_id }}
 
   call-release-workflow:
-    uses: ./.github/workflows/ci.yml
+    uses: ./.github/workflows/release.yml
     secrets: inherit
     needs: [ call-package-workflow ]
     with:

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -2,11 +2,11 @@ name: Create new release
 
 on:
   workflow_dispatch:
-      dry-run:
-        description: 'If true, the workflow only indicates which artifacts would be uploaded'
-        required: true
-        type: boolean
-        default: 'true'
+    dry-run:
+      description: 'If true, the workflow only indicates which artifacts would be uploaded'
+      required: true
+      type: boolean
+      default: 'true'
 
 jobs:
   call-ci-workflow:

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,6 +1,7 @@
 name: Create new release
 
 on:
+  push:
   workflow_dispatch:
     dry-run:
       description: 'If true, the workflow only indicates which artifacts would be uploaded'

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,18 +1,19 @@
-name: Create new release
+name: Create New Release
 
 on:
-  push:
   workflow_dispatch:
-    dry-run:
-      description: 'If true, the workflow only indicates which artifacts would be uploaded'
-      required: true
-      type: boolean
-      default: 'true'
+    inputs:
+      ref:
+        description: "The commit SHA to build"
+        required: false
+        type: string
 
 jobs:
   call-ci-workflow:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
+    with:
+      ref: ${{ github.event.inputs.ref }}
 
   call-package-workflow:
     uses: ./.github/workflows/package.yml

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -14,15 +14,16 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
-  job2:
-    runs-on: ubuntu-latest
-    needs: call-ci-workflow
-    steps:
-      - run: echo ${{ needs.call-ci-workflow.outputs.run-id }} 
+  call-package-workflow:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+    needs: [ call-ci-workflow ]
+    with:
+      run: ${{ github.run_id }}
 
-  # call-workflow-passing-data:
-  #   uses: octo-org/example-repo/.github/workflows/workflow-B.yml@main
-  #   with:
-  #     username: mona
-  #   secrets:
-  #     token: ${{ secrets.TOKEN }}
+  call-release-workflow:
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+    needs: [ call-package-workflow ]
+    with:
+      run: ${{ github.run_id }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,6 +1,7 @@
 name: Create New Release
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -1,7 +1,6 @@
 name: Create New Release
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   call-ci-workflow:
     uses: ./.github/workflows/ci.yml
+    secrets: inherit
 
   job2:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -18,12 +18,8 @@ jobs:
     uses: ./.github/workflows/package.yml
     secrets: inherit
     needs: [ call-ci-workflow ]
-    with:
-      run: ${{ github.run_id }}
 
   call-release-workflow:
     uses: ./.github/workflows/release.yml
     secrets: inherit
     needs: [ call-package-workflow ]
-    with:
-      run: ${{ github.run_id }}

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-ci-workflow:
-    uses: Devolutions/devolutions-gateway/.github/workflows/ci.yml
+    uses: .github/workflows/ci.yml
 
   job2:
     runs-on: ubuntu-latest

--- a/.github/workflows/jetsocat-nuget.yml
+++ b/.github/workflows/jetsocat-nuget.yml
@@ -1,7 +1,6 @@
-name: jetsocat nuget package
+name: Release jetsocat nuget package
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/jetsocat-nuget.yml
+++ b/.github/workflows/jetsocat-nuget.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   package:
-    runs-on: [self-hosted, Linux, X64, main]
+    runs-on: [ubuntu-latest]
     environment: artifactory-publish
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/jetsocat-nuget.yml
+++ b/.github/workflows/jetsocat-nuget.yml
@@ -1,0 +1,41 @@
+name: jetsocat nuget package
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (optional)'
+        required: false
+
+jobs:
+  package:
+    runs-on: [self-hosted, Linux, X64, main]
+    environment: artifactory-publish
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check out Devolutions/actions
+        uses: actions/checkout@v2
+        with:
+          repository: Devolutions/actions
+          ref: master
+          token: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+          path: ./.github/workflows
+
+      - name: create and publish
+        working-directory: ./jetsocat/nuget
+        shell: pwsh
+        run: |
+          $Version = '${{ github.event.inputs.version }}'
+          if ($Version) {
+            pwsh package.ps1 -AccessToken ${{ secrets.GITHUB_TOKEN }} -Version $Version
+          } else {
+            pwsh package.ps1 -AccessToken ${{ secrets.GITHUB_TOKEN }}
+          }
+
+      - name: Publish to Artifactory
+        uses: ./.github/workflows/nuget-publish-jfrog
+        with:
+          apikey: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          directory: /jetsocat/nuget

--- a/.github/workflows/jetsocat-nuget.yml
+++ b/.github/workflows/jetsocat-nuget.yml
@@ -1,6 +1,7 @@
 name: jetsocat nuget package
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/jetsocat-nuget.yml
+++ b/.github/workflows/jetsocat-nuget.yml
@@ -4,37 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number (optional)'
-        required: false
+        description: 'Version number'
+        required: true
 
 jobs:
   package:
     runs-on: [self-hosted, Linux, X64, main]
     environment: artifactory-publish
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Check out Devolutions/actions
-        uses: actions/checkout@v2
-        with:
-          repository: Devolutions/actions
-          ref: master
-          token: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-          path: ./.github/workflows
+      - uses: actions/checkout@v3
 
       - name: create and publish
         working-directory: ./jetsocat/nuget
         shell: pwsh
         run: |
           $Version = '${{ github.event.inputs.version }}'
-          if ($Version) {
-            pwsh package.ps1 -AccessToken ${{ secrets.GITHUB_TOKEN }} -Version $Version
-          } else {
-            pwsh package.ps1 -AccessToken ${{ secrets.GITHUB_TOKEN }}
-          }
+          pwsh package.ps1 -AccessToken ${{ secrets.GITHUB_TOKEN }} -Version $Version
 
       - name: Publish to Artifactory
-        uses: ./.github/workflows/nuget-publish-jfrog
+        uses: Devolutions/actions/nuget-publish-jfrog@master
         with:
           apikey: ${{ secrets.ARTIFACTORY_PASSWORD }}
           username: ${{ secrets.ARTIFACTORY_USERNAME }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -18,12 +18,16 @@ on:
         type: string
         required: false
         default: "workflow_call"
+      ref:
+        description: "The commit SHA to build"
+        required: false
+        type: string
 
 jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-18.04
-    outputs: 
+    outputs:
       run: ${{ steps.get-run.outputs.run }}
       commit: ${{ steps.get-commit.outputs.commit }}
       dl-strategy: ${{ steps.get-dl-strategy.outputs.dl-strategy }}
@@ -56,25 +60,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
           CI_RUN: ${{ steps.get-run.outputs.run }}
         run: |
-          $Run = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN | ConvertFrom-Json
-          if ($($Run.head_branch) -Ne "master") {
-            echo "::notice::specified run is not on master"
-          }
-
-          $ValidateDependency = $false
-          if ('${{ github.event.inputs.validate-dependency }}') {
-            $ValidateDependency = [System.Convert]::ToBoolean('${{ github.event.inputs.validate-dependency }}')
-          }
-
-          if ($ValidateDependency) {
-            if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
-              echo "::error::specified run is either not complete or not successful"
-              exit 1
+          $Ref = '${{ inputs.ref }}'
+          if (-Not $Ref) {
+            $Run = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN | ConvertFrom-Json
+            if ($($Run.head_branch) -Ne "master") {
+              echo "::notice::specified run is not on master"
             }
+
+            $ValidateDependency = $false
+            if ('${{ github.event.inputs.validate-dependency }}') {
+              $ValidateDependency = [System.Convert]::ToBoolean('${{ github.event.inputs.validate-dependency }}')
+            }
+
+            if ($ValidateDependency) {
+              if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
+                echo "::error::specified run is either not complete or not successful"
+                exit 1
+              }
+            }
+
+            $Ref = $($Run.head_sha)
           }
 
-          echo "::set-output name=commit::$($Run.head_sha)"
-          echo "::notice::Packaging artifacts built from commit $($Run.head_sha) in run ${{ steps.get-run.outputs.run }}"
+          echo "::set-output name=commit::$Ref"
+          echo "::notice::Packaging artifacts built from commit $Ref in run ${{ steps.get-run.outputs.run }}"
 
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,7 @@ on:
     inputs:
       run:
         required: true
+        type: string
 
 jobs:
   preflight:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,25 +12,32 @@ on:
         required: false
         default: true
   workflow_call:
-    inputs:
-      run:
-        required: true
-        type: string
 
 jobs:
   preflight:
     name: Preflight
     runs-on: ubuntu-18.04
     outputs: 
+      run: ${{ steps.get-run.outputs.run }}
       commit: ${{ steps.get-commit.outputs.commit }}
 
     steps:
+      - name: Get run
+        id: get-run
+        shell: pwsh
+        run: |
+          if ('${{ github.event.inputs.run }}') {
+            echo '::set-output name=run::${{ github.event.inputs.run }}'
+          } else {
+            echo '::set-output name=run::${{ github.sha }}'
+          }
+
       - name: Get commit
         id: get-commit
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-          CI_RUN: ${{ github.event.inputs.run }}
+          CI_RUN: ${{ steps.get-run.outputs.run }}
         run: |
           $Run = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN | ConvertFrom-Json
           if ($($Run.head_branch) -Ne "master") {
@@ -50,7 +57,7 @@ jobs:
           }
 
           echo "::set-output name=commit::$($Run.head_sha)"
-          echo "::notice::Packaging artifacts built from commit $($Run.head_sha) in run ${{ github.event.inputs.run }}"
+          echo "::notice::Packaging artifacts built from commit $($Run.head_sha) in run ${{ steps.get-run.outputs.run }}"
 
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v2
@@ -109,7 +116,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
           $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
-          gh run download ${{ github.event.inputs.run }} -n ${{ matrix.project }} -D "$Destination"
+          gh run download ${{ needs.preflight.outputs.run }} -n ${{ matrix.project }} -D "$Destination"
           if ('${{ matrix.project }}' -Eq 'jetsocat') {
             Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse 
           }

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,7 @@ jobs:
           if ('${{ github.event.inputs.run }}') {
             echo '::set-output name=run::${{ github.event.inputs.run }}'
           } else {
-            echo '::set-output name=run::${{ github.sha }}'
+            echo '::set-output name=run::${{ github.run_id }}'
           }
 
       - name: Get commit

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Manage artifacts
         shell: pwsh
         run: |
+          $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
           if ('${{ matrix.project }}' -Eq 'jetsocat') {
             Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse 
           }    

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,11 +6,19 @@ on:
       run:
         description: 'The CI workflow run to package'
         required: true
+      validate-dependency:
+        description: 'Validate that the CI workflow ran to completion'
+        required: false
+        default: true
   workflow_call:
     inputs:
       run:
         required: true
         type: string
+      validate-dependency:
+        description: 'Validate that the CI workflow ran to completion'
+        required: false
+        default: false
 
 jobs:
   preflight:
@@ -31,9 +39,12 @@ jobs:
           if ($($Run.head_branch) -Ne "master") {
             echo "::notice::specified run is not on master"
           }
-          if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
-            echo "::error::specified run is either not complete or not successful"
-            exit 1
+
+          if ([System.Convert]::ToBoolean('${{ github.event.inputs.validate-dependency }}')) {
+            if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
+              echo "::error::specified run is either not complete or not successful"
+              exit 1
+            }
           }
 
           echo "::set-output name=commit::$($Run.head_sha)"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,6 +6,10 @@ on:
       run:
         description: 'The CI workflow run to package'
         required: true
+  workflow_call:
+    inputs:
+      run:
+        required: true
 
 jobs:
   preflight:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,12 @@ on:
         required: false
         default: true
   workflow_call:
+    inputs:
+      dispatch:
+        description: "Marker to indicate that the workflow was dispatched via workflow_call"
+        type: string
+        required: false
+        default: "workflow_call"
 
 jobs:
   preflight:
@@ -20,8 +26,19 @@ jobs:
     outputs: 
       run: ${{ steps.get-run.outputs.run }}
       commit: ${{ steps.get-commit.outputs.commit }}
+      dl-strategy: ${{ steps.get-dl-strategy.outputs.dl-strategy }}
 
     steps:
+      - name: Get download strategy
+        id: get-dl-strategy
+        shell: pwsh
+        run: |
+          if ('${{ inputs.dispatch }}') {
+            echo '::set-output name=dl-strategy::action'
+          } else {
+            echo '::set-output name=dl-strategy::cli'
+          }
+
       - name: Get run
         id: get-run
         shell: pwsh
@@ -110,16 +127,28 @@ jobs:
         with:
           ref: ${{ needs.preflight.outputs.commit }}
 
-      - name: Download artifacts
+      - name: Download artifacts (action)
+        if: ${{ needs.preflight.outputs.dl-strategy }} = "action"
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ matrix.project }}
+          path: ${{ runner.temp }}/${{ matrix.project }}
+
+      - name: Download artifacts (cli)
+        if: ${{ needs.preflight.outputs.dl-strategy }} = "cli"
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
           $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
           gh run download ${{ needs.preflight.outputs.run }} -n ${{ matrix.project }} -D "$Destination"
+
+      - name: Manage artifacts
+        shell: pwsh
+        run: |
           if ('${{ matrix.project }}' -Eq 'jetsocat') {
             Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse 
-          }
+          }    
 
       - name: Configure certificates (Windows)
         if: matrix.os == 'windows'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,6 +33,8 @@ jobs:
       dl-strategy: ${{ steps.get-dl-strategy.outputs.dl-strategy }}
 
     steps:
+      ## workflow_dispatch: CI run artifacts are downloaded using `gh` (specifying the CI workflow run_id)
+      ## workflow_call:     CI run artifacts are downloaded using actions/download-artifact (using the current run_id)
       - name: Get download strategy
         id: get-dl-strategy
         shell: pwsh
@@ -43,6 +45,8 @@ jobs:
             echo '::set-output name=dl-strategy::cli'
           }
 
+      ## workflow_dispatch: The run_id is read from the inputs
+      ## workflow_call:     The run_id is the current run_id
       - name: Get run
         id: get-run
         shell: pwsh
@@ -53,6 +57,10 @@ jobs:
             echo '::set-output name=run::${{ github.run_id }}'
           }
 
+      ## To consistently repackage the CI artifacts, we must use the same commit that produced the artifacts
+      ##
+      ## workflow_dispatch: Lookup the SHA from the given run_id
+      ## workflow_call:     Use the input SHA; otherwise lookup the SHA from the current run_id
       - name: Get commit
         id: get-commit
         shell: pwsh
@@ -152,6 +160,8 @@ jobs:
           $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
           gh run download ${{ needs.preflight.outputs.run }} -n ${{ matrix.project }} -D "$Destination"
 
+      ## Delete the files that we won't operate on to prevent them being re-uploaded
+      ## This ensures consistency of the artifact since we are operating in a matrix
       - name: Manage artifacts
         shell: pwsh
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,11 +16,6 @@ on:
       run:
         required: true
         type: string
-      validate-dependency:
-        description: 'Validate that the CI workflow ran to completion'
-        type: boolean
-        required: false
-        default: false
 
 jobs:
   preflight:
@@ -42,7 +37,12 @@ jobs:
             echo "::notice::specified run is not on master"
           }
 
-          if ([System.Convert]::ToBoolean('${{ github.event.inputs.validate-dependency }}')) {
+          $ValidateDependency = $false
+          if ('${{ github.event.inputs.validate-dependency }}') {
+            $ValidateDependency = [System.Convert]::ToBoolean('${{ github.event.inputs.validate-dependency }}')
+          }
+
+          if ($ValidateDependency) {
             if (($($Run.status) -Ne "completed") -Or ($($Run.conclusion) -Ne "success")) {
               echo "::error::specified run is either not complete or not successful"
               exit 1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -128,14 +128,14 @@ jobs:
           ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Download artifacts (action)
-        if: ${{ needs.preflight.outputs.dl-strategy }} == "action"
+        if: needs.preflight.outputs.dl-strateg == 'action'
         uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.project }}
           path: ${{ runner.temp }}/${{ matrix.project }}
 
       - name: Download artifacts (cli)
-        if: ${{ needs.preflight.outputs.dl-strategy }} == "cli"
+        if: needs.preflight.outputs.dl-strategy == 'cli'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,7 +93,7 @@ jobs:
           name: docker
           path: package/**/Dockerfile
 
-      - name: Changelog artifacts
+      - name: Upload changelog artifacts
         uses: actions/upload-artifact@v2
         with:
           name: changelog
@@ -128,14 +128,14 @@ jobs:
           ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Download artifacts (action)
-        if: ${{ needs.preflight.outputs.dl-strategy }} = "action"
+        if: ${{ needs.preflight.outputs.dl-strategy }} == "action"
         uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.project }}
           path: ${{ runner.temp }}/${{ matrix.project }}
 
       - name: Download artifacts (cli)
-        if: ${{ needs.preflight.outputs.dl-strategy }} = "cli"
+        if: ${{ needs.preflight.outputs.dl-strategy }} == "cli"
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,7 @@ on:
         required: true
       validate-dependency:
         description: 'Validate that the CI workflow ran to completion'
+        type: boolean
         required: false
         default: true
   workflow_call:
@@ -17,6 +18,7 @@ on:
         type: string
       validate-dependency:
         description: 'Validate that the CI workflow ran to completion'
+        type: boolean
         required: false
         default: false
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -128,7 +128,7 @@ jobs:
           ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Download artifacts (action)
-        if: needs.preflight.outputs.dl-strateg == 'action'
+        if: needs.preflight.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.project }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,7 +94,7 @@ jobs:
           echo "::notice::Packaging artifacts built from commit $Ref in run ${{ steps.get-run.outputs.run }}"
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ steps.get-commit.outputs.commit }}
 
@@ -140,7 +140,7 @@ jobs:
 
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.preflight.outputs.commit }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
     inputs:
       run:
         required: true
+        type: string
 
 concurrency: gateway-release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check GitHub releases
         id: check-release
         shell: pwsh
-        run:
+        run: |
           $Output = (gh release list) | Out-String
           $Releases = ( $Output -split '\r?\n' ).Trim()
           $Versions = ForEach($Release in $Releases) {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n docker -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
 
+      - name: Manage artifacts
+        shell: pwsh
+        run: Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+
       - name: Prepare artifacts
         id: prepare-artifacts
         shell: pwsh
@@ -229,6 +233,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
 
+      - name: Manage artifacts
+        shell: pwsh
+        run: Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+
       - name: Create GitHub release
         shell: pwsh
         env:
@@ -276,6 +284,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
+
+      - name: Manage artifacts
+        shell: pwsh
+        run: Remove-Item (Join-Path PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
 
       - name: Publish PowerShell module
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,13 @@ jobs:
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u devolutionsbot --password-stdin
           $DockerPushCmd = 'docker push ${{ steps.build-container.outputs.image-name }}'
           Write-Host $DockerPushCmd
-          # if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
+
+          $DryRun = $false
+          if ('${{ github.event.inputs.dry-run }}') {
+            $DryRun = [System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')
+          }
+
+          # if (-Not $DryRun) {
           #   Invoke-Expression $DockerPushCmd
           # }
 
@@ -260,7 +266,13 @@ jobs:
 
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", $Env:GITHUB_REPOSITORY, "--notes-file", $ChangesPath, $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
-          # if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
+
+          $DryRun = $false
+          if ('${{ github.event.inputs.dry-run }}') {
+            $DryRun = [System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')
+          }
+
+          # if (-Not $DryRun) {
           #   Invoke-Expression $GhCmd
           # }
 
@@ -296,7 +308,13 @@ jobs:
           Expand-Archive -Path $Archive -DestinationPath 'PowerShell'
 
           $PublishCmd = @('Publish-Module', '-Force', '-Path', (Join-Path PowerShell DevolutionsGateway), '-NugetApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
-          if ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')) {
+
+          $DryRun = $false
+          if ('${{ github.event.inputs.dry-run }}') {
+            $DryRun = [System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')
+          }
+
+          if ($DryRun) {
             $PublishCmd += '-WhatIf'
           }
           $PublishCmd = $PublishCmd -Join ' '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,12 @@ on:
         type: boolean
         default: 'true'
   workflow_call:
+    inputs:
+      dispatch:
+        description: "Marker to indicate that the workflow was dispatched via workflow_call"
+        type: string
+        required: false
+        default: "workflow_call"
 
 concurrency: gateway-release
 
@@ -23,8 +29,19 @@ jobs:
       run: ${{ steps.get-run.outputs.run }}
       version: ${{ steps.get-version.outputs.version }}
       skip-publishing: ${{ steps.check-release.outputs.skip-publishing }}
+      dl-strategy: ${{ steps.get-dl-strategy.outputs.dl-strategy }}
 
     steps:
+      - name: Get download strategy
+        id: get-dl-strategy
+        shell: pwsh
+        run: |
+          if ('${{ inputs.dispatch }}') {
+            echo '::set-output name=dl-strategy::action'
+          } else {
+            echo '::set-output name=dl-strategy::cli'
+          }
+
       - name: Get run
         id: get-run
         shell: pwsh
@@ -32,16 +49,26 @@ jobs:
           if ('${{ github.event.inputs.run }}') {
             echo '::set-output name=run::${{ github.event.inputs.run }}'
           } else {
-            echo '::set-output name=run::${{ github.sha }}'
+            echo '::set-output name=run::${{ github.run_id }}'
           }
+
+      - name: Download version (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: version
+
+      - name: Download version (cli)
+        if: needs.preflight.outputs.dl-strategy == 'cli'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}    
+        run: gh run download ${{ steps.get-run.outputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
 
       - name: Get version
         id: get-version
         shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
-          gh run download ${{ steps.get-run.outputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
           $Version = Get-Content VERSION -TotalCount 1
           echo "::set-output name=version::$Version"
           echo "::notice::Releasing artifacts for version $Version from run ${{ steps.get-run.outputs.run }}"
@@ -72,7 +99,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: build-and-publish
     needs: [preflight]
-    if: ${{ needs.preflight.outputs.skip-publishing == 'false' }}
+    if: needs.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
     strategy:
       matrix:
         arch: [ x86_64 ]
@@ -93,7 +120,20 @@ jobs:
             base-image: nanoserver-1809
 
     steps:
-      - name: Download artifacts
+     - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: docker
+
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: devolutions-gateway
+
+      - name: Download artifacts (cli)
+        if: needs.preflight.outputs.dl-strategy == 'cli'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
@@ -153,13 +193,32 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: [preflight]
-    if: ${{ needs.preflight.outputs.skip-publishing == 'false' }}
+    if: needs.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
 
     steps:
       - name: Configure runner
         run: cargo install parse-changelog
 
-      - name: Download artifacts
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: jetsocat
+
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: devolutions-gateway
+
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: changelog
+
+      - name: Download artifacts (cli)
+        if: needs.preflight.outputs.dl-strategy == 'cli'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
@@ -197,10 +256,17 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: preflight
-    if: ${{ needs.preflight.outputs.skip-publishing == 'false' }}
+    if: eeds.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
 
     steps:
-      - name: Download artifacts
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: devolutions-gateway
+
+      - name: Download artifacts (cli)
+        if: needs.preflight.outputs.dl-strategy == 'cli'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,12 +125,14 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: docker
+          path: docker
 
       - name: Download artifacts (action)
         if: needs.preflight.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
           name: devolutions-gateway
+          path: devolutions-gateway
 
       - name: Download artifacts (cli)
         if: needs.preflight.outputs.dl-strategy == 'cli'
@@ -204,18 +206,21 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: jetsocat
+          path: jetsocat
 
       - name: Download artifacts (action)
         if: needs.preflight.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
           name: devolutions-gateway
+          path: devolutions-gateway
 
       - name: Download artifacts (action)
         if: needs.preflight.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
           name: changelog
+          path: changelog
 
       - name: Download artifacts (cli)
         if: needs.preflight.outputs.dl-strategy == 'cli'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,13 +53,13 @@ jobs:
           }
 
       - name: Download version (action)
-        if: needs.preflight.outputs.dl-strategy == 'action'
+        if: steps.get-dl-strategy.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
           name: version
 
       - name: Download version (cli)
-        if: needs.preflight.outputs.dl-strategy == 'cli'
+        if: steps.get-dl-strategy.outputs.dl-strategy == 'cli'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
-          $Output = (gh release list) | Out-String
+          $Output = (gh release list --repo $Env:GITHUB_REPOSITORY) | Out-String
           $Releases = ( $Output -split '\r?\n' ).Trim()
           $Versions = ForEach($Release in $Releases) {
               $Version = ( $Release -Split '\s+' ).Trim()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Check GitHub releases
         id: check-release
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
           $Output = (gh release list) | Out-String
           $Releases = ( $Output -split '\r?\n' ).Trim()
@@ -58,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: build-and-publish
     needs: [preflight]
-    if: ${{ always() && (needs.preflight.outputs.skip-publishing == 'false') }}
+    if: ${{ needs.preflight.outputs.skip-publishing == 'false' }}
     strategy:
       matrix:
         arch: [ x86_64 ]
@@ -139,7 +141,7 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: [preflight]
-    if: ${{ always() && (needs.preflight.outputs.skip-publishing == 'false') }}
+    if: ${{ needs.preflight.outputs.skip-publishing == 'false' }}
 
     steps:
       - name: Configure runner
@@ -183,7 +185,7 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: preflight
-    if: ${{ always() && (needs.preflight.outputs.skip-publishing == 'false') }}
+    if: ${{ needs.preflight.outputs.skip-publishing == 'false' }}
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,10 @@ jobs:
           }
 
           $SkipPublishing = 'false'
-          if ($Versions -Contains "${{ steps.get-version.outputs.version }}") {
-            echo "::warning::GitHub already has a release version ${{ steps.get-version.outputs.version }}; publishing will be skipped"
-            $SkipPublishing = 'true'
-          }
+          # if ($Versions -Contains "${{ steps.get-version.outputs.version }}") {
+          #   echo "::warning::GitHub already has a release version ${{ steps.get-version.outputs.version }}; publishing will be skipped"
+          #   $SkipPublishing = 'true'
+          # }
           echo "::set-output name=skip-publishing::$SkipPublishing"
 
   containers:
@@ -120,7 +120,7 @@ jobs:
             base-image: nanoserver-1809
 
     steps:
-     - name: Download artifacts (action)
+      - name: Download artifacts (action)
         if: needs.preflight.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
@@ -184,9 +184,9 @@ jobs:
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u devolutionsbot --password-stdin
           $DockerPushCmd = 'docker push ${{ steps.build-container.outputs.image-name }}'
           Write-Host $DockerPushCmd
-          if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
-            Invoke-Expression $DockerPushCmd
-          }
+          # if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
+          #   Invoke-Expression $DockerPushCmd
+          # }
 
   github-release:
     name: GitHub release
@@ -247,9 +247,9 @@ jobs:
 
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", $Env:GITHUB_REPOSITORY, "--notes-file", $ChangesPath, $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
-          if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
-            Invoke-Expression $GhCmd
-          }
+          # if (-Not ([System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}'))) {
+          #   Invoke-Expression $GhCmd
+          # }
 
   psgallery-release:
     name: PowerShell release
@@ -286,7 +286,7 @@ jobs:
           Write-Host $PublishCmd
 
           try {
-            Invoke-Expression $PublishCmd
+            # Invoke-Expression $PublishCmd
           }
           catch {
             if ($_.Exception.Message -ilike "*cannot be published as the current version*is already available in the repository*") {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: boolean
         default: 'true'
+  workflow_call:
+    inputs:
+      run:
+        required: true
 
 concurrency: gateway-release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-18.04
     outputs:
       version: ${{ steps.get-version.outputs.version }}
+      skip-publishing: ${{ steps.check-release.outputs.skip-publishing }}
 
     steps:
       - name: Get version
@@ -31,13 +32,33 @@ jobs:
           gh run download ${{ github.event.inputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
           $Version = Get-Content VERSION -TotalCount 1
           echo "::set-output name=version::$Version"
-          echo "::notice::Releasing artifacts for version ${{ steps.get-version.outputs.version }} from run ${{ github.event.inputs.run }}"
+          echo "::notice::Releasing artifacts for version $Version from run ${{ github.event.inputs.run }}"
+
+      - name: Check GitHub releases
+        id: check-release
+        shell: pwsh
+        run:
+          $Output = & gh release list
+          $Releases = ( $Output -split '\r?\n' ).Trim()
+          $Versions = ForEach($Release in $Releases) {
+              $Version = ( $Release -Split '\s+' ).Trim()
+              $Version = $Version.TrimStart("v")
+              $Version[0]
+          }
+
+          $SkipPublishing = 'false'
+          if ($Versions -Contains "${{ steps.get-version.outputs.version }}") {
+            echo "::warning::GitHub already has a release version ${{ steps.get-version.outputs.version }}; publishing will be skipped"
+            $SkipPublishing = 'true'
+          }
+          echo "::set-output name=skip-publishing::$SkipPublishing"
 
   containers:
     name: Containers [${{ matrix.os }} ${{ matrix.base-image }}]
     runs-on: ${{ matrix.runner }}
     environment: build-and-publish
     needs: [preflight]
+    if: ${{ always() && (needs.preflight.outputs.skip-publishing == 'false') }}
     strategy:
       matrix:
         arch: [ x86_64 ]
@@ -118,6 +139,7 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: [preflight]
+    if: ${{ always() && (needs.preflight.outputs.skip-publishing == 'false') }}
 
     steps:
       - name: Configure runner
@@ -161,6 +183,7 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: preflight
+    if: ${{ always() && (needs.preflight.outputs.skip-publishing == 'false') }}
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
       dl-strategy: ${{ steps.get-dl-strategy.outputs.dl-strategy }}
 
     steps:
+      ## workflow_dispatch: CI run artifacts are downloaded using `gh` (specifying the CI workflow run_id)
+      ## workflow_call:     CI run artifacts are downloaded using actions/download-artifact (using the current run_id)
       - name: Get download strategy
         id: get-dl-strategy
         shell: pwsh
@@ -42,6 +44,8 @@ jobs:
             echo '::set-output name=dl-strategy::cli'
           }
 
+      ## workflow_dispatch: The run_id is read from the inputs
+      ## workflow_call:     The run_id is the current run_id
       - name: Get run
         id: get-run
         shell: pwsh
@@ -73,6 +77,7 @@ jobs:
           echo "::set-output name=version::$Version"
           echo "::notice::Releasing artifacts for version $Version from run ${{ steps.get-run.outputs.run }}"
 
+      ## If we already released this version to GitHub, publishing will be skipped
       - name: Check GitHub releases
         id: check-release
         shell: pwsh
@@ -88,10 +93,10 @@ jobs:
           }
 
           $SkipPublishing = 'false'
-          # if ($Versions -Contains "${{ steps.get-version.outputs.version }}") {
-          #   echo "::warning::GitHub already has a release version ${{ steps.get-version.outputs.version }}; publishing will be skipped"
-          #   $SkipPublishing = 'true'
-          # }
+          if ($Versions -Contains "${{ steps.get-version.outputs.version }}") {
+            echo "::warning::GitHub already has a release version ${{ steps.get-version.outputs.version }}; publishing will be skipped"
+            $SkipPublishing = 'true'
+          }
           echo "::set-output name=skip-publishing::$SkipPublishing"
 
   containers:
@@ -141,6 +146,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n docker -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
 
+      ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
         shell: pwsh
         run: Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
@@ -196,9 +202,9 @@ jobs:
             $DryRun = [System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')
           }
 
-          # if (-Not $DryRun) {
-          #   Invoke-Expression $DockerPushCmd
-          # }
+          if (-Not $DryRun) {
+            Invoke-Expression $DockerPushCmd
+          }
 
   github-release:
     name: GitHub release
@@ -239,6 +245,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
 
+      ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
         shell: pwsh
         run: Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
@@ -272,9 +279,9 @@ jobs:
             $DryRun = [System.Convert]::ToBoolean('${{ github.event.inputs.dry-run }}')
           }
 
-          # if (-Not $DryRun) {
-          #   Invoke-Expression $GhCmd
-          # }
+          if (-Not $DryRun) {
+            Invoke-Expression $GhCmd
+          }
 
   psgallery-release:
     name: PowerShell release
@@ -297,6 +304,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
 
+      ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
         shell: pwsh
         run: Remove-Item (Join-Path PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
@@ -321,7 +329,7 @@ jobs:
           Write-Host $PublishCmd
 
           try {
-            # Invoke-Expression $PublishCmd
+            Invoke-Expression $PublishCmd
           }
           catch {
             if ($_.Exception.Message -ilike "*cannot be published as the current version*is already available in the repository*") {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,6 @@ on:
         type: boolean
         default: 'true'
   workflow_call:
-    inputs:
-      run:
-        required: true
-        type: string
 
 concurrency: gateway-release
 
@@ -24,20 +20,31 @@ jobs:
     name: Preflight
     runs-on: ubuntu-18.04
     outputs:
+      run: ${{ steps.get-run.outputs.run }}
       version: ${{ steps.get-version.outputs.version }}
       skip-publishing: ${{ steps.check-release.outputs.skip-publishing }}
 
     steps:
+      - name: Get run
+        id: get-run
+        shell: pwsh
+        run: |
+          if ('${{ github.event.inputs.run }}') {
+            echo '::set-output name=run::${{ github.event.inputs.run }}'
+          } else {
+            echo '::set-output name=run::${{ github.sha }}'
+          }
+
       - name: Get version
         id: get-version
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
         run: |
-          gh run download ${{ github.event.inputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
+          gh run download ${{ steps.get-run.outputs.run }} -n version --repo $Env:GITHUB_REPOSITORY
           $Version = Get-Content VERSION -TotalCount 1
           echo "::set-output name=version::$Version"
-          echo "::notice::Releasing artifacts for version $Version from run ${{ github.event.inputs.run }}"
+          echo "::notice::Releasing artifacts for version $Version from run ${{ steps.get-run.outputs.run }}"
 
       - name: Check GitHub releases
         id: check-release
@@ -90,7 +97,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n docker -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n docker -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
 
       - name: Prepare artifacts
         id: prepare-artifacts
@@ -156,7 +163,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
 
       - name: Create GitHub release
         shell: pwsh
@@ -197,7 +204,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
-        run: gh run download ${{ github.event.inputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
 
       - name: Publish PowerShell module
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,7 +256,7 @@ jobs:
     runs-on: ubuntu-18.04
     environment: build-and-publish
     needs: preflight
-    if: eeds.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
+    if: needs.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
 
     steps:
       - name: Download artifacts (action)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         id: check-release
         shell: pwsh
         run:
-          $Output = & gh release list
+          $Output = (gh release list) | Out-String
           $Releases = ( $Output -split '\r?\n' ).Trim()
           $Versions = ForEach($Release in $Releases) {
               $Version = ( $Release -Split '\s+' ).Trim()

--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ Using FreeRDP, token can be provided using `/pcb` argument with `xfreerdp`.
 Unfortunately, Microsoft Windows 7/8/8.1/Server 2008/Server 2012 machines
 cannot accept connections from [rustls](https://crates.io/crates/rustls)
 client. Support for required cipher suits was not implemented until Windows 10.
+
+## Continuous Integration and Delivery
+
+See the dedicated [README](.github/workflows//README.md) in the workflows directory.

--- a/jetsocat/nuget/.gitignore
+++ b/jetsocat/nuget/.gitignore
@@ -1,0 +1,2 @@
+*.nupkg
+bin

--- a/jetsocat/nuget/Devolutions.Jetsocat.nuspec
+++ b/jetsocat/nuget/Devolutions.Jetsocat.nuspec
@@ -1,0 +1,14 @@
+<package>
+  <metadata>
+    <id>Devolutions.Jetsocat</id>
+    <version>1.0.0</version>
+    <authors>Richard Markiewicz</authors>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Websocket toolkit for jet protocol related operations</description>
+    <dependencies />
+  </metadata>
+  <files>
+    <file src="bin/x64/jetsocat.exe" target="runtimes/win-x64/native" />
+    <file src="Devolutions.Jetsocat.targets" target="build" />
+  </files>
+</package>

--- a/jetsocat/nuget/Devolutions.Jetsocat.targets
+++ b/jetsocat/nuget/Devolutions.Jetsocat.targets
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/jetsocat.exe">
+            <Link>runtimes\win-x64\native\%(Filename)%(Extension)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+</Project>

--- a/jetsocat/nuget/package.ps1
+++ b/jetsocat/nuget/package.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = "Stop"
+
+function Package-Jetsocat {
+    Param(
+        [Parameter(Mandatory=$True)]
+        [string]$AccessToken,
+
+        [Parameter(Mandatory=$True)]
+        [string]$Version
+    )
+
+    New-Item -ItemType Directory -Force -Path "bin"
+
+    $Org = "Devolutions"
+    $Repo = "devolutions-gateway" # public repo, no API key needed
+    $Architectures = ( "x86_64" )
+
+    $Release = Invoke-WebRequest https://api.github.com/repos/$Org/$Repo/releases/latest -Headers @{ 
+        "accept" = "application/json" 
+        "authorization" = "Bearer $AccessToken"
+    }
+    $ReleaseJson = $Release.Content | ConvertFrom-Json
+    $JetsocatVersion = $ReleaseJson.tag_name
+
+    foreach ($Architecture in $Architectures) {
+        $ArchDir = $Architecture
+
+        if ($Architecture -eq "x86_64") {
+            $ArchDir = "x64"
+        }
+
+        $DestPath = Join-Path -Path "bin" -ChildPath $ArchDir
+        New-Item -ItemType Directory -Force -Path $DestPath
+        $Asset = $ReleaseJson.assets | Where-Object name -Match "jetsocat_windows_.*_${Architecture}.exe"
+
+        Invoke-WebRequest $Asset.url -Headers @{ 
+            "accept" = "application/octet-stream" 
+            "authorization" = "Bearer $AccessToken"
+        } -OutFile (Join-Path -Path $DestPath -ChildPath "jetsocat.exe")
+    }
+
+    $Nuspec = (Resolve-Path "Devolutions.Jetsocat.nuspec")
+    $Xml = [xml] (Get-Content $Nuspec)
+    Select-Xml -xml $Xml -XPath //package/metadata/version | % { $_.Node.'#text' = "$Version" }
+    Select-Xml -xml $Xml -XPath //package/metadata/description | % { $_.Node.'#text' = "Websocket toolkit for jet protocol related operations (jetsocat $JetsocatVersion)" }
+    $Xml.Save($Nuspec)
+
+    nuget pack Devolutions.Jetsocat.nuspec -NonInteractive
+}
+
+Package-Jetsocat @args


### PR DESCRIPTION
Workup improvements to build and release workflows.

- The "Release" workflow now checks if this version has already been released (on GitHub) and will fail-fast. GitHub releases are not idempotent, so in this case it's necessary to increment the version (👍) or delete the existing release (👎) and try again.
- Migrate the jetsocat nuget workflow from conan-nuget repository. This must be run separately since it's necessary to specify the nuget package version using workflow_dispatch. GH is currently not starting the workflow, so this is untested but we should be able to easily resolve any issues once they transpire.
- Add a new "Generate New Release" workflow which calls each individual workflow (CI, Package, Release) and runs the whole release process from start-to-finish. 
- Add some explanatory comments, update the README.