### PR TITLE
feat(jetsocat): file-based pipes

### DIFF
--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -33,7 +33,7 @@ seahorse = "2.1.0"
 humantime = "2.1.0"
 
 # async
-tokio = { version = "1.20.1", features = ["io-std", "io-util", "net", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
+tokio = { version = "1.20.1", features = ["io-std", "io-util", "net", "fs", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
 tokio-tungstenite = "0.17.2"
 futures-util = "0.3.21"
 transport = { path = "../crates/transport" }

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -86,6 +86,8 @@ pub fn exit(res: anyhow::Result<()>) -> ! {
 const PIPE_FORMATS: &str = r#"Pipe formats:
     `stdio` or `-`: Standard input output
     `cmd://<COMMAND>`: Spawn a new process with specified command using `cmd /C` on windows or `sh -c` otherwise
+    `write-file://<PATH>`: Open specified file in write mode
+    `read-file://<PATH>`: Open specified file in read mode
     `tcp://<ADDRESS>`: Plain TCP stream
     `tcp-listen://<BINDING ADDRESS>`: TCP listener
     `jet-tcp-connect://<ADDRESS>/<ASSOCIATION ID>/<CANDIDATE ID>`: TCP stream over JET protocol as client
@@ -466,6 +468,12 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
         }),
         "cmd" => Ok(PipeMode::ProcessCmd {
             command: value.to_owned(),
+        }),
+        "write-file" => Ok(PipeMode::WriteFile {
+            path: PathBuf::from(value.to_owned()),
+        }),
+        "read-file" => Ok(PipeMode::ReadFile {
+            path: PathBuf::from(value.to_owned()),
         }),
         "tcp" => Ok(PipeMode::Tcp { addr: value.to_owned() }),
         "jet-tcp-connect" => {

--- a/jetsocat/src/utils.rs
+++ b/jetsocat/src/utils.rs
@@ -139,3 +139,39 @@ where
         future.await
     }
 }
+
+pub(crate) struct DummyReaderWriter;
+
+impl tokio::io::AsyncRead for DummyReaderWriter {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        _: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Pending
+    }
+}
+
+impl tokio::io::AsyncWrite for DummyReaderWriter {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        std::task::Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}


### PR DESCRIPTION
- `write-file://<PATH>`: write file at the specified location
- `read-file://<PATH>`: read wile at the specified location