### PR TITLE
feat(dgw): add Telnet protocol variant

### DIFF
--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -264,7 +264,7 @@ impl ConfHandle {
 fn save_config(conf: &dto::ConfFile) -> anyhow::Result<()> {
     let conf_file_path = get_conf_file_path();
     let json = serde_json::to_string_pretty(conf).context("Failed JSON serialization of configuration")?;
-    std::fs::write(&conf_file_path, &json).with_context(|| format!("Failed to write file at {conf_file_path}"))?;
+    std::fs::write(&conf_file_path, json).with_context(|| format!("Failed to write file at {conf_file_path}"))?;
     Ok(())
 }
 

--- a/devolutions-gateway/src/http/controllers/health.rs
+++ b/devolutions-gateway/src/http/controllers/health.rs
@@ -83,14 +83,11 @@ fn get_health(controller: &HealthController, req: Request) -> Result<HealthRespo
         .into_iter()
         .flat_map(|hval| hval.split(','))
     {
-        match hval {
-            "application/json" => {
-                return Ok(HealthResponse::Identity(Identity {
-                    id: conf.id,
-                    hostname: conf.hostname.clone(),
-                }))
-            }
-            _ => {}
+        if hval == "application/json" {
+            return Ok(HealthResponse::Identity(Identity {
+                id: conf.id,
+                hostname: conf.hostname.clone(),
+            }));
         }
     }
 

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -159,14 +159,16 @@ pub enum Protocol {
     Ard,
     /// Virtual Network Computing
     Vnc,
-    /// Secure Shell Protocol
+    /// Secure Shell
     Ssh,
-    /// PowerShell over SSH
+    /// PowerShell over SSH transport
     SshPwsh,
     /// SSH File Transfer Protocol
     Sftp,
     /// Secure Copy Protocol
     Scp,
+    /// Telnet
+    Telnet,
     /// PowerShell over WinRM via HTTP transport
     WinrmHttpPwsh,
     /// PowerShell over WinRM via HTTPS transport
@@ -186,10 +188,11 @@ impl Protocol {
             Self::Vnc => 5900,
             Self::Ssh => 22,
             Self::SshPwsh => 22,
-            Self::WinrmHttpPwsh => 5985,
-            Self::WinrmHttpsPwsh => 5986,
             Self::Sftp => 22,
             Self::Scp => 22,
+            Self::Telnet => 23,
+            Self::WinrmHttpPwsh => 5985,
+            Self::WinrmHttpsPwsh => 5986,
             Self::Http => 80,
             Self::Https => 443,
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
This change is making possible to omit the port in the target host field. The Telnet default port will be inferred as appropriate.