### PR TITLE
Fix nuget packaging for jetsocat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
           $OutputPath = Join-Path "macos" "universal"
           New-Item -ItemType Directory -Path $OutputPath | Out-Null
           $Binaries = Get-ChildItem -Recurse -Path "macos" -Filter "jetsocat_*" | Foreach-Object { $_.FullName } | Select -Unique
-          $LipoCmd = $(@('lipo', '-create', '-output', (Join-Path -Path $OutputPath -ChildPath "jetsocat_macos_${{ needs.preflight.outputs.version }}_universal")) + $Binaries) -Join ' '
+          $LipoCmd = $(@('lipo', '-create', '-output', (Join-Path -Path $OutputPath -ChildPath "jetsocat_macOS_${{ needs.preflight.outputs.version }}_universal")) + $Binaries) -Join ' '
           Write-Host $LipoCmd
           Invoke-Expression $LipoCmd
 

--- a/.github/workflows/jetsocat-nuget.yml
+++ b/.github/workflows/jetsocat-nuget.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: jfrog/setup-jfrog-cli@v2
+        with:
+          version: latest
+
       - name: create and publish
         working-directory: ./jetsocat/nuget
         shell: pwsh


### PR DESCRIPTION
- Fix the casing of the jetsocat universal binary to match thin binaries (this doesn't matter for the release, since the build script performs a case-insensitive match)
- Install jfrog CLI in the actions runner