### PR TITLE
feat(jetsocat): use rustls-native-certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4237,12 +4237,12 @@ dependencies = [
  "log",
  "native-tls",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "tungstenite",
  "webpki",
- "webpki-roots",
 ]
 
 [[package]]

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [features]
 default = ["rustls", "detect-proxy"]
 detect-proxy = ["proxy_cfg"]
-rustls = ["tokio-tungstenite/rustls-tls-webpki-roots"]
+rustls = ["tokio-tungstenite/rustls-tls-native-roots"]
 native-tls = ["tokio-tungstenite/native-tls"]
 
 [dependencies]


### PR DESCRIPTION
Let rustls use the plateform’s native certificate store.