### PR TITLE
fix(ts-angular-client): fix npm package

### DIFF
--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -139,6 +139,9 @@ jobs:
       - npm-build
 
     steps:
+      - name: Check out ${{ github.repository }}
+        uses: actions/checkout@v3
+
       - name: Download NPM packages artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -53,6 +53,7 @@ jobs:
 
           $Path = './devolutions-gateway/openapi/${{matrix.library}}'
           & "$Path/build.ps1"
+
           New-Item -ItemType "directory" -Path . -Name "nuget-packages"
           Get-ChildItem -Path $Path -Recurse *.nupkg | ForEach { Copy-Item $_ "./nuget-packages" }
 
@@ -63,7 +64,7 @@ jobs:
           path: nuget-packages/*.nupkg
 
   npm-build:
-    name: NPM build
+    name: NPM package build
     runs-on: ubuntu-20.04
 
     steps:
@@ -78,6 +79,15 @@ jobs:
           $Path = './devolutions-gateway/openapi/ts-angular-client'
           & "$Path/build.ps1"
 
+          New-Item -ItemType "directory" -Path . -Name "npm-packages"
+          Get-ChildItem -Path $Path -Recurse *.tgz | ForEach { Copy-Item $_ "./npm-packages" }
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: npm
+          path: npm-packages/*.tgz
+
   nuget-publish:
     name: Publish NuGet packages
     runs-on: ubuntu-20.04
@@ -88,7 +98,7 @@ jobs:
       - nuget-build
 
     steps:
-      - name: Download NuGet package artifact
+      - name: Download NuGet packages artifact
         uses: actions/download-artifact@v3
         with:
           name: nupkg
@@ -129,8 +139,11 @@ jobs:
       - npm-build
 
     steps:
-      - name: Check out ${{ github.repository }}
-        uses: actions/checkout@v3
+      - name: Download NPM packages artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: npm
+          path: npm-packages
       
       - name: Configure NPM
         shell: pwsh
@@ -140,4 +153,10 @@ jobs:
         shell: pwsh
         run: |
           Set-PSDebug -Trace 1
-          ./ci/npm-publish.ps1 -Path './devolutions-gateway/openapi/ts-angular-client' -Access 'public'
+
+          $Files = Get-ChildItem -Recurse npm-packages/*.tgz
+
+          foreach ($File in $Files) {
+            Write-Host "Publishing $($File.Name)..."
+            ./ci/npm-publish.ps1 -Tarball "$File" -Access 'public'
+          }

--- a/devolutions-gateway/openapi/ts-angular-client/README.md
+++ b/devolutions-gateway/openapi/ts-angular-client/README.md
@@ -1,4 +1,4 @@
-## @devolutions/gateway-client@0.2.0
+## @devolutions/gateway-client@0.2.1
 
 ### Building
 
@@ -19,7 +19,7 @@ Navigate to the folder of your consuming project and run one of next commands.
 _published:_
 
 ```
-npm install @devolutions/gateway-client@0.2.0 --save
+npm install @devolutions/gateway-client@0.2.1 --save
 ```
 
 _without publishing (not recommended):_

--- a/devolutions-gateway/openapi/ts-angular-client/build.ps1
+++ b/devolutions-gateway/openapi/ts-angular-client/build.ps1
@@ -4,7 +4,16 @@ $ErrorActionPreference = "Stop"
 
 Push-Location -Path $PSScriptRoot
 
-npm install
-npm run build
+try
+{
+	npm install
 
-Pop-Location
+	npm run build
+
+	Set-Location -Path ./dist/
+	npm pack
+}
+finally
+{
+	Pop-Location
+}

--- a/devolutions-gateway/openapi/ts-angular-client/config.json
+++ b/devolutions-gateway/openapi/ts-angular-client/config.json
@@ -1,6 +1,6 @@
 {
   "npmName": "@devolutions/gateway-client",
-  "npmVersion": "0.2.0",
+  "npmVersion": "0.2.1",
   "license": "MIT OR Apache-2.0",
 
   "gitHost": "github.com",

--- a/devolutions-gateway/openapi/ts-angular-client/package.json
+++ b/devolutions-gateway/openapi/ts-angular-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devolutions/gateway-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "OpenAPI client for @devolutions/gateway-client",
   "author": "OpenAPI-Generator Contributors",
   "repository": {


### PR DESCRIPTION
Actually mostly a CI fix.

In fact, the TypeScript package must be built and then the resulting artifacts used when publishing.

Roughly:
- `npm run build`
- `cd ./dist/`
- `npm publish`