### PR TITLE
fix(installer): grant Local Service access rights to the ProgramData directory

### DIFF
--- a/package/Windows/Includes/DevolutionsGateway.wxi
+++ b/package/Windows/Includes/DevolutionsGateway.wxi
@@ -13,8 +13,10 @@
   <?define InfoURL="https://server.devolutions.net" ?>
 
   <!-- SDDL string representing desired %programdata%\devolutions\gateway ACL -->
-  <!-- SYSTEM/BuiltInAdministrators = Full Control, BuiltInUsers - Read/Execute -->
-  <?define ProgramDataSddl="D:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)" ?>
+  <!-- Easiest way to generate an SDDL is to configure the required access, and then query -->
+  <!-- the path with PowerShell: `Get-Acl | Format-List`-->
+  <!-- SYSTEM/BuiltInAdministrators = Full Control, LocalService = Read/Write/Execute, BuiltInUsers - Read/Execute -->
+  <?define ProgramDataSddl="D:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)" ?>
 
   <!-- 32-bit / 64-bit variables -->
   <?if $(var.Platform) = x64 ?>


### PR DESCRIPTION
We specify access rights to the %programdata%\devolutions\gateway directory using an SDDL string.

PowerShell has some functionality to convert ACLs to SDDLs and vice-versa. To retrieve the SDDL for a path, you can run `Get-Acl | Format-List` (The returned object has an `Sddl` property).

Going the other way, one can use `ConvertFrom-SddlString`. In this specific example:

`PS C:\wayk\dev\devolutions-gateway> ConvertFrom-SddlString -Sddl "D:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)"`

> Owner            : 
> Group            : 
> DiscretionaryAcl : {NT AUTHORITY\SYSTEM: AccessAllowed (ChangePermissions, CreateDirectories, Delete, DeleteSubdirectoriesAndFiles, ExecuteKey, FullControl, FullControl,
>                    FullControl, FullControl, GenericAll, GenericExecute, GenericRead, GenericWrite, ListDirectory, Modify, Read, ReadAndExecute, ReadAttributes,
>                    ReadExtendedAttributes, ReadPermissions, Synchronize, TakeOwnership, Traverse, Write, WriteAttributes, WriteData, WriteExtendedAttributes, WriteKey), NT       
>                    AUTHORITY\LOCAL SERVICE: AccessAllowed (CreateDirectories, ExecuteKey, GenericExecute, GenericRead, GenericWrite, ListDirectory, Read, ReadAndExecute,
>                    ReadAttributes, ReadExtendedAttributes, ReadPermissions, Synchronize, Traverse, Write, WriteAttributes, WriteData, WriteExtendedAttributes, WriteKey), 
>                    BUILTIN\Administrators: AccessAllowed (ChangePermissions, CreateDirectories, Delete, DeleteSubdirectoriesAndFiles, ExecuteKey, FullControl, FullControl,       
>                    FullControl, FullControl, GenericAll, GenericExecute, GenericRead, GenericWrite, ListDirectory, Modify, Read, ReadAndExecute, ReadAttributes,
>                    ReadExtendedAttributes, ReadPermissions, Synchronize, TakeOwnership, Traverse, Write, WriteAttributes, WriteData, WriteExtendedAttributes, WriteKey),
>                    BUILTIN\Users: AccessAllowed (GenericWrite, ListDirectory, Read, ReadAndExecute, ReadAttributes, ReadExtendedAttributes, ReadPermissions, Synchronize,
>                    Traverse)}
> SystemAcl        : {}
> RawDescriptor    : System.Security.AccessControl.CommonSecurityDescriptor