### PR TITLE
fix(dgw): Content-Type header present twice for Json responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,7 +3003,7 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 [[package]]
 name = "saphir"
 version = "2.8.2"
-source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#dff5d11a57b7ae93e3004fccef6dc85a31753d12"
+source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#7d5e0991281805d51a23ccbdd5568b254877c5e2"
 dependencies = [
  "brotli",
  "chrono",
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "saphir_macro"
 version = "2.1.1"
-source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#dff5d11a57b7ae93e3004fccef6dc85a31753d12"
+source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#7d5e0991281805d51a23ccbdd5568b254877c5e2"
 dependencies = [
  "http",
  "proc-macro2 1.0.43",


### PR DESCRIPTION
This is bad.

Indeed, `Content-Type` is a "singleton field": a single member is anticipated as the field value.

RFC9110 says:

> Although Content-Type is defined as a singleton field,
> it is sometimes incorrectly generated multiple times,
> resulting in a combined field value that appears to be a list.
> Recipients often attempt to handle this error by using
> the last syntactically valid member of the list, leading to
> potential interoperability and security issues if different
> implementations have different error handling behaviors.

This was a bug in Saphir. I fixed it and updated the reference in Cargo.lock.