### PR TITLE
fix(jetsocat): set execute permission in binary

### DIFF
--- a/jetsocat/nuget/Devolutions.Jetsocat.targets
+++ b/jetsocat/nuget/Devolutions.Jetsocat.targets
@@ -1,4 +1,18 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <CompileDependsOn>
+            $(CompileDependsOn)
+            SetFilePermissionsTarget
+        </CompileDependsOn>
+    </PropertyGroup>
+    <Target Name="SetFilePermissionsTarget">
+        <Exec Command="chmod a+x &quot;$(MSBuildThisFileDirectory)../runtimes/osx-universal/native/jetsocat&quot;"
+              ConsoleToMsBuild="true" 
+              Condition="$([MSBuild]::IsOSPlatform('OSX'))"/>
+        <Exec Command="chmod a+x &quot;$(MSBuildThisFileDirectory)../runtimes/linux-x64/native/jetsocat&quot;"
+              ConsoleToMsBuild="true"
+              Condition="$([MSBuild]::IsOSPlatform('Linux'))"/>
+    </Target>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
         <None Include="$(MSBuildThisFileDirectory)../runtimes/win-x64/native/jetsocat.exe">
             <Link>runtimes\win-x64\native\%(Filename)%(Extension)</Link>


### PR DESCRIPTION
It's preferable if we set the execute bit on jetsocat binaries for macOS and Linux rather than relying on the consumer to do it. However, even if we set this properly at build time it's unlikely to be preserved by the nuget package.

Instead, set the file permissions while building the final target. The solution is not the neatest (I don't know how to target the copied file in the target `bin` directory, particularly on macOS where it might be somewhere in the final .app bundle structure).