### PR TITLE
build: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -39,13 +39,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.3",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aes-gcm"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6"
 dependencies = [
  "aead",
- "aes",
+ "aes 0.7.5",
  "cipher 0.3.0",
  "ctr",
  "ghash",
@@ -87,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -105,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "arc-swap"
@@ -146,7 +157,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros 4.1.0",
  "thiserror",
- "time 0.3.7",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -155,9 +166,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -167,9 +178,28 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "async-dnssd"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98efc05996cc8d660e88841fcffb75aa71be5339c9ae559a8c8016c048420b82"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-util",
+ "libc",
+ "log",
+ "pin-utils",
+ "pkg-config",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -188,20 +218,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -210,7 +240,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -251,7 +281,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -270,21 +300,27 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
-version = "1.4.0"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42bc66d2304056cf5b732c24fe578d88871449c6d10aefff27f371e5f927e33"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -337,7 +373,7 @@ checksum = "72936ee4afc7f8f736d1c38383b56480b5497b4617b4a77bdbf1d2ababc76127"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
@@ -348,20 +384,20 @@ checksum = "db539cc2b5f6003621f1cd9ef92d7ded8ea5232c7de0f9faa2de251cd98730d4"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.3.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+checksum = "42ae2468a89544a466886840aa467a25b766499f4f04bf7d9fcd10ecee9fccef"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
  "cc",
  "cfg-if 1.0.0",
- "constant_time_eq",
+ "constant_time_eq 0.2.4",
 ]
 
 [[package]]
@@ -382,16 +418,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -409,7 +445,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -435,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.9.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-tools"
@@ -452,6 +488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,15 +504,15 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "camino"
-version = "1.0.9"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+checksum = "c77df041dc383319cc661b428b6961a005db4d6808d5e12536931b1ca9556055"
 dependencies = [
  "serde",
 ]
@@ -483,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "ceviche"
@@ -521,25 +566,19 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "cipher"
@@ -547,7 +586,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -585,6 +624,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +656,12 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
 
 [[package]]
 name = "core-foundation"
@@ -635,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -672,22 +727,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d88231face754cdb045c1b65912a0f4ff78ca24bf371e30a4a8cfa993b3897"
+dependencies = [
+ "crypto-common",
+]
+
+[[package]]
 name = "crypto-bigint"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "typenum",
 ]
 
@@ -697,7 +761,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
@@ -721,10 +785,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.3.2"
+name = "cxx"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "scratch",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "data-encoding-macro"
@@ -743,7 +851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn 1.0.99",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -798,19 +906,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e0925824edd2cc2de26da32852c7cd30844011dbf4956c12c88ad2f42d910"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "derive-into-owned"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576fce04d31d592013a5887ba8d9c3830adff329e5096d7e1eb5e8e61262ca62"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
- "quote 0.3.15",
- "syn 0.11.11",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher 0.4.3",
 ]
 
 [[package]]
@@ -819,9 +937,9 @@ version = "2023.1.1"
 dependencies = [
  "anyhow",
  "backoff",
- "base64 0.13.0",
+ "base64 0.21.0",
  "byteorder",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "camino",
  "ceviche",
  "cfg-if 1.0.0",
@@ -848,7 +966,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pcap-file",
  "picky",
- "picky-krb",
+ "picky-krb 0.6.0",
  "pin-project-lite",
  "portpicker",
  "proptest",
@@ -863,7 +981,7 @@ dependencies = [
  "sha1",
  "smol_str",
  "sogar-core",
- "sspi 0.3.2",
+ "sspi 0.6.0",
  "tap",
  "tempfile",
  "thiserror",
@@ -871,15 +989,15 @@ dependencies = [
  "tokio-rustls",
  "tokio-test",
  "tokio-tungstenite",
- "tokio-util 0.7.3",
+ "tokio-util 0.7.7",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
  "transport",
  "typed-builder",
- "url 2.2.2",
+ "url 2.3.1",
  "utoipa",
- "uuid 1.1.2",
+ "uuid 1.3.0",
  "zeroize",
 ]
 
@@ -890,7 +1008,7 @@ dependencies = [
  "devolutions-gateway",
  "proptest",
  "serde",
- "uuid 1.1.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -908,17 +1026,18 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.2",
+ "block-buffer 0.10.3",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -948,9 +1067,9 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -996,9 +1115,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embed-resource"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936c1354206a875581696369aef920e12396e93bbd251c43a7a3f3fa85023a7d"
+checksum = "e62abb876c07e4754fae5c14cafa77937841f01740637e17d78dc04352f32a5e"
 dependencies = [
  "cc",
  "rustc_version",
@@ -1009,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1023,9 +1142,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
 dependencies = [
  "heck",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1069,9 +1188,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -1083,23 +1202,21 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -1110,9 +1227,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "focaccia"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf0a769c74a0ab16fad2ad5ef4b4432d2ba3d079e607c55083e66d3f9d1bb8f"
+checksum = "dc925590c53027bd7fe404cdb7b806a021ec4fc7682a470f387f1055d7c74ef9"
 
 [[package]]
 name = "foreign-types"
@@ -1131,12 +1248,11 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
 ]
 
 [[package]]
@@ -1153,9 +1269,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1168,9 +1284,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1178,15 +1294,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1195,32 +1311,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -1230,9 +1346,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1284,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -1294,13 +1410,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1321,11 +1437,11 @@ checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "h2"
-version = "0.3.11"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1334,7 +1450,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -1346,15 +1462,24 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1395,6 +1520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,31 +1541,31 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "http",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1456,11 +1590,11 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1497,7 +1631,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "hyper",
  "native-tls",
  "tokio",
@@ -1506,15 +1640,26 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.42"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9512e544c25736b82aebbd2bf739a47c8a1c935dfcc3a6adcde10e35cd3cd468"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
- "core-foundation",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1540,10 +1685,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
+name = "idna"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
@@ -1552,12 +1707,12 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1f03d4ab4d5dc9ec2d219f86c15d2a15fc08239d1cd3b2d6a19717c0a2f443"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding 0.3.2",
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -1583,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.3.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "ironrdp"
@@ -1630,10 +1785,10 @@ dependencies = [
  "bitflags",
  "bitvec 1.0.1",
  "byteorder",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "der-parser 8.1.0",
  "lazy_static",
- "md-5 0.10.1",
+ "md-5 0.10.5",
  "num-bigint 0.4.3",
  "num-derive 0.3.3",
  "num-integer",
@@ -1649,7 +1804,7 @@ name = "ironrdp-devolutions-gateway"
 version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=898fb8d40a3c84#898fb8d40a3c8495e22c1a08c9e9401d3ba0a199"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "der 0.6.0",
 ]
 
@@ -1682,7 +1837,7 @@ dependencies = [
  "bit_field",
  "bitflags",
  "byteorder",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "chrono",
  "dns-lookup",
  "failure",
@@ -1702,16 +1857,16 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jet-proto"
 version = "0.0.0"
 dependencies = [
  "byteorder",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "exitcode",
  "hex-literal 0.3.4",
  "http",
@@ -1722,12 +1877,12 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sspi 0.3.2",
+ "sspi 0.6.0",
  "tempfile",
  "tokio-rustls",
  "ureq",
- "url 2.2.2",
- "uuid 1.1.2",
+ "url 2.3.1",
+ "uuid 1.3.0",
  "x509-parser 0.14.0",
 ]
 
@@ -1756,7 +1911,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "transport",
- "uuid 1.1.2",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -1771,7 +1926,7 @@ dependencies = [
 name = "jmux-proto"
 version = "0.0.0"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "jmux-generators",
  "proptest",
  "smol_str",
@@ -1783,28 +1938,31 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "bitvec 1.0.1",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-util",
  "jmux-proto",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "kerberos_constants"
@@ -1851,28 +2009,38 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
-version = "0.2.2"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -1927,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "md-5"
@@ -1955,11 +2123,11 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -2033,15 +2201,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.4"
+name = "miniz_oxide"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2066,40 +2243,40 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.16.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c346cf9999c631f002d8f977c4eaeaa0e6386f16007202308d0b3757522c2cc"
+checksum = "15e5d911412e631e1de11eb313e4dd71f73fd964401102aab23d6c8327c431ba"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "blake3",
  "core2",
- "digest 0.10.3",
+ "digest 0.10.6",
  "multihash-derive",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "sha3",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "multihash-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
+checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2172,16 +2349,26 @@ dependencies = [
 
 [[package]]
 name = "nonempty"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f1f8e5676e1a1f2ee8b21f38238e1243c827531c9435624c7bfb305102cee4"
+checksum = "aeaf4ad7403de93e699c191202f017118df734d3850b01e13a3a8b2e6953d3c9"
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
  "winapi",
 ]
 
@@ -2223,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566d173b2f9406afbc5510a90925d5a2cd80cae4605631f1212303df265de011"
+checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -2266,16 +2453,16 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg 1.1.0",
  "num-traits",
@@ -2283,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg 1.1.0",
  "num-integer",
@@ -2306,9 +2493,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
@@ -2316,19 +2503,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "num_threads"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
@@ -2359,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -2377,16 +2564,28 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2397,9 +2596,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.72"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg 1.1.0",
  "cc",
@@ -2407,6 +2606,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "packet"
@@ -2437,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.7",
 ]
 
 [[package]]
@@ -2456,24 +2661,48 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.32.0",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.6",
+ "hmac 0.12.1",
+ "password-hash",
+ "sha-1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
 name = "pcap-file"
-version = "1.1.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad13fed1a83120159aea81b265074f21d753d157dd16b10cc3790ecba40a341"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
 dependencies = [
- "byteorder",
+ "byteorder_slice",
  "derive-into-owned",
  "thiserror",
 ]
@@ -2495,9 +2724,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "phf"
@@ -2519,26 +2748,26 @@ dependencies = [
 
 [[package]]
 name = "picky"
-version = "7.0.0-rc.3"
+version = "7.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b467d8082dcc552d4ca8c9aecdc94a09b0e092b961c542bb78b6feff8f1b3ea"
+checksum = "d2c80faad111028a7dc724b220316209af32d3db6b4a3251d2b8b94277d2af5c"
 dependencies = [
  "aes-gcm",
- "base64 0.13.0",
+ "base64 0.13.1",
  "cbc",
- "digest 0.10.3",
- "md-5 0.10.1",
+ "digest 0.10.6",
+ "md-5 0.10.5",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.6.0",
- "picky-asn1-der",
- "picky-asn1-x509 0.8.0",
+ "picky-asn1 0.7.1",
+ "picky-asn1-der 0.4.0",
+ "picky-asn1-x509 0.9.0",
  "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
  "sha-1",
- "sha2 0.10.2",
+ "sha2 0.10.6",
  "sha3",
  "thiserror",
 ]
@@ -2557,10 +2786,11 @@ dependencies = [
 
 [[package]]
 name = "picky-asn1"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7a3f07db0e5b22727979a992df18c78170c7c30279ab4149a395c0c3843832"
+checksum = "47530ada7dc2327eba0200cfbdbb8d7f7751856bef43a01c20afa9bd00f54c76"
 dependencies = [
+ "chrono",
  "oid",
  "serde",
  "serde_bytes",
@@ -2579,30 +2809,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "picky-asn1-der"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47267a46f4ea246b772381970b8ed3f15963dd3e15ffc2c3f4ac3bc2d77384b"
+dependencies = [
+ "picky-asn1 0.7.1",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "picky-asn1-x509"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43aa17ded8046e4809d21f0a007439ebcd1aa23e88003a6d68ba9992b26c96f7"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "oid",
  "picky-asn1 0.5.0",
- "picky-asn1-der",
+ "picky-asn1-der 0.3.1",
  "serde",
 ]
 
 [[package]]
 name = "picky-asn1-x509"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ffcd92e3f788f0f76506f3b86310876cc0014ade835d68a6365ee0fd1009dc"
+checksum = "fdb51541f90aa99f2fa7191c8daebc224d500cd5963c6ca3e6cede9645a1b2e1"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "num-bigint-dig",
  "oid",
- "picky-asn1 0.6.0",
- "picky-asn1-der",
+ "picky-asn1 0.7.1",
+ "picky-asn1-der 0.4.0",
  "serde",
+ "widestring 0.5.1",
  "zeroize",
 ]
 
@@ -2614,9 +2856,59 @@ checksum = "eabfa40bab64b6bb0b0be4fa24b167a4e7980724b545ea1bb4e756eae1020dad"
 dependencies = [
  "byteorder",
  "picky-asn1 0.5.0",
- "picky-asn1-der",
+ "picky-asn1-der 0.3.1",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "picky-krb"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237e5fe07bdd05afa0f14a05b535ee139532b3ef7e8271631bec57f45bc6ba79"
+dependencies = [
+ "aes 0.8.2",
+ "byteorder",
+ "cbc",
+ "crypto",
+ "des",
+ "hmac 0.12.1",
+ "num-bigint-dig",
+ "oid",
+ "pbkdf2",
+ "picky-asn1 0.7.1",
+ "picky-asn1-der 0.4.0",
+ "picky-asn1-x509 0.9.0",
+ "rand 0.8.5",
+ "serde",
+ "sha1",
+ "thiserror",
+ "uuid 1.3.0",
+]
+
+[[package]]
+name = "picky-krb"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ce6e874e53f3a7375000c959adebeee4f419f1340280cfd59fb8962bfe6edf"
+dependencies = [
+ "aes 0.8.2",
+ "byteorder",
+ "cbc",
+ "crypto",
+ "des",
+ "hmac 0.12.1",
+ "num-bigint-dig",
+ "oid",
+ "pbkdf2",
+ "picky-asn1 0.7.1",
+ "picky-asn1-der 0.4.0",
+ "picky-asn1-x509 0.9.0",
+ "rand 0.8.5",
+ "serde",
+ "sha1",
+ "thiserror",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -2655,9 +2947,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polyval"
@@ -2682,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2703,9 +2995,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2715,8 +3007,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
  "version_check",
 ]
 
@@ -2737,18 +3029,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
  "bitflags",
@@ -2759,9 +3051,10 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
- "regex-syntax 0.6.25",
+ "regex-syntax 0.6.28",
  "rusty-fork",
  "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2776,7 +3069,7 @@ dependencies = [
 name = "proxy-http"
 version = "0.0.0"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "pin-project-lite",
  "proptest",
  "proxy-generators",
@@ -2826,7 +3119,7 @@ checksum = "4873cd217803ccb250f2563adf3f7a128a6a2039a0aeb2417a58130a079748b4"
 dependencies = [
  "core-foundation",
  "system-configuration-sys",
- "url 2.2.2",
+ "url 2.3.1",
  "winapi",
  "winreg 0.9.0",
 ]
@@ -2845,12 +3138,6 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-
-[[package]]
-name = "quote"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -2860,11 +3147,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.51",
 ]
 
 [[package]]
@@ -2929,7 +3216,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2949,7 +3236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2969,9 +3256,9 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
@@ -3044,7 +3331,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3058,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
@@ -3096,7 +3383,7 @@ checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick 0.7.15",
  "memchr",
- "regex-syntax 0.6.25",
+ "regex-syntax 0.6.28",
 ]
 
 [[package]]
@@ -3105,7 +3392,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax 0.6.25",
+ "regex-syntax 0.6.28",
 ]
 
 [[package]]
@@ -3119,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -3134,12 +3421,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64 0.13.0",
- "bytes 1.3.0",
+ "base64 0.21.0",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3151,11 +3438,11 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
- "percent-encoding 2.1.0",
+ "once_cell",
+ "percent-encoding 2.2.0",
  "pin-project-lite",
  "rustls",
  "rustls-native-certs",
@@ -3166,11 +3453,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tokio-util 0.7.3",
+ "tokio-util 0.7.7",
  "tower-service",
- "url 2.2.2",
+ "url 2.3.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg 0.10.1",
@@ -3208,14 +3496,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
 dependencies = [
  "byteorder",
- "digest 0.10.3",
+ "digest 0.10.6",
  "num-bigint-dig",
  "num-integer",
  "num-iter",
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "smallvec",
  "subtle",
  "zeroize",
@@ -3223,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3235,15 +3523,16 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
  "rustc_version",
- "syn 1.0.99",
+ "syn 1.0.107",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3252,9 +3541,9 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50162d19404029c1ceca6f6980fe40d45c8b369f6f44446fa14bb39573b5bb9"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "blake2b_simd",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
  "crossbeam-utils",
 ]
 
@@ -3268,7 +3557,7 @@ dependencies = [
  "libc",
  "rand 0.3.23",
  "rustc-serialize",
- "time 0.1.44",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -3312,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b323592e3164322f5b193dc4302e4e36cd8d37158a712d664efae1a5c2791700"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -3336,11 +3625,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3363,9 +3652,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "saphir"
@@ -3385,7 +3674,7 @@ dependencies = [
  "mime_guess",
  "nom 6.2.1",
  "parking_lot 0.11.2",
- "percent-encoding 2.1.0",
+ "percent-encoding 2.2.0",
  "regex 1.4.6",
  "saphir-cookie",
  "saphir_macro",
@@ -3405,7 +3694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebbfddbcede862061268cdcf2657ebb430d139d33d82932f0f7accc3a78bff74"
 dependencies = [
  "chrono",
- "time 0.1.44",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -3414,19 +3703,18 @@ version = "2.1.1"
 source = "git+https://github.com/CBenoit/saphir?branch=hyper-update#7d5e0991281805d51a23ccbdd5568b254877c5e2"
 dependencies = [
  "http",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3440,6 +3728,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sct"
@@ -3459,9 +3753,9 @@ checksum = "b3367111e93171f2f51f16fb46201bf6687f9da95eb1d409b6067cbc77af9c9c"
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3472,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3482,44 +3776,44 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.5"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -3552,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.4"
+version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
+checksum = "8fb06d4b6cdaef0e0c51fa881acb721bed3c924cfaa71d9c94a3b771dfdf6567"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3565,24 +3859,24 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -3612,22 +3906,22 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "sha3"
-version = "0.10.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -3657,9 +3951,12 @@ checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "slog"
@@ -3676,7 +3973,7 @@ dependencies = [
  "crossbeam-channel",
  "slog",
  "take_mut",
- "thread_local 1.1.4",
+ "thread_local 1.1.7",
 ]
 
 [[package]]
@@ -3735,30 +4032,30 @@ dependencies = [
  "atty",
  "slog",
  "term",
- "thread_local 1.1.4",
- "time 0.3.7",
+ "thread_local 1.1.7",
+ "time 0.3.19",
 ]
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smol_str"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
+checksum = "fad6c857cbab2627dcf01ec85a623ca4e7dcb5691cbaa3d7fb7653671f0d09c9"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -3813,30 +4110,6 @@ dependencies = [
 
 [[package]]
 name = "sspi"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f48b69fd354a25f5b9d57f0168d601994f3e8e93848fad92d43f1d6fd3b3f7c"
-dependencies = [
- "bitflags",
- "byteorder",
- "cfg-if 0.1.10",
- "chrono",
- "crypto-mac",
- "hmac",
- "lazy_static",
- "md-5 0.9.1",
- "md4 0.9.0",
- "num-derive 0.2.5",
- "num-traits",
- "rand 0.6.5",
- "serde",
- "serde_derive",
- "sha2 0.9.9",
- "winapi",
-]
-
-[[package]]
-name = "sspi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e143b3c7250cf53d843a2fc0bdae895a5b6a3e6ba7c9f77a51ef971d91aa0a5f"
@@ -3846,7 +4119,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "chrono",
  "crypto-mac",
- "hmac",
+ "hmac 0.11.0",
  "kerberos_constants",
  "kerberos_crypto",
  "lazy_static",
@@ -3856,9 +4129,9 @@ dependencies = [
  "num-traits",
  "oid",
  "picky-asn1 0.5.0",
- "picky-asn1-der",
+ "picky-asn1-der 0.3.1",
  "picky-asn1-x509 0.7.1",
- "picky-krb",
+ "picky-krb 0.3.1",
  "portpicker",
  "rand 0.6.5",
  "reqwest",
@@ -3867,8 +4140,49 @@ dependencies = [
  "sha2 0.9.9",
  "sys-info",
  "trust-dns-resolver",
- "url 2.2.2",
+ "url 2.3.1",
  "winapi",
+]
+
+[[package]]
+name = "sspi"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173122cce7fa3693e1429867e3ef78d20907dbeb95f632ad729288b2803e2be2"
+dependencies = [
+ "async-dnssd",
+ "bitflags",
+ "byteorder",
+ "cfg-if 0.1.10",
+ "chrono",
+ "crypto-mac",
+ "futures",
+ "hmac 0.11.0",
+ "lazy_static",
+ "md-5 0.9.1",
+ "md4 0.9.0",
+ "num-bigint-dig",
+ "num-derive 0.2.5",
+ "num-traits",
+ "oid",
+ "picky",
+ "picky-asn1 0.7.1",
+ "picky-asn1-der 0.4.0",
+ "picky-asn1-x509 0.9.0",
+ "picky-krb 0.5.0",
+ "rand 0.8.5",
+ "serde",
+ "serde_derive",
+ "sha1",
+ "sha2 0.9.9",
+ "tokio",
+ "tracing",
+ "url 2.3.1",
+ "uuid 1.3.0",
+ "winapi",
+ "windows",
+ "windows-sys 0.42.0",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3891,17 +4205,6 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -3913,22 +4216,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
  "unicode-ident",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -3937,10 +4231,10 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
- "unicode-xid 0.2.2",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -3955,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.25.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1594a36887d0f70096702bffadfb67dfbfe76ad4bf84605e86157dc9fce9961a"
+checksum = "727220a596b4ca0af040a07091e49f5c105ec8f2592674339a5bf35be592f76e"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -4038,6 +4332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "test-utils"
 version = "0.0.0"
 dependencies = [
@@ -4061,22 +4364,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4090,18 +4393,19 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.4"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -4110,21 +4414,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.7"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
+checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.3"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "timer"
@@ -4137,56 +4452,55 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
 
 [[package]]
 name = "tinyvec_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg 1.1.0",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "tokio-native-tls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
@@ -4221,7 +4535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
 dependencies = [
  "async-stream",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "tokio",
  "tokio-stream",
@@ -4229,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -4251,7 +4565,7 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
  "log",
@@ -4261,11 +4575,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -4275,24 +4589,24 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tower-service"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -4307,26 +4621,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.7",
+ "time 0.3.19",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4345,19 +4659,19 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term",
  "matchers",
+ "nu-ansi-term",
  "once_cell",
  "parking_lot 0.12.1",
  "regex 1.4.6",
  "sharded-slab",
  "smallvec",
- "thread_local 1.1.4",
- "time 0.3.7",
+ "thread_local 1.1.7",
+ "time 0.3.19",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4399,7 +4713,7 @@ dependencies = [
  "thiserror",
  "tinyvec",
  "tokio",
- "url 2.2.2",
+ "url 2.3.1",
 ]
 
 [[package]]
@@ -4424,54 +4738,60 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "byteorder",
- "bytes 1.3.0",
+ "bytes 1.4.0",
  "http",
  "httparse",
  "log",
  "native-tls",
  "rand 0.8.5",
  "rustls",
- "sha-1",
+ "sha1",
  "thiserror",
- "url 2.2.2",
+ "url 2.3.1",
  "utf-8",
  "webpki",
 ]
 
 [[package]]
 name = "typed-builder"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
+checksum = "6179333b981641242a768f30f371c9baccbfcc03749627000c500ab88bf4528b"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85f514e095d348c279b1e5cd76795082cf15bd59b93207832abe0b1d8fed236"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -4484,36 +4804,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.19"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -4523,9 +4837,9 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -4533,15 +4847,15 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "subtle",
 ]
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "unsigned-varint"
@@ -4557,19 +4871,18 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "2.5.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
- "base64 0.13.0",
- "chunked_transfer",
+ "base64 0.13.1",
  "flate2",
  "log",
  "once_cell",
  "rustls",
  "serde",
  "serde_json",
- "url 2.2.2",
+ "url 2.3.1",
  "webpki",
  "webpki-roots",
 ]
@@ -4587,14 +4900,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna 0.2.3",
- "matches",
- "percent-encoding 2.1.0",
+ "idna 0.3.0",
+ "percent-encoding 2.2.0",
  "serde",
 ]
 
@@ -4612,27 +4924,28 @@ checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "utoipa"
-version = "2.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035e5a4314681e845a8d2f44d19aa1974384024b1129fd492cbdb8abe1b1479"
+checksum = "a15f6da6a2b471134ca44b7d18e8a76d73035cf8b3ed24c4dd5ca6a63aa439c5"
 dependencies = [
  "indexmap",
  "serde",
- "serde_yaml 0.9.4",
+ "serde_json",
+ "serde_yaml 0.9.17",
  "utoipa-gen",
 ]
 
 [[package]]
 name = "utoipa-gen"
-version = "2.0.1"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d62661083d9a2471687ac93ea3e2638e41ec26a618d32154b584102f6fecf5"
+checksum = "6f2e33027986a4707b3f5c37ed01b33d0e5a53da30204b52ff18f80600f1d0ec"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
- "uuid 1.1.2",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
+ "uuid 1.3.0",
 ]
 
 [[package]]
@@ -4647,9 +4960,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
@@ -4732,9 +5045,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4742,24 +5055,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4769,38 +5082,51 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
- "quote 1.0.21",
+ "quote 1.0.23",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4818,9 +5144,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.2"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -4864,96 +5190,143 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.32.0"
+name = "windows"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
 dependencies = [
- "windows_aarch64_msvc 0.32.0",
- "windows_i686_gnu 0.32.0",
- "windows_i686_msvc 0.32.0",
- "windows_x86_64_gnu 0.32.0",
- "windows_x86_64_msvc 0.32.0",
+ "windows_aarch64_msvc 0.39.0",
+ "windows_i686_gnu 0.39.0",
+ "windows_i686_msvc 0.39.0",
+ "windows_x86_64_gnu 0.39.0",
+ "windows_x86_64_msvc 0.39.0",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.32.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"
@@ -4993,7 +5366,7 @@ dependencies = [
  "nom 5.1.2",
  "num-bigint 0.2.6",
  "rusticata-macros 2.1.0",
- "time 0.1.44",
+ "time 0.1.45",
 ]
 
 [[package]]
@@ -5003,7 +5376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
  "asn1-rs",
- "base64 0.13.0",
+ "base64 0.13.1",
  "data-encoding",
  "der-parser 8.1.0",
  "lazy_static",
@@ -5011,7 +5384,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros 4.1.0",
  "thiserror",
- "time 0.3.7",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -5038,8 +5411,8 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
- "syn 1.0.99",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "synstructure",
 ]

--- a/crates/devolutions-gateway-generators/Cargo.toml
+++ b/crates/devolutions-gateway-generators/Cargo.toml
@@ -7,6 +7,6 @@ publish = false
 
 [dependencies]
 devolutions-gateway = { path = "../../devolutions-gateway" }
-proptest = "1.0.0"
-uuid = "1.1.2"
-serde = { version = "1.0.143", features = ["derive"] }
+proptest = "1.1.0"
+uuid = "1.3.0"
+serde = { version = "1.0.152", features = ["derive"] }

--- a/crates/jet-proto/Cargo.toml
+++ b/crates/jet-proto/Cargo.toml
@@ -8,22 +8,22 @@ publish = false
 [dependencies]
 log = "0.4.17"
 byteorder = "1.4.3"
-uuid = { version = "1.1.2", features = ["v4"] }
-httparse = "1.7.1"
-http = "0.2.8"
+uuid = { version = "1.3.0", features = ["v4"] }
+httparse = "1.8.0"
+http = "0.2.9"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-bytes = "1.2.1"
-sspi = "0.3.2"
-ureq = { version = "2.5.0", features = ["json"] }
-url = "2.2.2"
+bytes = "1.4.0"
+sspi = "0.6.0"
+ureq = { version = "2.6.2", features = ["json"] }
+url = "2.3.1"
 x509-parser = "0.14.0"
 exitcode = "1.1.2"
 tempfile = "3.3.0"
 hex-literal = "0.3.4"
 ironrdp = { version = "0.4", git = "https://github.com/Devolutions/IronRDP", rev = "ca53209c84c55b41" }
 tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration", "tls12"] }
-serde = "1.0.143"
-serde_derive = "1.0.143"
-serde_json = "1.0.83"
+serde = "1.0.152"
+serde_derive = "1.0.152"
+serde_json = "1.0.93"

--- a/crates/jmux-generators/Cargo.toml
+++ b/crates/jmux-generators/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 jmux-proto = { path = "../jmux-proto" }
-proptest = "1.0.0"
+proptest = "1.1.0"

--- a/crates/jmux-proto/Cargo.toml
+++ b/crates/jmux-proto/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1.2.1"
-smol_str = "0.1.23"
+bytes = "1.4.0"
+smol_str = "0.1.24"
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.1.0"
 jmux-generators = { path = "../jmux-generators" }

--- a/crates/jmux-proxy/Cargo.toml
+++ b/crates/jmux-proxy/Cargo.toml
@@ -12,16 +12,16 @@ publish = false
 jmux-proto = { path = "../jmux-proto" }
 
 # async
-tokio = { version = "1.20.1", features = ["net", "rt", "io-util", "macros"] }
-tokio-util = { version = "0.7.3", features = ["codec"] }
-futures-util = { version = "0.3.21", features = ["sink"] }
+tokio = { version = "1.25.0", features = ["net", "rt", "io-util", "macros"] }
+tokio-util = { version = "0.7.7", features = ["codec"] }
+futures-util = { version = "0.3.26", features = ["sink"] }
 
 # error handling
-anyhow = "1.0.61"
+anyhow = "1.0.69"
 
 # logging
-tracing = "0.1.36"
+tracing = "0.1.37"
 
 # codec implementation
-bytes = "1.2.1"
+bytes = "1.4.0"
 bitvec = "1.0.1"

--- a/crates/mock-net/Cargo.toml
+++ b/crates/mock-net/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Devolutions Inc. <infos@devolutions.net>"]
 publish = false
 
 [dependencies]
-tokio = { version = "1.20.1", features = ["io-util", "sync"] }
+tokio = { version = "1.25.0", features = ["io-util", "sync"] }
 loom = { version = "0.5.6", features = ["futures", "checkpoint"] }
 lazy_static = "1.4.0"
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["rt"] }
+tokio = { version = "1.25.0", features = ["rt"] }

--- a/crates/proxy-generators/Cargo.toml
+++ b/crates/proxy-generators/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 proxy-types = { path = "../proxy-types" }
-proptest = "1.0.0"
+proptest = "1.1.0"

--- a/crates/proxy-http/Cargo.toml
+++ b/crates/proxy-http/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 
 [dependencies]
 proxy-types = { path = "../proxy-types" }
-tokio = { version = "1.20.1", features = ["io-util"] }
+tokio = { version = "1.25.0", features = ["io-util"] }
 pin-project-lite = "0.2.9"
-bytes = "1.2.1"
+bytes = "1.4.0"
 
 [dev-dependencies]
-proptest = "1.0.0"
+proptest = "1.1.0"
 proxy-generators = { path = "../proxy-generators" }

--- a/crates/proxy-server/Cargo.toml
+++ b/crates/proxy-server/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 proxy-socks = { path = "../proxy-socks" }
 proxy-http = { path = "../proxy-http" }
 proxy-types = { path = "../proxy-types" }
-tokio = { version = "1.20.1", features = ["rt", "net", "rt-multi-thread", "macros"] }
+tokio = { version = "1.25.0", features = ["rt", "net", "rt-multi-thread", "macros"] }

--- a/crates/proxy-socks/Cargo.toml
+++ b/crates/proxy-socks/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 
 [dependencies]
 proxy-types = { path = "../proxy-types" }
-tokio = { version = "1.20.1", features = ["io-util"] }
+tokio = { version = "1.25.0", features = ["io-util"] }
 
 [dev-dependencies]
-tokio = { version = "1.20.1", features = ["rt", "macros"] }
+tokio = { version = "1.25.0", features = ["rt", "macros"] }
 tokio-test = "0.4.2"
-proptest = "1.0.0"
+proptest = "1.1.0"
 proxy-generators = { path = "../proxy-generators" }

--- a/crates/proxy-tester/Cargo.toml
+++ b/crates/proxy-tester/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-tokio = { version = "1.20.1", features = ["rt", "net"] }
+tokio = { version = "1.25.0", features = ["rt", "net"] }
 proxy-http = { path = "../proxy-http" }
 proxy-socks = { path = "../proxy-socks" }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 
 [dependencies]
 transport = { path = "../transport" }
-tokio = { version = "1.20.1", features = ["io-util"] }
-tokio-tungstenite = "0.17.2"
-futures-util = "0.3.21"
-proptest = "1.0.0"
-anyhow = "1.0.61"
+tokio = { version = "1.25.0", features = ["io-util"] }
+tokio-tungstenite = "0.18.0"
+futures-util = "0.3.26"
+proptest = "1.1.0"
+anyhow = "1.0.69"
 portpicker = "0.1.1"

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -8,18 +8,18 @@ publish = false
 [dependencies]
 
 # async
-tokio = "1.20.1"
-tokio-tungstenite = "0.17.2"
+tokio = "1.25.0"
+tokio-tungstenite = "0.18.0"
 tokio-rustls = "0.23.4"
-futures-util = "0.3.21"
+futures-util = "0.3.26"
 
 # error handling
-anyhow = "1.0.61"
+anyhow = "1.0.69"
 
 # Safe pin projection
 pin-project-lite = "0.2.9"
 
 [dev-dependencies]
 test-utils = { path = "../test-utils" }
-tokio = { version = "1.20.1", features = ["rt", "macros"] }
-proptest = "1.0.0"
+tokio = { version = "1.25.0", features = ["rt", "macros"] }
+proptest = "1.1.0"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -22,90 +22,90 @@ sogar-core = { version = "0.3", git = "https://github.com/Devolutions/sogar", br
 ironrdp = { version = "0.4.1", git = "https://github.com/Devolutions/IronRDP", rev = "aa85fe4869aad3a1e1827" }
 ironrdp-devolutions-gateway = { version = "0.1.0", git = "https://github.com/Devolutions/IronRDP", rev = "898fb8d40a3c84" }
 ceviche = "0.5.2"
-picky-krb = "0.3.1"
+picky-krb = "0.6.0"
 
 # serialization
-serde = "1.0.143"
-serde_derive = "1.0.143"
-serde_json = "1.0.83"
+serde = "1.0.152"
+serde_derive = "1.0.152"
+serde_json = "1.0.93"
 
 # utils, misc
 hostname = "0.3.1"
-camino = { version = "1.0.9", features = ["serde1"] }
-smol_str = "0.1.23"
-nonempty = "0.8.0"
+camino = { version = "1.1.2", features = ["serde1"] }
+smol_str = "0.1.24"
+nonempty = "0.8.1"
 tap = "1.0.1"
 byteorder = "1.4.3"
 lazy_static = "1.4.0"
-bytes = "1.3"
+bytes = "1.4"
 cfg-if = "1.0.0"
-url = { version = "2.2.2", features = ["serde"] }
+url = { version = "2.3.1", features = ["serde"] }
 tempfile = "3.3.0"
-indexmap = "1.9.1"
-uuid = { version = "1.1.2", features = ["v4", "serde"] }
-chrono = { version = "0.4.21", features = ["serde"] } # TODO: switch to `time`
+indexmap = "1.9.2"
+uuid = { version = "1.3.0", features = ["v4", "serde"] }
+chrono = { version = "0.4.23", features = ["serde"] } # TODO: switch to `time`
 parking_lot = "0.12.1"
-anyhow = "1.0.61"
-thiserror = "1.0.37"
-typed-builder = "0.10.0"
+anyhow = "1.0.69"
+thiserror = "1.0.38"
+typed-builder = "0.12.0"
 # Unicode case folding comparisons
-focaccia = "1.2.0"
+focaccia = "1.3.1"
 backoff = "0.4.0"
 
 # security, crypto…
 zeroize = { version = "1.5.7", features = ["derive"] }
 rust-argon2 = "1.0.0"
-picky = { version = "7.0.0-rc.3", default-features = false, features = ["jose", "x509"] }
-sspi = "0.3.2"
+picky = { version = "7.0.0-rc.4", default-features = false, features = ["jose", "x509"] }
+sspi = "0.6.0"
 # evaluate use of ring in our codebase
 ring = "0.16.20"
 # (unrequired if using `axum`)
-sha1 = "0.10.1"
+sha1 = "0.10.5"
 # (unrequired if using `axum`)
-base64 = "0.13.0"
-multihash = "0.16.3"
+base64 = "0.21.0"
+multihash = "0.18.0"
 multibase = "0.9.1"
 
 # logging
-tracing = "0.1.36"
-tracing-subscriber = { version = "0.3.15", features = ["env-filter", "parking_lot", "smallvec", "local-time", "tracing-log"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "parking_lot", "smallvec", "local-time", "tracing-log"] }
 tracing-appender = "0.2.2"
 # TODO: consider `tracing-error` crate
 
 # async, futures…
-tokio = { version = "1.20.1", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot"] }
-tokio-util = { version = "0.7.3", features = ["codec"] }
-tokio-tungstenite = "0.17.2"
+tokio = { version = "1.25.0", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot"] }
+tokio-util = { version = "0.7.7", features = ["codec"] }
+tokio-tungstenite = "0.18.0"
 tokio-rustls = { version = "0.23.4", features = ["dangerous_configuration", "tls12"] }
-futures = "0.3.21"
+futures = "0.3.26"
 
 # Safe pin projection
 pin-project-lite = "0.2.9"
 
 # http
-hyper = "0.14.20"
+hyper = "0.14.24"
 # NOTE: maybe directly use hyper (we already use hyper)
-reqwest = "0.11.11"
-http = "0.2.8"
+reqwest = "0.11.14"
+http = "0.2.9"
 # FIXME: update once next saphir version is published or use `axum`/`warp`
 saphir = { version = "2.8", default-features = false, features = ["json", "macro", "form", "operation", "file"], git = "https://github.com/CBenoit/saphir", branch = "hyper-update" }
 # for KDC proxy
 portpicker = "0.1.1"
 # OpenAPI generator
-utoipa = { version = "2.0.1", default-features = false, features = ["uuid", "chrono"], optional = true }
+utoipa = { version = "3.0.3", default-features = false, features = ["uuid", "chrono"], optional = true }
 
 # plugins
 dlopen = "0.1.8"
 dlopen_derive = "0.1.4"
 # Dependencies required for PCAP support (FIXME: should we keep that built-in?)
-pcap-file = "1.1.1"
+pcap-file = "2.0.0"
 packet = { git = "https://github.com/fdubois1/rust-packet.git" }
 
 [target.'cfg(windows)'.build-dependencies]
-embed-resource = "1.7.3"
+embed-resource = "1.8.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"
-proptest = "1.0.0"
-rstest = "0.15.0"
+proptest = "1.1.0"
+rstest = "0.16.0"
 devolutions-gateway-generators = { path = "../crates/devolutions-gateway-generators" }

--- a/devolutions-gateway/openapi/doc/index.adoc
+++ b/devolutions-gateway/openapi/doc/index.adoc
@@ -49,7 +49,7 @@ Modifies configuration
 
 ===== Description
 
-Modifies configuration 
+Modifies configuration
 
 
 // markup not found, no include::{specDir}jet/config/PATCH/spec.adoc[opts=optional]
@@ -152,7 +152,7 @@ Retrieves server's clock in order to diagnose clock drifting.
 
 ===== Description
 
-Retrieves server's clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as `nbf` and `exp`. 
+Retrieves server's clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as `nbf` and `exp`.
 
 
 // markup not found, no include::{specDir}jet/diagnostics/clock/GET/spec.adoc[opts=optional]
@@ -205,7 +205,7 @@ Retrieves configuration.
 
 ===== Description
 
-Retrieves configuration. 
+Retrieves configuration.
 
 
 // markup not found, no include::{specDir}jet/diagnostics/configuration/GET/spec.adoc[opts=optional]
@@ -280,7 +280,7 @@ Retrieves latest logs.
 
 ===== Description
 
-Retrieves latest logs. 
+Retrieves latest logs.
 
 
 // markup not found, no include::{specDir}jet/diagnostics/logs/GET/spec.adoc[opts=optional]
@@ -366,7 +366,7 @@ Performs a health check
 
 ===== Description
 
-Performs a health check 
+Performs a health check
 
 
 // markup not found, no include::{specDir}jet/health/GET/spec.adoc[opts=optional]
@@ -429,7 +429,7 @@ Retrieves current JRL (Json Revocation List) info
 
 ===== Description
 
-Retrieves current JRL (Json Revocation List) info 
+Retrieves current JRL (Json Revocation List) info
 
 
 // markup not found, no include::{specDir}jet/jrl/info/GET/spec.adoc[opts=optional]
@@ -509,7 +509,7 @@ Updates JRL (Json Revocation List) using a JRL token
 
 ===== Description
 
-Updates JRL (Json Revocation List) using a JRL token 
+Updates JRL (Json Revocation List) using a JRL token
 
 
 // markup not found, no include::{specDir}jet/jrl/POST/spec.adoc[opts=optional]
@@ -592,7 +592,7 @@ Lists running sessions
 
 ===== Description
 
-Lists running sessions 
+Lists running sessions
 
 
 // markup not found, no include::{specDir}jet/sessions/GET/spec.adoc[opts=optional]
@@ -672,7 +672,7 @@ Terminate forcefully a running session
 
 ===== Description
 
-Terminate forcefully a running session 
+Terminate forcefully a running session
 
 
 // markup not found, no include::{specDir}jet/session/\{id\}/terminate/POST/spec.adoc[opts=optional]
@@ -847,7 +847,7 @@ Service configuration diagnostic
 | listeners
 | X
 | List  of <<ListenerUrls>>
-| 
+| Listeners configured on this instance
 | 
 
 | version

--- a/devolutions-gateway/openapi/dotnet-client/docs/ConfigApi.md
+++ b/devolutions-gateway/openapi/dotnet-client/docs/ConfigApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://localhost*
 
 Modifies configuration
 
-Modifies configuration 
+Modifies configuration
 
 ### Example
 ```csharp

--- a/devolutions-gateway/openapi/dotnet-client/docs/ConfigDiagnostic.md
+++ b/devolutions-gateway/openapi/dotnet-client/docs/ConfigDiagnostic.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Hostname** | **string** | This Gateway&#39;s hostname | 
 **Id** | **Guid** | This Gateway&#39;s unique ID | [optional] 
-**Listeners** | [**List&lt;ListenerUrls&gt;**](ListenerUrls.md) |  | 
+**Listeners** | [**List&lt;ListenerUrls&gt;**](ListenerUrls.md) | Listeners configured on this instance | 
 **_Version** | **string** | Gateway service version | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/devolutions-gateway/openapi/dotnet-client/docs/DiagnosticsApi.md
+++ b/devolutions-gateway/openapi/dotnet-client/docs/DiagnosticsApi.md
@@ -14,7 +14,7 @@ All URIs are relative to *http://localhost*
 
 Retrieves server's clock in order to diagnose clock drifting.
 
-Retrieves server's clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as `nbf` and `exp`. 
+Retrieves server's clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as `nbf` and `exp`.
 
 ### Example
 ```csharp
@@ -100,7 +100,7 @@ No authorization required
 
 Retrieves configuration.
 
-Retrieves configuration. 
+Retrieves configuration.
 
 ### Example
 ```csharp
@@ -192,7 +192,7 @@ This endpoint does not need any parameter.
 
 Retrieves latest logs.
 
-Retrieves latest logs. 
+Retrieves latest logs.
 
 ### Example
 ```csharp

--- a/devolutions-gateway/openapi/dotnet-client/docs/HealthApi.md
+++ b/devolutions-gateway/openapi/dotnet-client/docs/HealthApi.md
@@ -12,7 +12,7 @@ All URIs are relative to *http://localhost*
 
 Performs a health check
 
-Performs a health check 
+Performs a health check
 
 ### Example
 ```csharp

--- a/devolutions-gateway/openapi/dotnet-client/docs/JrlApi.md
+++ b/devolutions-gateway/openapi/dotnet-client/docs/JrlApi.md
@@ -13,7 +13,7 @@ All URIs are relative to *http://localhost*
 
 Retrieves current JRL (Json Revocation List) info
 
-Retrieves current JRL (Json Revocation List) info 
+Retrieves current JRL (Json Revocation List) info
 
 ### Example
 ```csharp
@@ -106,7 +106,7 @@ This endpoint does not need any parameter.
 
 Updates JRL (Json Revocation List) using a JRL token
 
-Updates JRL (Json Revocation List) using a JRL token 
+Updates JRL (Json Revocation List) using a JRL token
 
 ### Example
 ```csharp

--- a/devolutions-gateway/openapi/dotnet-client/docs/SessionsApi.md
+++ b/devolutions-gateway/openapi/dotnet-client/docs/SessionsApi.md
@@ -13,7 +13,7 @@ All URIs are relative to *http://localhost*
 
 Lists running sessions
 
-Lists running sessions 
+Lists running sessions
 
 ### Example
 ```csharp
@@ -106,7 +106,7 @@ This endpoint does not need any parameter.
 
 Terminate forcefully a running session
 
-Terminate forcefully a running session 
+Terminate forcefully a running session
 
 ### Example
 ```csharp

--- a/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/ConfigApi.cs
+++ b/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/ConfigApi.cs
@@ -31,7 +31,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Modifies configuration
         /// </summary>
         /// <remarks>
-        /// Modifies configuration 
+        /// Modifies configuration
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -43,7 +43,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Modifies configuration
         /// </summary>
         /// <remarks>
-        /// Modifies configuration 
+        /// Modifies configuration
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -63,7 +63,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Modifies configuration
         /// </summary>
         /// <remarks>
-        /// Modifies configuration 
+        /// Modifies configuration
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -76,7 +76,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Modifies configuration
         /// </summary>
         /// <remarks>
-        /// Modifies configuration 
+        /// Modifies configuration
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -205,7 +205,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Modifies configuration Modifies configuration 
+        /// Modifies configuration Modifies configuration
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -217,7 +217,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Modifies configuration Modifies configuration 
+        /// Modifies configuration Modifies configuration
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -280,7 +280,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Modifies configuration Modifies configuration 
+        /// Modifies configuration Modifies configuration
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>
@@ -293,7 +293,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Modifies configuration Modifies configuration 
+        /// Modifies configuration Modifies configuration
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="configPatch">JSON-encoded configuration patch</param>

--- a/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/DiagnosticsApi.cs
+++ b/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/DiagnosticsApi.cs
@@ -31,7 +31,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves server&#39;s clock in order to diagnose clock drifting.
         /// </summary>
         /// <remarks>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -42,7 +42,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves server&#39;s clock in order to diagnose clock drifting.
         /// </summary>
         /// <remarks>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -52,7 +52,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves configuration.
         /// </summary>
         /// <remarks>
-        /// Retrieves configuration. 
+        /// Retrieves configuration.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -63,7 +63,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves configuration.
         /// </summary>
         /// <remarks>
-        /// Retrieves configuration. 
+        /// Retrieves configuration.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -73,7 +73,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves latest logs.
         /// </summary>
         /// <remarks>
-        /// Retrieves latest logs. 
+        /// Retrieves latest logs.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -84,7 +84,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves latest logs.
         /// </summary>
         /// <remarks>
-        /// Retrieves latest logs. 
+        /// Retrieves latest logs.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -103,7 +103,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves server&#39;s clock in order to diagnose clock drifting.
         /// </summary>
         /// <remarks>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -115,7 +115,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves server&#39;s clock in order to diagnose clock drifting.
         /// </summary>
         /// <remarks>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -126,7 +126,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves configuration.
         /// </summary>
         /// <remarks>
-        /// Retrieves configuration. 
+        /// Retrieves configuration.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -138,7 +138,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves configuration.
         /// </summary>
         /// <remarks>
-        /// Retrieves configuration. 
+        /// Retrieves configuration.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -149,7 +149,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves latest logs.
         /// </summary>
         /// <remarks>
-        /// Retrieves latest logs. 
+        /// Retrieves latest logs.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -161,7 +161,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves latest logs.
         /// </summary>
         /// <remarks>
-        /// Retrieves latest logs. 
+        /// Retrieves latest logs.
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -289,7 +289,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -301,7 +301,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -350,7 +350,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -363,7 +363,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+        /// Retrieves server&#39;s clock in order to diagnose clock drifting. Retrieves server&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -415,7 +415,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves configuration. Retrieves configuration. 
+        /// Retrieves configuration. Retrieves configuration.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -427,7 +427,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves configuration. Retrieves configuration. 
+        /// Retrieves configuration. Retrieves configuration.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -482,7 +482,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves configuration. Retrieves configuration. 
+        /// Retrieves configuration. Retrieves configuration.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -495,7 +495,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves configuration. Retrieves configuration. 
+        /// Retrieves configuration. Retrieves configuration.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -553,7 +553,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves latest logs. Retrieves latest logs. 
+        /// Retrieves latest logs. Retrieves latest logs.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -565,7 +565,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves latest logs. Retrieves latest logs. 
+        /// Retrieves latest logs. Retrieves latest logs.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -620,7 +620,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves latest logs. Retrieves latest logs. 
+        /// Retrieves latest logs. Retrieves latest logs.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -633,7 +633,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves latest logs. Retrieves latest logs. 
+        /// Retrieves latest logs. Retrieves latest logs.
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>

--- a/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/HealthApi.cs
+++ b/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/HealthApi.cs
@@ -31,7 +31,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Performs a health check
         /// </summary>
         /// <remarks>
-        /// Performs a health check 
+        /// Performs a health check
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -42,7 +42,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Performs a health check
         /// </summary>
         /// <remarks>
-        /// Performs a health check 
+        /// Performs a health check
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -61,7 +61,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Performs a health check
         /// </summary>
         /// <remarks>
-        /// Performs a health check 
+        /// Performs a health check
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -73,7 +73,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Performs a health check
         /// </summary>
         /// <remarks>
-        /// Performs a health check 
+        /// Performs a health check
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -201,7 +201,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Performs a health check Performs a health check 
+        /// Performs a health check Performs a health check
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -213,7 +213,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Performs a health check Performs a health check 
+        /// Performs a health check Performs a health check
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -262,7 +262,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Performs a health check Performs a health check 
+        /// Performs a health check Performs a health check
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -275,7 +275,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Performs a health check Performs a health check 
+        /// Performs a health check Performs a health check
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>

--- a/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/JrlApi.cs
+++ b/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/JrlApi.cs
@@ -31,7 +31,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <remarks>
-        /// Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -42,7 +42,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <remarks>
-        /// Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -52,7 +52,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <remarks>
-        /// Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -63,7 +63,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <remarks>
-        /// Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -82,7 +82,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <remarks>
-        /// Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -94,7 +94,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <remarks>
-        /// Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -105,7 +105,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <remarks>
-        /// Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -117,7 +117,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <remarks>
-        /// Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -245,7 +245,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -257,7 +257,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -312,7 +312,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -325,7 +325,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info 
+        /// Retrieves current JRL (Json Revocation List) info Retrieves current JRL (Json Revocation List) info
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -383,7 +383,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -394,7 +394,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -448,7 +448,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -460,7 +460,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token 
+        /// Updates JRL (Json Revocation List) using a JRL token Updates JRL (Json Revocation List) using a JRL token
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>

--- a/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/SessionsApi.cs
+++ b/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Api/SessionsApi.cs
@@ -31,7 +31,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Lists running sessions
         /// </summary>
         /// <remarks>
-        /// Lists running sessions 
+        /// Lists running sessions
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -42,7 +42,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Lists running sessions
         /// </summary>
         /// <remarks>
-        /// Lists running sessions 
+        /// Lists running sessions
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -52,7 +52,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Terminate forcefully a running session
         /// </summary>
         /// <remarks>
-        /// Terminate forcefully a running session 
+        /// Terminate forcefully a running session
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -64,7 +64,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Terminate forcefully a running session
         /// </summary>
         /// <remarks>
-        /// Terminate forcefully a running session 
+        /// Terminate forcefully a running session
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -84,7 +84,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Lists running sessions
         /// </summary>
         /// <remarks>
-        /// Lists running sessions 
+        /// Lists running sessions
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -96,7 +96,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Lists running sessions
         /// </summary>
         /// <remarks>
-        /// Lists running sessions 
+        /// Lists running sessions
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -107,7 +107,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Terminate forcefully a running session
         /// </summary>
         /// <remarks>
-        /// Terminate forcefully a running session 
+        /// Terminate forcefully a running session
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -120,7 +120,7 @@ namespace Devolutions.Gateway.Client.Api
         /// Terminate forcefully a running session
         /// </summary>
         /// <remarks>
-        /// Terminate forcefully a running session 
+        /// Terminate forcefully a running session
         /// </remarks>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -249,7 +249,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Lists running sessions Lists running sessions 
+        /// Lists running sessions Lists running sessions
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -261,7 +261,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Lists running sessions Lists running sessions 
+        /// Lists running sessions Lists running sessions
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -316,7 +316,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Lists running sessions Lists running sessions 
+        /// Lists running sessions Lists running sessions
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -329,7 +329,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Lists running sessions Lists running sessions 
+        /// Lists running sessions Lists running sessions
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="operationIndex">Index associated with the operation.</param>
@@ -387,7 +387,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Terminate forcefully a running session Terminate forcefully a running session 
+        /// Terminate forcefully a running session Terminate forcefully a running session
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -399,7 +399,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Terminate forcefully a running session Terminate forcefully a running session 
+        /// Terminate forcefully a running session Terminate forcefully a running session
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -455,7 +455,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Terminate forcefully a running session Terminate forcefully a running session 
+        /// Terminate forcefully a running session Terminate forcefully a running session
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>
@@ -468,7 +468,7 @@ namespace Devolutions.Gateway.Client.Api
         }
 
         /// <summary>
-        /// Terminate forcefully a running session Terminate forcefully a running session 
+        /// Terminate forcefully a running session Terminate forcefully a running session
         /// </summary>
         /// <exception cref="Devolutions.Gateway.Client.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">Session / association ID of the session to terminate</param>

--- a/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Model/ConfigDiagnostic.cs
+++ b/devolutions-gateway/openapi/dotnet-client/src/Devolutions.Gateway.Client/Model/ConfigDiagnostic.cs
@@ -42,7 +42,7 @@ namespace Devolutions.Gateway.Client.Model
         /// </summary>
         /// <param name="hostname">This Gateway&#39;s hostname (required).</param>
         /// <param name="id">This Gateway&#39;s unique ID.</param>
-        /// <param name="listeners">listeners (required).</param>
+        /// <param name="listeners">Listeners configured on this instance (required).</param>
         /// <param name="version">Gateway service version (required).</param>
         public ConfigDiagnostic(string hostname = default(string), Guid id = default(Guid), List<ListenerUrls> listeners = default(List<ListenerUrls>), string version = default(string))
         {
@@ -82,8 +82,9 @@ namespace Devolutions.Gateway.Client.Model
         public Guid Id { get; set; }
 
         /// <summary>
-        /// Gets or Sets Listeners
+        /// Listeners configured on this instance
         /// </summary>
+        /// <value>Listeners configured on this instance</value>
         [DataMember(Name = "listeners", IsRequired = true, EmitDefaultValue = false)]
         public List<ListenerUrls> Listeners { get; set; }
 

--- a/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Controllers/SubscriberApi.cs
+++ b/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Controllers/SubscriberApi.cs
@@ -28,7 +28,7 @@ namespace Devolutions.Gateway.Subscriber.Controllers
         /// <summary>
         /// Process a message originating from a Devolutions Gateway instance
         /// </summary>
-        /// <remarks>Process a message originating from a Devolutions Gateway instance </remarks>
+        /// <remarks>Process a message originating from a Devolutions Gateway instance</remarks>
         /// <param name="subscriberMessage">Message</param>
         /// <response code="200">Message received and processed successfully</response>
         /// <response code="400">Bad message</response>

--- a/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Models/SubscriberMessage.cs
+++ b/devolutions-gateway/openapi/dotnet-subscriber/src/Devolutions.Gateway.Subscriber/Models/SubscriberMessage.cs
@@ -40,8 +40,9 @@ namespace Devolutions.Gateway.Subscriber.Models
         public SubscriberSessionInfo Session { get; set; }
 
         /// <summary>
-        /// Gets or Sets SessionList
+        /// Session list associated to this event
         /// </summary>
+        /// <value>Session list associated to this event</value>
         [DataMember(Name="session_list", EmitDefaultValue=false)]
         public List<SubscriberSessionInfo> SessionList { get; set; }
 

--- a/devolutions-gateway/openapi/gateway-api.yaml
+++ b/devolutions-gateway/openapi/gateway-api.yaml
@@ -14,8 +14,7 @@ paths:
       tags:
       - Config
       summary: Modifies configuration
-      description: |
-        Modifies configuration
+      description: Modifies configuration
       operationId: PatchConfig
       requestBody:
         description: JSON-encoded configuration patch
@@ -44,7 +43,7 @@ paths:
       tags:
       - Diagnostics
       summary: Retrieves server's clock in order to diagnose clock drifting.
-      description: |
+      description: |-
         Retrieves server's clock in order to diagnose clock drifting.
 
         Clock drift is an issue for token validation because of claims such as `nbf` and `exp`.
@@ -62,8 +61,7 @@ paths:
       tags:
       - Diagnostics
       summary: Retrieves configuration.
-      description: |
-        Retrieves configuration.
+      description: Retrieves configuration.
       operationId: GetConfigurationDiagnostic
       responses:
         '200':
@@ -87,8 +85,7 @@ paths:
       tags:
       - Diagnostics
       summary: Retrieves latest logs.
-      description: |
-        Retrieves latest logs.
+      description: Retrieves latest logs.
       operationId: GetLogs
       responses:
         '200':
@@ -114,8 +111,7 @@ paths:
       tags:
       - Health
       summary: Performs a health check
-      description: |
-        Performs a health check
+      description: Performs a health check
       operationId: GetHealth
       responses:
         '200':
@@ -132,8 +128,7 @@ paths:
       tags:
       - Jrl
       summary: Updates JRL (Json Revocation List) using a JRL token
-      description: |
-        Updates JRL (Json Revocation List) using a JRL token
+      description: Updates JRL (Json Revocation List) using a JRL token
       operationId: UpdateJrl
       responses:
         '200':
@@ -154,8 +149,7 @@ paths:
       tags:
       - Jrl
       summary: Retrieves current JRL (Json Revocation List) info
-      description: |
-        Retrieves current JRL (Json Revocation List) info
+      description: Retrieves current JRL (Json Revocation List) info
       operationId: GetJrlInfo
       responses:
         '200':
@@ -181,15 +175,13 @@ paths:
       tags:
       - Sessions
       summary: Terminate forcefully a running session
-      description: |
-        Terminate forcefully a running session
+      description: Terminate forcefully a running session
       operationId: TerminateSession
       parameters:
       - name: id
         in: path
         description: Session / association ID of the session to terminate
         required: true
-        deprecated: false
         schema:
           type: string
           format: uuid
@@ -215,8 +207,7 @@ paths:
       tags:
       - Sessions
       summary: Lists running sessions
-      description: |
-        Lists running sessions
+      description: Lists running sessions
       operationId: GetSessions
       responses:
         '200':
@@ -284,6 +275,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ListenerUrls'
+          description: Listeners configured on this instance
         version:
           type: string
           description: Gateway service version
@@ -393,8 +385,7 @@ components:
         time_to_live:
           type: integer
           format: int64
-          description: Maximum session duration in minutes (0 is used for the infinite
-            duration)
+          description: Maximum session duration in minutes (0 is used for the infinite duration)
     SubProvisionerKey:
       type: object
       required:

--- a/devolutions-gateway/openapi/subscriber-api.yaml
+++ b/devolutions-gateway/openapi/subscriber-api.yaml
@@ -1,8 +1,7 @@
 openapi: 3.0.3
 info:
   title: devolutions-gateway-subscriber
-  description: API a service must implement in order to receive Devolutions Gateway
-    notifications
+  description: API a service must implement in order to receive Devolutions Gateway notifications
   contact:
     name: Devolutions Inc.
     email: infos@devolutions.net
@@ -15,8 +14,7 @@ paths:
       tags:
       - Subscriber
       summary: Process a message originating from a Devolutions Gateway instance
-      description: |
-        Process a message originating from a Devolutions Gateway instance
+      description: Process a message originating from a Devolutions Gateway instance
       operationId: PostMessage
       requestBody:
         description: Message
@@ -56,6 +54,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SubscriberSessionInfo'
+          description: Session list associated to this event
         timestamp:
           type: string
           format: date-time

--- a/devolutions-gateway/openapi/ts-angular-client/api/config.service.ts
+++ b/devolutions-gateway/openapi/ts-angular-client/api/config.service.ts
@@ -89,7 +89,7 @@ export class ConfigService {
 
     /**
      * Modifies configuration
-     * Modifies configuration 
+     * Modifies configuration
      * @param configPatch JSON-encoded configuration patch
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.

--- a/devolutions-gateway/openapi/ts-angular-client/api/diagnostics.service.ts
+++ b/devolutions-gateway/openapi/ts-angular-client/api/diagnostics.service.ts
@@ -91,7 +91,7 @@ export class DiagnosticsService {
 
     /**
      * Retrieves server\&#39;s clock in order to diagnose clock drifting.
-     * Retrieves server\&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;. 
+     * Retrieves server\&#39;s clock in order to diagnose clock drifting.  Clock drift is an issue for token validation because of claims such as &#x60;nbf&#x60; and &#x60;exp&#x60;.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -145,7 +145,7 @@ export class DiagnosticsService {
 
     /**
      * Retrieves configuration.
-     * Retrieves configuration. 
+     * Retrieves configuration.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -206,7 +206,7 @@ export class DiagnosticsService {
 
     /**
      * Retrieves latest logs.
-     * Retrieves latest logs. 
+     * Retrieves latest logs.
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/devolutions-gateway/openapi/ts-angular-client/api/health.service.ts
+++ b/devolutions-gateway/openapi/ts-angular-client/api/health.service.ts
@@ -89,7 +89,7 @@ export class HealthService {
 
     /**
      * Performs a health check
-     * Performs a health check 
+     * Performs a health check
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/devolutions-gateway/openapi/ts-angular-client/api/jrl.service.ts
+++ b/devolutions-gateway/openapi/ts-angular-client/api/jrl.service.ts
@@ -89,7 +89,7 @@ export class JrlService {
 
     /**
      * Retrieves current JRL (Json Revocation List) info
-     * Retrieves current JRL (Json Revocation List) info 
+     * Retrieves current JRL (Json Revocation List) info
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -150,7 +150,7 @@ export class JrlService {
 
     /**
      * Updates JRL (Json Revocation List) using a JRL token
-     * Updates JRL (Json Revocation List) using a JRL token 
+     * Updates JRL (Json Revocation List) using a JRL token
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */

--- a/devolutions-gateway/openapi/ts-angular-client/api/sessions.service.ts
+++ b/devolutions-gateway/openapi/ts-angular-client/api/sessions.service.ts
@@ -89,7 +89,7 @@ export class SessionsService {
 
     /**
      * Lists running sessions
-     * Lists running sessions 
+     * Lists running sessions
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.
      */
@@ -150,7 +150,7 @@ export class SessionsService {
 
     /**
      * Terminate forcefully a running session
-     * Terminate forcefully a running session 
+     * Terminate forcefully a running session
      * @param id Session / association ID of the session to terminate
      * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
      * @param reportProgress flag to report request and response progress.

--- a/devolutions-gateway/openapi/ts-angular-client/model/configDiagnostic.ts
+++ b/devolutions-gateway/openapi/ts-angular-client/model/configDiagnostic.ts
@@ -24,6 +24,9 @@ export interface ConfigDiagnostic {
      * This Gateway\'s unique ID
      */
     id?: string;
+    /**
+     * Listeners configured on this instance
+     */
     listeners: Array<ListenerUrls>;
     /**
      * Gateway service version

--- a/devolutions-gateway/src/interceptor/pcap.rs
+++ b/devolutions-gateway/src/interceptor/pcap.rs
@@ -5,7 +5,7 @@ use packet::builder::Builder;
 use packet::ether::{Builder as BuildEthernet, Protocol};
 use packet::ip::v6::Builder as BuildV6;
 use packet::tcp::flag::Flags;
-use pcap_file::PcapWriter;
+use pcap_file::pcap::{PcapPacket, PcapWriter};
 use std::fs::File;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -142,12 +142,9 @@ async fn writer_task(
                     .duration_since(std::time::UNIX_EPOCH)
                     .expect("Time went backwards");
 
-                if let Err(e) = pcap_writer.write(
-                    since_epoch.as_secs() as u32,
-                    since_epoch.subsec_micros(),
-                    &tcpip_packet,
-                    tcpip_packet.len() as u32,
-                ) {
+                let packet = PcapPacket::new(since_epoch, tcpip_packet.len() as u32, &tcpip_packet);
+
+                if let Err(e) = pcap_writer.write_packet(&packet) {
                     error!("Error writing pcap file: {}", e);
                 }
 

--- a/devolutions-gateway/src/rdp.rs
+++ b/devolutions-gateway/src/rdp.rs
@@ -19,7 +19,7 @@ use crate::utils::{self, TargetAddr};
 use anyhow::Context;
 use bytes::BytesMut;
 use nonempty::NonEmpty;
-use sspi::internal::credssp;
+use sspi::credssp;
 use sspi::AuthIdentity;
 use std::io;
 use std::net::SocketAddr;

--- a/devolutions-gateway/src/rdp/sequence_future/nla.rs
+++ b/devolutions-gateway/src/rdp/sequence_future/nla.rs
@@ -7,7 +7,7 @@ use crate::utils;
 use bytes::{Buf, BytesMut};
 use futures::{ready, SinkExt, StreamExt};
 use ironrdp::nego;
-use sspi::internal::credssp::{
+use sspi::credssp::{
     self, CredSspClient, CredSspMode, CredSspServer, EarlyUserAuthResult, TsRequest, EARLY_USER_AUTH_RESULT_PDU_SIZE,
 };
 use sspi::AuthIdentity;
@@ -250,7 +250,7 @@ pub struct CredSspWithClientFuture {
 
 impl CredSspWithClientFuture {
     pub fn new(tls_proxy_pubkey: Vec<u8>, identity: RdpIdentity) -> io::Result<Self> {
-        let cred_ssp_server = CredSspServer::new(tls_proxy_pubkey, identity.clone())?;
+        let cred_ssp_server = CredSspServer::new(tls_proxy_pubkey, identity.clone(), credssp::ClientMode::Ntlm)?;
 
         Ok(Self {
             cred_ssp_server,
@@ -351,7 +351,13 @@ impl CredSspWithServerFuture {
         } else {
             CredSspMode::WithCredentials
         };
-        let cred_ssp_client = CredSspClient::new(public_key, target_credentials, cred_ssp_mode)?;
+        let cred_ssp_client = CredSspClient::new(
+            public_key,
+            target_credentials,
+            cred_ssp_mode,
+            credssp::ClientMode::Ntlm,
+            "unknown".to_owned(),
+        )?;
 
         Ok(Self {
             cred_ssp_client,

--- a/devolutions-gateway/src/transport/tsrequest.rs
+++ b/devolutions-gateway/src/transport/tsrequest.rs
@@ -1,5 +1,5 @@
 use bytes::{Buf, BytesMut};
-use sspi::internal::credssp::TsRequest;
+use sspi::credssp::TsRequest;
 use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 

--- a/devolutions-gateway/src/websocket_client.rs
+++ b/devolutions-gateway/src/websocket_client.rs
@@ -449,12 +449,14 @@ fn process_req(req: &Request<Body>) -> Response<Body> {
         Author: Ran Benita<bluetech> (ran234@gmail.com)
     */
 
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
     fn convert_key(input: &[u8]) -> String {
         const WS_GUID: &[u8] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
         let mut hasher = sha1::Sha1::new();
         hasher.update(input);
         hasher.update(WS_GUID);
-        base64::encode(hasher.finalize())
+        STANDARD.encode(hasher.finalize())
     }
     fn connection_has(value: &header::HeaderValue, needle: &str) -> bool {
         if let Ok(v) = value.to_str() {

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -16,7 +16,7 @@ native-tls = ["tokio-tungstenite/native-tls"]
 
 # jet protocol support
 jet-proto = { path = "../crates/jet-proto" }
-uuid = "1.1.2"
+uuid = "1.3.0"
 
 # jmux protocol support
 jmux-proto = { path = "../crates/jmux-proto" }
@@ -33,26 +33,26 @@ seahorse = "2.1.0"
 humantime = "2.1.0"
 
 # async
-tokio = { version = "1.20.1", features = ["io-std", "io-util", "net", "fs", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
-tokio-tungstenite = "0.17.2"
-futures-util = "0.3.21"
+tokio = { version = "1.25.0", features = ["io-std", "io-util", "net", "fs", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
+tokio-tungstenite = "0.18.0"
+futures-util = "0.3.26"
 transport = { path = "../crates/transport" }
 
 # logging
-tracing = "0.1.36"
-tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 tracing-appender = "0.2.2"
 
 # error handling
-anyhow = "1.0.61"
+anyhow = "1.0.69"
 
 # location of special directories
 dirs-next = "2.0.0"
 
 # find parent process / watch process 
-sysinfo = { version = "0.25.2", default-features = false }
+sysinfo = { version = "0.28.0", default-features = false }
 
 [dev-dependencies]
 test-utils = { path = "../crates/test-utils" }
-tokio = { version = "1.20.1", features = ["time"] }
-proptest = "1.0.0"
+tokio = { version = "1.25.0", features = ["time"] }
+proptest = "1.1.0"

--- a/tools/generate-openapi/Cargo.toml
+++ b/tools/generate-openapi/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 devolutions-gateway = { path = "../../devolutions-gateway", features = ["openapi"] }
-utoipa = { version = "2.0.1", default-features = false, features = ["uuid", "chrono", "yaml"] }
+utoipa = { version = "3.0.3", default-features = false, features = ["uuid", "chrono", "yaml"] }


### PR DESCRIPTION
Notably update picky-asn1 to its latest version so we get better Debug representation for KDC messages.