### PR TITLE
fix(dgw): better TLS leaf certificate public key extracting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
+name = "const-oid"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,18 +866,20 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
  "crypto-bigint",
  "pem-rfc7468",
 ]
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
+ "const-oid 0.9.1",
  "der_derive",
+ "flagset",
 ]
 
 [[package]]
@@ -901,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "der_derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e0925824edd2cc2de26da32852c7cd30844011dbf4956c12c88ad2f42d910"
+checksum = "8ef71ddb5b3a1f53dee24817c8f70dfa1cb29e804c18d88c228d4bc9c86ee3b9"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.51",
@@ -998,6 +1006,7 @@ dependencies = [
  "url 2.3.1",
  "utoipa",
  "uuid 1.3.0",
+ "x509-cert",
  "zeroize",
 ]
 
@@ -1208,6 +1217,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "flagset"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
 
 [[package]]
 name = "flate2"
@@ -1805,7 +1820,7 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=898fb8d40a3c84#898fb8d40a3c8495e22c1a08c9e9401d3ba0a199"
 dependencies = [
  "bytes 1.4.0",
- "der 0.6.0",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -2941,7 +2956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
 dependencies = [
  "der 0.5.1",
- "spki",
+ "spki 0.5.4",
  "zeroize",
 ]
 
@@ -4106,6 +4121,16 @@ checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
 dependencies = [
  "base64ct",
  "der 0.5.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -5353,6 +5378,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d224a125dec5adda27d0346b9cae9794830279c4f9c27e4ab0b6c408d54012"
+dependencies = [
+ "const-oid 0.9.1",
+ "der 0.6.1",
+ "flagset",
+ "spki 0.6.0",
 ]
 
 [[package]]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -56,6 +56,7 @@ backoff = "0.4.0"
 zeroize = { version = "1.5.7", features = ["derive"] }
 rust-argon2 = "1.0.0"
 picky = { version = "7.0.0-rc.4", default-features = false, features = ["jose", "x509"] }
+x509-cert = { version = "0.1.1", features = ["std"] }
 sspi = "0.6.0"
 # evaluate use of ring in our codebase
 ring = "0.16.20"


### PR DESCRIPTION
Use `x509-cert` crate to extract the public key from the leaf TLS certificate. `x509-cert` supports more certificates.