### PR TITLE
feat(installer): don't show an error dialog from installer custom action

### DIFF
--- a/package/Windows/Actions/CustomAction.cpp
+++ b/package/Windows/Actions/CustomAction.cpp
@@ -541,7 +541,6 @@ UINT __stdcall QueryGatewayStartupType(MSIHANDLE hInstall)
 	{
 		DWORD dwError = GetLastError();
 		LogGLE(hInstall, L"OpenSCManager failed", dwError);
-		ShowErrorMessage(hInstall, Errors::ServiceQueryFailure);
 		hr = HRESULT_FROM_WIN32(dwError);
 
 		goto LExit;
@@ -553,7 +552,6 @@ UINT __stdcall QueryGatewayStartupType(MSIHANDLE hInstall)
 	{
 		DWORD dwError = GetLastError();
 		LogGLE(hInstall, L"OpenService failed", dwError);
-		ShowErrorMessage(hInstall, Errors::ServiceQueryFailure);
 		hr = HRESULT_FROM_WIN32(dwError);
 
 		goto LExit;


### PR DESCRIPTION
On a new install, the Devolutions Gateway service will not exist and the attempt to read its startup type will obviously fail. 

Currently this pops a warning dialog to the user, which is almost certainly not what we want - it could be interpreted as an error. The issue is already written to the .msi log, so don't prompt the user.