### PR TITLE
fix: normalize file extensions

### DIFF
--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -624,7 +624,7 @@ pub mod dto {
             Self {
                 id: Some(Uuid::new_v4()),
                 hostname: None,
-                provisioner_public_key_file: Some("provisioner.pub.key".into()),
+                provisioner_public_key_file: Some("provisioner.pem".into()),
                 provisioner_public_key_data: None,
                 sub_provisioner_public_key: None,
                 delegation_private_key_file: None,

--- a/powershell/DevolutionsGateway/Public/DGateway.ps1
+++ b/powershell/DevolutionsGateway/Public/DGateway.ps1
@@ -7,10 +7,10 @@
 $script:DGatewayConfigFileName = 'gateway.json'
 $script:DGatewayCertificateFileName = 'server.crt'
 $script:DGatewayPrivateKeyFileName = 'server.key'
-$script:DGatewayProvisionerPublicKeyFileName = 'provisioner.pub.key'
-$script:DGatewayProvisionerPrivateKeyFileName = 'provisioner.priv.key'
-$script:DGatewayDelegationPublicKeyFileName = 'delegation.pub.key'
-$script:DGatewayDelegationPrivateKeyFileName = 'delegation.priv.key'
+$script:DGatewayProvisionerPublicKeyFileName = 'provisioner.pem'
+$script:DGatewayProvisionerPrivateKeyFileName = 'provisioner.key'
+$script:DGatewayDelegationPublicKeyFileName = 'delegation.pem'
+$script:DGatewayDelegationPrivateKeyFileName = 'delegation.key'
 
 function Get-DGatewayVersion {
     param(


### PR DESCRIPTION
By convention:

.pem -> public key
.key -> private key
.crt -> certificate

Note that this is merely a convention, not a standard, and file openers should be able to select a .key file when choosing a public key (through the drop-down menu typically)