### PR TITLE
feat(dgw): add timestamp to subscriber messages

### DIFF
--- a/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Models/SubscriberMessage.cs
+++ b/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Models/SubscriberMessage.cs
@@ -21,7 +21,7 @@ using Devolutions.Gateway.Subscriber.Converters;
 namespace Devolutions.Gateway.Subscriber.Models
 { 
     /// <summary>
-    /// 
+    /// Message produced on various Gateway events
     /// </summary>
     [DataContract]
     public class SubscriberMessage : IEquatable<SubscriberMessage>
@@ -46,6 +46,14 @@ namespace Devolutions.Gateway.Subscriber.Models
         public List<SubscriberSessionInfo> SessionList { get; set; }
 
         /// <summary>
+        /// Date and time this message was produced
+        /// </summary>
+        /// <value>Date and time this message was produced</value>
+        [Required]
+        [DataMember(Name="timestamp", EmitDefaultValue=false)]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
         /// Returns the string presentation of the object
         /// </summary>
         /// <returns>String presentation of the object</returns>
@@ -56,6 +64,7 @@ namespace Devolutions.Gateway.Subscriber.Models
             sb.Append("  Kind: ").Append(Kind).Append("\n");
             sb.Append("  Session: ").Append(Session).Append("\n");
             sb.Append("  SessionList: ").Append(SessionList).Append("\n");
+            sb.Append("  Timestamp: ").Append(Timestamp).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
         }
@@ -107,6 +116,11 @@ namespace Devolutions.Gateway.Subscriber.Models
                     SessionList != null &&
                     other.SessionList != null &&
                     SessionList.SequenceEqual(other.SessionList)
+                ) && 
+                (
+                    Timestamp == other.Timestamp ||
+                    Timestamp != null &&
+                    Timestamp.Equals(other.Timestamp)
                 );
         }
 
@@ -126,6 +140,8 @@ namespace Devolutions.Gateway.Subscriber.Models
                     hashCode = hashCode * 59 + Session.GetHashCode();
                     if (SessionList != null)
                     hashCode = hashCode * 59 + SessionList.GetHashCode();
+                    if (Timestamp != null)
+                    hashCode = hashCode * 59 + Timestamp.GetHashCode();
                 return hashCode;
             }
         }

--- a/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Models/SubscriberMessageKind.cs
+++ b/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Models/SubscriberMessageKind.cs
@@ -21,8 +21,9 @@ using Devolutions.Gateway.Subscriber.Converters;
 namespace Devolutions.Gateway.Subscriber.Models
 { 
         /// <summary>
-        /// Gets or Sets SubscriberMessageKind
+        /// Event type for messages
         /// </summary>
+        /// <value>Event type for messages</value>
         [TypeConverter(typeof(CustomEnumConverter<SubscriberMessageKind>))]
         [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public enum SubscriberMessageKind

--- a/devolutions-gateway/openapi/subscriber-api.yaml
+++ b/devolutions-gateway/openapi/subscriber-api.yaml
@@ -43,8 +43,10 @@ components:
   schemas:
     SubscriberMessage:
       type: object
+      description: Message produced on various Gateway events
       required:
       - kind
+      - timestamp
       properties:
         kind:
           $ref: '#/components/schemas/SubscriberMessageKind'
@@ -54,8 +56,13 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SubscriberSessionInfo'
+        timestamp:
+          type: string
+          format: date-time
+          description: Date and time this message was produced
     SubscriberMessageKind:
       type: string
+      description: Event type for messages
       enum:
       - session.started
       - session.ended

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -95,12 +95,10 @@ pub fn add_session_in_progress(tx: &subscriber::SubscriberSender, session: Gatew
 
     SESSIONS_IN_PROGRESS.write().insert(association_id, session);
 
-    let message = subscriber::SubscriberMessage::SessionStarted {
-        session: subscriber::SubscriberSessionInfo {
-            association_id,
-            start_timestamp,
-        },
-    };
+    let message = subscriber::Message::session_started(subscriber::SubscriberSessionInfo {
+        association_id,
+        start_timestamp,
+    });
 
     if let Err(error) = tx.try_send(message) {
         warn!(%error, "Failed to send subscriber message");
@@ -112,12 +110,10 @@ pub fn remove_session_in_progress(tx: &subscriber::SubscriberSender, id: Uuid) {
     let terminated_session = SESSIONS_IN_PROGRESS.write().remove(&id);
 
     if let Some(session) = terminated_session {
-        let message = subscriber::SubscriberMessage::SessionEnded {
-            session: subscriber::SubscriberSessionInfo {
-                association_id: id,
-                start_timestamp: session.start_timestamp,
-            },
-        };
+        let message = subscriber::Message::session_ended(subscriber::SubscriberSessionInfo {
+            association_id: id,
+            start_timestamp: session.start_timestamp,
+        });
 
         if let Err(error) = tx.try_send(message) {
             warn!(%error, "Failed to send subscriber message");

--- a/devolutions-gateway/src/openapi.rs
+++ b/devolutions-gateway/src/openapi.rs
@@ -101,22 +101,34 @@ struct SubscriberSessionInfo {
     start_timestamp: DateTime<Utc>,
 }
 
+/// Event type for messages
 #[allow(unused)]
 #[derive(utoipa::ToSchema, Serialize)]
 enum SubscriberMessageKind {
+    /// A new session started
     #[serde(rename = "session.started")]
     SessionStarted,
+    /// A session terminated
     #[serde(rename = "session.ended")]
     SessionEnded,
+    /// Periodic running session listing
     #[serde(rename = "session.list")]
     SessionList,
 }
 
+/// Message produced on various Gateway events
 #[derive(utoipa::ToSchema, Serialize)]
 #[serde(tag = "kind")]
 struct SubscriberMessage {
+    /// Name of the event type associated to this message
+    ///
+    /// Presence or absence of additionnal fields depends on the value of this field.
     kind: SubscriberMessageKind,
+    /// Date and time this message was produced
+    timestamp: DateTime<Utc>,
+    /// Session information associated to this event
     session: Option<SubscriberSessionInfo>,
+    /// Session list associated to this event
     session_list: Option<Vec<SubscriberSessionInfo>>,
 }
 


### PR DESCRIPTION
This timestamp is the date and time the message was produced on Gateway side. The field is present in all subscriber messages.

Issue: DGW-50