### PR TITLE
fix(installer): fix configuration creation with installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
         - name: Configure Linux runner
           if: matrix.os == 'linux'
           run: |
-            sudo apt update
-            sudo apt install libsystemd-dev
+            sudo apt-get update
+            sudo apt-get -o Acquire::Retries=3 install libsystemd-dev
 
         - name: Test
           shell: pwsh
@@ -158,8 +158,8 @@ jobs:
       - name: Configure Linux runner
         if: matrix.os == 'linux'
         run: |
-          sudo apt update
-          sudo apt install python3-wget python3-setuptools
+          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 install python3-wget python3-setuptools
 
       - name: Configure Windows runner
         if: matrix.os == 'windows' && matrix.arch == 'x86'
@@ -323,8 +323,8 @@ jobs:
       - name: Configure Linux runner
         if: matrix.os == 'linux'
         run: |
-          sudo apt update
-          sudo apt install python3-wget python3-setuptools libsystemd-dev dh-make
+          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 install python3-wget python3-setuptools libsystemd-dev dh-make
 
       # WiX is installed on Windows runners but not in the PATH
       - name: Configure Windows runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           if (-Not $Ref) {
             $Ref = '${{ github.sha }}'
           }
-          echo "::set-output name=ref::$Ref"
+          echo "ref=$Ref" >> $Env:GITHUB_OUTPUT
 
       - name: Checkout ${{ github.repository }}
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
         shell: pwsh
         run: |
           $Version = Get-Content VERSION -TotalCount 1
-          echo "::set-output name=version::$Version"
+          echo "version=$Version" >> $Env:GITHUB_OUTPUT
 
       - name: Configure rust toolchain
         id: rust-toolchain
@@ -59,7 +59,7 @@ jobs:
           $Channel = (Get-Content 'rust-toolchain.toml' | Select -Skip 1 | ConvertFrom-StringData).channel
           rustup toolchain install $Channel
           rustup component add rustfmt
-          echo "::set-output name=rust-channel::$Channel"
+          echo "rust-channel=$Channel" >> $Env:GITHUB_OUTPUT
 
       - name: Check formatting
         run: |
@@ -79,7 +79,7 @@ jobs:
             $CargoProfile = "production"
           }
 
-          echo "::set-output name=rust-profile::$CargoProfile"
+          echo "rust-profile=$CargoProfile" >> $Env:GITHUB_OUTPUT
 
       - name: Upload version artifact
         uses: actions/upload-artifact@v3
@@ -227,7 +227,7 @@ jobs:
 
           ./ci/tlk.ps1 build -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
 
-          echo "::set-output name=staging-path::$StagingPath"
+          echo "staging-path=$StagingPath" >> $Env:GITHUB_OUTPUT
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -307,15 +307,15 @@ jobs:
             $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
             $DGatewayPackage = Join-Path $TargetOutputPath $PackageFileName
 
-            echo "::set-output name=psmodule-output-path::$PSModuleOutputPath"
-            echo "::set-output name=dgateway-psmodule-output-path::$DGatewayPSModulePath"
-            echo "::set-output name=dgateway-package::$DGatewayPackage"
+            echo "psmodule-output-path=$PSModuleOutputPath" >> $Env:GITHUB_OUTPUT
+            echo "dgateway-psmodule-output-path=$DGatewayPSModulePath" >> $Env:GITHUB_OUTPUT
+            echo "dgateway-package=$DGatewayPackage" >> $Env:GITHUB_OUTPUT
           }
 
           $DGatewayExecutable = Join-Path $TargetOutputPath $ExecutableFileName
-          echo "::set-output name=staging-path::$StagingPath"
-          echo "::set-output name=target-output-path::$TargetOutputPath"
-          echo "::set-output name=dgateway-executable::$DGatewayExecutable"
+          echo "staging-path=$StagingPath" >> $Env:GITHUB_OUTPUT
+          echo "target-output-path=$TargetOutputPath" >> $Env:GITHUB_OUTPUT
+          echo "dgateway-executable=$DGatewayExecutable" >> $Env:GITHUB_OUTPUT
 
       - name: Configure rust toolchain
         run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
@@ -423,7 +423,7 @@ jobs:
 
       - name: Get current timestamp
         id: timestamp
-        run: echo "::set-output name=timestamp::$(date +'%Y%m%d%H%M')"
+        run: echo "timestamp=$(date +'%Y%m%d%H%M')" >> $GITHUB_OUTPUT
 
       ## Devolutions Toolbox is required for OneDrive uploading
 
@@ -464,9 +464,9 @@ jobs:
           Write-Host "version = $version"
           Write-Host "ref = $ref"
 
-          Write-Host "::set-output name=version::${version}"
-          Write-Host "::set-output name=short-ref::${shortRef}"
-          Write-Host "::set-output name=files-to-upload::${destinationFolder}"
+          echo "version=$version" >> $Env:GITHUB_OUTPUT
+          echo "short-ref=$shortRef" >> $Env:GITHUB_OUTPUT
+          echo "files-to-upload=$destinationFolder" >> $Env:GITHUB_OUTPUT
 
           New-Item -Path "$destinationFolder" -ItemType "directory"
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -41,9 +41,9 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ inputs.dispatch }}') {
-            echo '::set-output name=dl-strategy::action'
+            echo "dl-strategy=action" >> $Env:GITHUB_OUTPUT
           } else {
-            echo '::set-output name=dl-strategy::cli'
+            echo "dl-strategy=cli" >> $Env:GITHUB_OUTPUT
           }
 
       ## workflow_dispatch: The run_id is read from the inputs
@@ -53,9 +53,9 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ github.event.inputs.run }}') {
-            echo '::set-output name=run::${{ github.event.inputs.run }}'
+            echo "run=${{ github.event.inputs.run }}" >> $Env:GITHUB_OUTPUT
           } else {
-            echo '::set-output name=run::${{ github.run_id }}'
+            echo "run=${{ github.run_id }}" >> $Env:GITHUB_OUTPUT
           }
 
       ## To consistently repackage the CI artifacts, we must use the same commit that produced the artifacts
@@ -91,7 +91,7 @@ jobs:
             $Ref = $($Run.head_sha)
           }
 
-          echo "::set-output name=commit::$Ref"
+          echo "commit=$Ref" >> $Env:GITHUB_OUTPUT
           echo "::notice::Packaging artifacts built from commit $Ref in run ${{ steps.get-run.outputs.run }}"
 
       - name: Checkout ${{ github.repository }}
@@ -100,19 +100,19 @@ jobs:
           ref: ${{ steps.get-commit.outputs.commit }}
 
       - name: Upload version artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: version
           path: VERSION
 
       - name: Upload docker file artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docker
           path: package/**/Dockerfile
 
       - name: Upload changelog artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: changelog
           path: CHANGELOG.md
@@ -122,7 +122,7 @@ jobs:
         shell: pwsh
         run: |
           $Version = Get-Content VERSION -TotalCount 1
-          echo "::set-output name=version::$Version"
+          echo "version=$Version" >> $Env:GITHUB_OUTPUT
 
   codesign:
     name: Codesign
@@ -317,7 +317,7 @@ jobs:
           }
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.project }}
           path: ${{ runner.temp }}/${{ matrix.project }}

--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -28,9 +28,9 @@ jobs:
           $IsDryRun = '${{ github.event.inputs.dry-run }}' -Eq 'true' -Or '${{ github.event_name }}' -Eq 'schedule'
 
           if ($IsDryRun) {
-            Write-Host '::set-output name=dry-run::true'
+            echo "dry-run=true" >> $Env:GITHUB_OUTPUT
           } else {
-            Write-Host '::set-output name=dry-run::false'
+            echo "dry-run=false" >> $Env:GITHUB_OUTPUT
           }
 
   nuget-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ inputs.dispatch }}') {
-            echo '::set-output name=dl-strategy::action'
+            echo "dl-strategy=action" >> $Env:GITHUB_OUTPUT
           } else {
-            echo '::set-output name=dl-strategy::cli'
+            echo "dl-strategy=cli" >> $Env:GITHUB_OUTPUT
           }
 
       ## workflow_dispatch: The run_id is read from the inputs
@@ -51,9 +51,9 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ github.event.inputs.run }}') {
-            echo '::set-output name=run::${{ github.event.inputs.run }}'
+            echo "run=${{ github.event.inputs.run }}" >> $Env:GITHUB_OUTPUT
           } else {
-            echo '::set-output name=run::${{ github.run_id }}'
+            echo "run=${{ github.run_id }}" >> $Env:GITHUB_OUTPUT
           }
 
       - name: Download version (action)
@@ -74,7 +74,7 @@ jobs:
         shell: pwsh
         run: |
           $Version = Get-Content VERSION -TotalCount 1
-          echo "::set-output name=version::$Version"
+          echo "version=$Version" >> $Env:GITHUB_OUTPUT
           echo "::notice::Releasing artifacts for version $Version from run ${{ steps.get-run.outputs.run }}"
 
       ## If we already released this version to GitHub, publishing will be skipped
@@ -97,7 +97,7 @@ jobs:
             echo "::warning::GitHub already has a release version ${{ steps.get-version.outputs.version }}; publishing will be skipped"
             $SkipPublishing = 'true'
           }
-          echo "::set-output name=skip-publishing::$SkipPublishing"
+          echo "skip-publishing=$SkipPublishing" >> $Env:GITHUB_OUTPUT
 
   containers:
     name: Containers [${{ matrix.os }} ${{ matrix.base-image }}]
@@ -156,7 +156,7 @@ jobs:
         shell: pwsh
         run: |
           $PkgDir = Join-Path docker $Env:RUNNER_OS # RUNNER_OS is camelcase
-          echo "::set-output name=package-path::$PkgDir"
+          echo "package-path=$PkgDir" >> $Env:GITHUB_OUTPUT
 
           $SourceFileName = "DevolutionsGateway_$($Env:RUNNER_OS)_${{ needs.preflight.outputs.version }}_${{ matrix.arch }}"
 
@@ -186,7 +186,7 @@ jobs:
           } else {
             docker build -t "$ImageName" .
           }
-          echo "::set-output name=image-name::$ImageName"
+          echo "image-name=$ImageName" >> $Env:GITHUB_OUTPUT
           Get-ChildItem -Recurse
 
       - name: Push container
@@ -385,8 +385,8 @@ jobs:
           $version="${{ needs.preflight.outputs.version }}"
 
           # Note that ".0" is appended here (required by release tooling downstream)
-          Write-Host "::set-output name=version::${version}.0"
-          Write-Host "::set-output name=files-to-upload::${destinationFolder}"
+          echo "version=${version}.0" >> $Env:GITHUB_OUTPUT
+          echo "files-to-upload=$destinationFolder" >> $Env:GITHUB_OUTPUT
 
           New-Item -Path "$destinationFolder" -ItemType "directory"
           Move-Item -Path "./windows/x86_64/DevolutionsGateway-x86_64-${version}.msi" -Destination "$destinationFolder/DevolutionsGateway-x86_64-${version}.0.msi"

--- a/package/Windows/Actions/CustomAction.cpp
+++ b/package/Windows/Actions/CustomAction.cpp
@@ -726,7 +726,7 @@ UINT __stdcall ValidateAccessUri(MSIHANDLE hInstall)
 	LPWSTR szAccessUriScheme = NULL;
 	LPWSTR szAccessUriHost = NULL;
 	LPWSTR szAccessUriPort = NULL;
-	static LPCWSTR psCommandFormat = L"Set-DGatewayHostname %ls://%ls:%ls";
+	static LPCWSTR psCommandFormat = L"Set-DGatewayHostname %ls";
 	int psCommandLen = 0;
 	WCHAR* psCommand = NULL;
 
@@ -785,9 +785,9 @@ UINT __stdcall ValidateAccessUri(MSIHANDLE hInstall)
 		ExitOnFailure(hr, "The expected property was not found.");
 	}
 
-	psCommandLen = _snwprintf(NULL, 0, psCommandFormat, szAccessUriScheme, szAccessUriHost, szAccessUriPort);
+	psCommandLen = _snwprintf(NULL, 0, psCommandFormat, szAccessUriHost);
 	psCommand = new WCHAR[psCommandLen + 1];
-	_snwprintf(psCommand, psCommandLen, psCommandFormat, szAccessUriScheme, szAccessUriHost, szAccessUriPort);
+	_snwprintf(psCommand, psCommandLen, psCommandFormat, szAccessUriHost);
 	psCommand[psCommandLen] = L'\0';
 
 	hr = WcaSetProperty(L"P.ACCESSURI_CMD", psCommand);

--- a/package/Windows/DevolutionsGateway.wxs
+++ b/package/Windows/DevolutionsGateway.wxs
@@ -140,11 +140,11 @@
       </Custom>
       <Custom Action="CA.QueryGatewayStartupType" Before="RemoveExistingProducts">1</Custom>
       <Custom Action="CA.SetGatewayStartupType" Before="StartServices">1</Custom>
-      <Custom Action="CA.InitConfigAfterFinalize" Before="StartServices">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "1")</Custom>
-      <Custom Action="CA.ConfigHostname" Before="StartServices">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
-      <Custom Action="CA.ConfigListeners" Before="StartServices">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
-      <Custom Action="CA.ConfigCert" Before="StartServices">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
-      <Custom Action="CA.ConfigPk" Before="StartServices">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
+      <Custom Action="CA.InitConfigAfterFinalize" Before="StartServices">(NOT Installed OR REINSTALL)</Custom>
+      <Custom Action="CA.ConfigHostname" After="CA.InitConfigAfterFinalize">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
+      <Custom Action="CA.ConfigListeners" After="CA.ConfigHostname">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
+      <Custom Action="CA.ConfigCert" After="CA.ConfigListeners">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
+      <Custom Action="CA.ConfigPk" After="CA.ConfigCert">(NOT Installed OR REINSTALL) AND (P.CONFIGURE = "0")</Custom>
       <Custom Action="CA.StartGatewayIfNeeded" After="StartServices">(NOT Uninstalling) AND (NOT P.DGW.NO_START_SERVICE)</Custom>
     </InstallExecuteSequence>
 


### PR DESCRIPTION
- On first time installs, always initialize the default config file before applying any PowerShell configuration commands. This ensures that the ID is properly created.
- Properly pass only the hostname (instead of the full URI) to `Set-DGatewayHostname`
- Fix deprecation warnings in GitHub Actions

Issue: DGW-72
Issue: DGW-73