### PR TITLE
fix(dgw): size-based log rotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,7 @@ jobs:
         shell: pwsh
         run: |
           rustup target add aarch64-pc-windows-msvc
-          @('', '[patch.crates-io]',
-          'ring = { git = "https://github.com/awakecoding/ring", branch = "0.16.20_alpha" }') | % {
+          'ring = { git = "https://github.com/awakecoding/ring", branch = "0.16.20_alpha" }' | % {
             Add-Content -Path "./Cargo.toml" -Value $_
           }
           $VSINSTALLDIR = $(vswhere.exe -latest -requires Microsoft.VisualStudio.Component.VC.Llvm.Clang -property installationPath)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -4641,11 +4641,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+version = "0.2.999"
+source = "git+https://github.com/CBenoit/tracing?rev=454313f66da3a662#454313f66da3a66261955924bc283af147758550"
 dependencies = [
  "crossbeam-channel",
+ "thiserror",
  "time 0.3.19",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ default-members = [
 [profile.production]
 inherits = "release"
 lto = true
+
+[patch.crates-io]
+tracing-appender = { git = "https://github.com/CBenoit/tracing", rev = "454313f66da3a662" }

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -152,7 +152,7 @@ impl Conf {
         let log_file = conf_file
             .log_file
             .clone()
-            .unwrap_or_else(|| Utf8PathBuf::from("gateway.log"))
+            .unwrap_or_else(|| Utf8PathBuf::from("gateway"))
             .pipe_ref(|path| normalize_data_path(path, &data_dir));
 
         let jrl_file = conf_file

--- a/devolutions-gateway/src/http/middlewares/log.rs
+++ b/devolutions-gateway/src/http/middlewares/log.rs
@@ -25,6 +25,13 @@ impl LogMiddleware {
             uri
         };
 
+        let span = if uri.len() > 512 {
+            // Truncate long URI to keep log readable and prevent fast growing log file
+            info_span!("request", request_id = %operation_id, %method, uri = %&uri[..512])
+        } else {
+            info_span!("request", request_id = %operation_id, %method, %uri)
+        };
+
         async move {
             let start_time = Instant::now();
 
@@ -42,7 +49,7 @@ impl LogMiddleware {
 
             Ok(ctx)
         }
-        .instrument(info_span!("request", request_id = %operation_id, %method, %uri))
+        .instrument(span)
         .await
     }
 }


### PR DESCRIPTION
Set a maximum size of 3 MB for each file and a maximum of 10 log files.
With this change, Devolutions Gateway should never consume more than 30 MB for its logs.

Issue: DGW-34

A pull request was opened in `tracing` repository: https://github.com/tokio-rs/tracing/pull/2497
Until it’s merged, `tracing-appender` dependency is patched and points to my fork.
Future work includes removing this patch.