### PR TITLE
ci: fix tlk.ps1 eating stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,8 @@ jobs:
             sudo apt install libsystemd-dev
 
         - name: Test
-          shell: bash
-          run: cargo test --workspace --locked --profile ${{ needs.preflight.outputs.rust-profile }}
+          shell: pwsh
+          run: ./ci/tlk.ps1 test -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
 
   jetsocat:
     name: jetsocat [${{ matrix.os }} ${{ matrix.arch }}]

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -280,7 +280,7 @@ class TlkRecipe
 
         $CargoCmd = $(@('cargo') + $CargoArgs) -Join ' '
         Write-Host $CargoCmd
-        & $CargoCmd | Out-Host
+        & cargo $CargoArgs | Out-Host
     }
 
     [void] Build() {


### PR DESCRIPTION
stdout of invoked commands was eaten by the PowerShell pipeline stream. Appending `| Out-Host` make it clear that we don’t want that.