### PR TITLE
fix(installer): fix command execution and add validation

### DIFF
--- a/package/Windows/Actions/CustomAction.cpp
+++ b/package/Windows/Actions/CustomAction.cpp
@@ -426,7 +426,7 @@ HRESULT __stdcall ExecuteCommand(MSIHANDLE hInstall, LPCWSTR command, LPDWORD dw
 	
 	// CreateProcessW can modify the contents of the lpCommand parameter
 	lpCommandLen = lstrlenW(command);
-	lpCommand = (LPWSTR) calloc((size_t)lpCommandLen, sizeof(WCHAR));
+	lpCommand = (LPWSTR) calloc((size_t)lpCommandLen + 1, sizeof(WCHAR));
 	ExitOnNull(lpCommand, hr, E_OUTOFMEMORY, "calloc");
 	CopyMemory(lpCommand, command, lpCommandLen * sizeof(WCHAR));
 
@@ -959,7 +959,7 @@ UINT __stdcall ValidateListeners(MSIHANDLE hInstall)
 	WCHAR* externalUrl = nullptr;
 	int internalUrlLen = 0;
 	WCHAR* internalUrl = nullptr;
-	static LPCWSTR psCommandFormat = L"$httpListener = New-DGatewayListener \"%ls\" \"%ls\"; $tcpListener = New-DGatewayListener \"tcp://*:%ls\" \"tcp://*:%ls\"; $listeners = $httpListener, $tcpListener; Set-DGatewayListeners $listeners";
+	static LPCWSTR psCommandFormat = L"$httpListener = New-DGatewayListener '%ls' '%ls'; $tcpListener = New-DGatewayListener 'tcp://*:%ls' 'tcp://*:%ls'; $listeners = $httpListener, $tcpListener; Set-DGatewayListeners $listeners";
 	int psCommandLen = 0;
 	WCHAR* psCommand = nullptr;
 
@@ -1152,7 +1152,7 @@ UINT __stdcall ValidatePublicKey(MSIHANDLE hInstall)
 	HRESULT hr = S_OK;
 	UINT er = ERROR_SUCCESS;
 	LPWSTR szPkFile = nullptr;
-	static LPCWSTR psCommandFormat = L"Import-DGatewayProvisionerKey -PublicKeyFile \"%ls\"";
+	static LPCWSTR psCommandFormat = L"Import-DGatewayProvisionerKey -PublicKeyFile '%ls'";
 	int psCommandLen = 0;
 	WCHAR* psCommand = nullptr;
 

--- a/package/Windows/DevolutionsGateway.wxs
+++ b/package/Windows/DevolutionsGateway.wxs
@@ -100,10 +100,10 @@
                  Before="CA.SetProgramDataPermissions" />
     <SetProperty Id="CA.InitConfigAfterFinalize" Value="&quot;[INSTALLDIR]\DevolutionsGateway.exe&quot; --config-init-only" Sequence="execute" Before="CA.InitConfigAfterFinalize" />
     <SetProperty Id="CA.SetGatewayStartupType" Value="[P.SERVICE_START]" Sequence="execute" Before="CA.SetGatewayStartupType" />
-    <SetProperty Id="CA.ConfigAccessUri" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command "&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.ACCESSURI_CMD]"' Sequence="execute" Before="CA.ConfigAccessUri" />
-    <SetProperty Id="CA.ConfigListeners" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command "&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.LISTENER_CMD]"' Sequence="execute" Before="CA.ConfigListeners" />
-    <SetProperty Id="CA.ConfigCert" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command "&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.CERT_CMD]"' Sequence="execute" Before="CA.ConfigCert" />
-    <SetProperty Id="CA.ConfigPublicKey" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command "&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.PK_CMD]"' Sequence="execute" Before="CA.ConfigPublicKey" />
+    <SetProperty Id="CA.ConfigAccessUri" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command &quot;&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.ACCESSURI_CMD]&quot;' Sequence="execute" Before="CA.ConfigAccessUri" />
+    <SetProperty Id="CA.ConfigListeners" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command &quot;&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.LISTENER_CMD]&quot;' Sequence="execute" Before="CA.ConfigListeners" />
+    <SetProperty Id="CA.ConfigCert" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command &quot;&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.CERT_CMD]&quot;' Sequence="execute" Before="CA.ConfigCert" />
+    <SetProperty Id="CA.ConfigPublicKey" Value='&quot;[P.POWERSHELLEXE]&quot; -ep Bypass -Command &quot;&amp; Import-Module &apos;[INSTALLDIR]PowerShell\Modules\DevolutionsGateway&apos;; [P.PK_CMD]&quot;' Sequence="execute" Before="CA.ConfigPublicKey" />
 
     <!-- Reinstall the DGatewayService feature on maintenance installations 
             This forces the service to be stopped and started, 

--- a/package/Windows/DevolutionsGateway_en-us.wxl
+++ b/package/Windows/DevolutionsGateway_en-us.wxl
@@ -145,11 +145,11 @@
   <String Id="WelcomeDlgTitle" Overridable="yes">{\WixUI_Font_Bigger}Welcome to the [ProductName] 20[ProductVersion] Setup Wizard</String>
   <String Id="WelcomeEulaDlgTitle">{\MyWixUI_Font_Title}Please read the [ProductName] License Agreement</String>
 
-  <String Id="Error29989">Failed to configure the provisioner public key.&#xa;&#xa; Error details: [2]</String>
-  <String Id="Error29990">Failed to configure the certificate.&#xa;&#xa; Error details: [2]</String>
-  <String Id="Error29991">Failed to configure the listeners.&#xa;&#xa; Error details: [2]</String>
-  <String Id="Error29992">Failed to configure the access URI.&#xa;&#xa; Error details: [2]</String>
-  <String Id="Error29993">Failed to execute a configuration command.&#xa;&#xa; Error details: [2]</String>
+  <String Id="Error29989">Failed to configure the provisioner public key.&#xa;&#xa;Details: [2]</String>
+  <String Id="Error29990">Failed to configure the certificate.&#xa;&#xa;Details: [2]</String>
+  <String Id="Error29991">Failed to configure the listeners.&#xa;&#xa;Details: [2]</String>
+  <String Id="Error29992">Failed to configure the access URI.&#xa;&#xa;Details: [2]</String>
+  <String Id="Error29993">Failed to execute a configuration command.&#xa;&#xa;Details: [2]</String>
   <String Id="Error29994">Failed to query existing service configuration</String> 
   <String Id="Error29995">You must provide a valid certificate file and either a password or private key file</String>
   <String Id="Error29996">The specified file was invalid or not accessible</String>

--- a/package/Windows/DevolutionsGateway_fr-fr.wxl
+++ b/package/Windows/DevolutionsGateway_fr-fr.wxl
@@ -157,11 +157,11 @@
   <String Id="WelcomeEulaDlgTitle">{\MyWixUI_Font_Title}Veuillez lire la Convention de licence de [ProductName]</String>
   <String Id="WelcomeDlgTitle" Overridable="yes">{\WixUI_Font_Bigger}Bienvenue dans l'assistant d'installation de [ProductName] 20[ProductVersion]</String>
 
-  <String Id="Error29989">Échec de la configuration de la clé publique du fournisseur.&#xa;&#xa; Détails: [2]</String>
-  <String Id="Error29990">Échec de la configuration du certificat.&#xa;&#xa; Détails: [2]</String>
-  <String Id="Error29991">Échec de la configuration des écouteurs.&#xa;&#xa; Détails: [2]</String>
-  <String Id="Error29992">Échec de la configuration des URI d'accès.&#xa;&#xa; Détails: [2]</String>
-  <String Id="Error29993">L'exécution d'une commande de configuration a échoué.&#xa;&#xa; Détails: [2]</String>
+  <String Id="Error29989">Échec de la configuration de la clé publique du fournisseur.&#xa;&#xa;Détails: [2]</String>
+  <String Id="Error29990">Échec de la configuration du certificat.&#xa;&#xa;Détails: [2]</String>
+  <String Id="Error29991">Échec de la configuration des écouteurs.&#xa;&#xa;Détails: [2]</String>
+  <String Id="Error29992">Échec de la configuration des URI d'accès.&#xa;&#xa;Détails: [2]</String>
+  <String Id="Error29993">L'exécution d'une commande de configuration a échoué.&#xa;&#xa;Détails: [2]</String>
   <String Id="Error29994">Échec de lecture de la configuration existante du service</String> 
   <String Id="Error29995">Vous devez fournir un fichier de certificat valide avec mot de passe ou fichier de clée privée</String>
   <String Id="Error29996">Le chemin de fichier spécifié est invalide ou inaccessible</String>

--- a/powershell/DevolutionsGateway/Public/DGateway.ps1
+++ b/powershell/DevolutionsGateway/Public/DGateway.ps1
@@ -607,7 +607,16 @@ function Import-DGatewayProvisionerKey {
     $Config = Get-DGatewayConfig -ConfigPath:$ConfigPath -NullProperties
 
     if ($PublicKeyFile) {
+        if (-Not (Test-Path -Path $PublicKeyFile)) {
+            throw "$PublicKeyFile doesn't exist"
+        }
+
         $PublicKeyData = Get-Content -Path $PublicKeyFile -Encoding UTF8
+
+        if (!$PublicKeyData) {
+            throw "$PublicKeyFile appears to be empty"          
+        }
+
         $OutputFile = Join-Path $ConfigPath $DGatewayProvisionerPublicKeyFileName
         $Config.ProvisionerPublicKeyFile = $DGatewayProvisionerPublicKeyFileName
         New-Item -Path $ConfigPath -ItemType 'Directory' -Force | Out-Null
@@ -615,7 +624,16 @@ function Import-DGatewayProvisionerKey {
     }
 
     if ($PrivateKeyFile) {
+        if (-Not (Test-Path -Path $PrivateKeyFile)) {
+            throw "$PrivateKeyFile doesn't exist"
+        }
+
         $PrivateKeyData = Get-Content -Path $PrivateKeyFile -Encoding UTF8
+
+        if (!$PrivateKeyData) {
+            throw "$PrivateKeyFile appears to be empty"          
+        }
+
         $OutputFile = Join-Path $ConfigPath $DGatewayProvisionerPrivateKeyFileName
         $Config.ProvisionerPrivateKeyFile = $DGatewayProvisionerPrivateKeyFileName
         New-Item -Path $ConfigPath -ItemType 'Directory' -Force | Out-Null


### PR DESCRIPTION
Add a missing null-terminator when formatting PowerShell commands, and cleanup quotation behaviour in command execution.

Additionally, I added some simple validation to `Import-DGatewayProvisionerKey`. This cmdlet was failing (admittedly, for invalid reasons) but the installation still succeeded as no errors were reported from PowerShell.

Issue: DGW-84