### PR TITLE
fix(pwsh): nil UUID when creating an empty DGatewayConfig

### DIFF
--- a/powershell/DevolutionsGateway/Public/DGateway.ps1
+++ b/powershell/DevolutionsGateway/Public/DGateway.ps1
@@ -160,7 +160,7 @@ class DGatewaySubscriber {
 }
 
 class DGatewayConfig {
-    [Guid] $Id
+    [System.Nullable[Guid]] $Id
     [string] $Hostname
     [string] $FarmName
     [string[]] $FarmMembers


### PR DESCRIPTION
Without this patch, the nil UUID is used as the "missing" value instead of $null.

Issue: DGW-73