### PR TITLE
fix(installer): avoid unicode char literals

### DIFF
--- a/package/Windows/Actions/CustomAction.cpp
+++ b/package/Windows/Actions/CustomAction.cpp
@@ -961,7 +961,7 @@ UINT __stdcall ValidateCertificate(MSIHANDLE hInstall)
 
 		for (int i = 0; i < lstrlenW(szCertPass); i++)
 		{
-			szValBuf[i] = L'●';
+			szValBuf[i] = L'*';
 		}
 
 		szValBuf[lstrlenW(szCertPass)] = L'\0';


### PR DESCRIPTION
Unicode character literals in source files can be problematic, depending on the editor and encoding. Instead, avoid the issue by masking the character with an asterisk instead of a unicode "bullet".

Issue: DGW-74