### PR TITLE
devolutions-gateway: package macOS universal jetsocat binary

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -129,7 +129,7 @@ jobs:
           - os: windows
             runner: windows-2019
           - os: macos
-            runner: macos-10.15
+            runner: macos-10.11
           - os: linux
             runner: ubuntu-20.04
         exclude:

--- a/jetsocat/nuget/Devolutions.Jetsocat.nuspec
+++ b/jetsocat/nuget/Devolutions.Jetsocat.nuspec
@@ -8,7 +8,10 @@
     <dependencies />
   </metadata>
   <files>
-    <file src="bin/x64/jetsocat.exe" target="runtimes/win-x64/native" />
+    <file src="bin/windows/x64/jetsocat.exe" target="runtimes/win-x64/native" />
+    <file src="bin/macos/x64/jetsocat" target="runtimes/osx-x64/native/jetsocat" />
+    <file src="bin/macos/arm64/jetsocat" target="runtimes/osx-arm64/native/jetsocat" />
+    <file src="bin/macos/universal/jetsocat" target="runtimes/osx-universal/native/jetsocat" />
     <file src="Devolutions.Jetsocat.targets" target="build" />
   </files>
 </package>

--- a/jetsocat/nuget/Devolutions.Jetsocat.targets
+++ b/jetsocat/nuget/Devolutions.Jetsocat.targets
@@ -1,8 +1,15 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <None Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/jetsocat.exe">
             <Link>runtimes\win-x64\native\%(Filename)%(Extension)</Link>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+    </ItemGroup>
+    <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+        <Content Include="$(MSBuildThisFileDirectory)../runtimes/osx-universal/native/jetsocat">
+            <Link>%(Filename)</Link>
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+            <PublishState>Included</PublishState>
+        </Content>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Include the jetsocat universal binary for macOS inside the nuget package.

The binary is deployed to the `Resources` folder of the final application bundle