### PR TITLE
fix(installer): recursively reset permissions on the ProgramData directory

### DIFF
--- a/package/Windows/DevolutionsGateway.wxs
+++ b/package/Windows/DevolutionsGateway.wxs
@@ -92,7 +92,7 @@
     <Property Id="P.PK_CMD" Secure="yes" />
 
     <SetProperty Id="CA.SetProgramDataPermissions" 
-                 Value='"cmd.exe" /c ECHO Y| &quot;%windir%\System32\cacls.exe&quot; %ProgramData%\Devolutions\Gateway /S:$(var.ProgramDataSddl) /C' 
+                 Value='"cmd.exe" /c ECHO Y| &quot;%windir%\System32\cacls.exe&quot; %ProgramData%\Devolutions\Gateway /S:$(var.ProgramDataSddl) /C /t' 
                  Sequence="execute" 
                  Before="CA.SetProgramDataPermissions" />
     <SetProperty Id="CA.InitConfigAfterFinalize" Value="&quot;[INSTALLDIR]\DevolutionsGateway.exe&quot; --config-init-only" Sequence="execute" Before="CA.InitConfigAfterFinalize" />


### PR DESCRIPTION
The installer invokes calcs.exe to reset the permissions on %programdata%\Devolutions\Gateway

However, if a user or tool has previously edited permissions on a file within the directory (and removed the "inheritance" flag), those permissions will not be reset. By adding the `/t` switch to [calcs](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cacls), we can ask it to traverse subdirectories and files:

> /t | Changes ACLs of specified files in the current directory and all subdirectories.


