### PR TITLE
fix powershell/build.ps1 output path

### DIFF
--- a/powershell/build.ps1
+++ b/powershell/build.ps1
@@ -21,7 +21,7 @@ $Env:NUGET_CERT_REVOCATION_MODE='offline'
 
 & dotnet restore "$PSScriptRoot\$ModuleName\src" 2>&1>$null
 
-& dotnet publish "$PSScriptRoot\$ModuleName\src" -f netstandard2.0 -c Release -o "$PSScriptRoot\$ModuleName\bin"
+& dotnet publish "$PSScriptRoot\$ModuleName\src\$ModuleName.csproj" -f netstandard2.0 -c Release -o "$PSScriptRoot\$ModuleName\bin"
 
 Copy-Item "$PSScriptRoot\$ModuleName\bin" -Destination "$PSModuleOutputPath\$ModuleName" -Recurse -Force
 


### PR DESCRIPTION
use csproj explicitly with dotnet publish -o parameter (output path) since recent .NET SDK makes it an error rather than a warning on a .sln (default), breaking the build