### PR TITLE
improve session recording file layout

### DIFF
--- a/devolutions-gateway/src/jrec.rs
+++ b/devolutions-gateway/src/jrec.rs
@@ -5,10 +5,13 @@ use crate::config::Conf;
 use crate::token::{CurrentJrl, JrecTokenClaims, TokenCache, TokenError};
 
 use anyhow::Context as _;
+use camino::{Utf8Path, Utf8PathBuf};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite, BufWriter};
 use tokio::{fs, io};
 use typed_builder::TypedBuilder;
+use uuid::Uuid;
 
 #[derive(Debug, Error)]
 pub enum AuthorizationError {
@@ -36,6 +39,23 @@ pub fn authorize(
     }
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct JrecManifest {
+    session_id: Uuid,
+    file_type: String,
+    start_time: i64,
+    duration: i64,
+}
+
+impl JrecManifest {
+    pub fn save_to_file(&self, path: &Utf8Path) -> anyhow::Result<()> {
+        let json = serde_json::to_string_pretty(&self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+}
+
 #[derive(TypedBuilder)]
 pub struct PlainForward<S> {
     conf: Arc<Conf>,
@@ -55,18 +75,32 @@ where
             mut client_stream,
         } = self;
 
-        let recording_path = &conf.recording_path.clone();
+        let session_id = claims.jet_aid;
+        let session_id_str = session_id.hyphenated().to_string();
+
+        let mut recording_path = conf.recording_path.clone();
+        recording_path.push(session_id_str.as_str());
 
         if !recording_path.exists() {
-            fs::create_dir_all(recording_path)
+            fs::create_dir_all(&recording_path)
                 .await
                 .with_context(|| format!("Failed to create recording path: {recording_path}"))?;
         }
 
-        let session_id = claims.jet_aid;
-        let file_ext = claims.jet_rft.as_str();
-        let filename = format!("{session_id}.{file_ext}");
+        let start_time = chrono::Utc::now().timestamp();
+        let file_type = claims.jet_rft.as_str();
 
+        let mut manifest = JrecManifest {
+            session_id: session_id.clone(),
+            file_type: file_type.to_string(),
+            start_time: start_time,
+            duration: 0,
+        };
+
+        let manifest_file = recording_path.join("session.json");
+        manifest.save_to_file(&manifest_file)?;
+
+        let filename = format!("session.{0}", file_type);
         let path = recording_path.join(filename);
 
         debug!(%path, "Opening file");
@@ -80,11 +114,13 @@ where
             .with_context(|| format!("Failed to open file at {path}"))
             .map(BufWriter::new)?;
 
-        debug!(%path, "File opened");
-
         io::copy(&mut client_stream, &mut file)
             .await
             .context("JREC streaming to file")?;
+
+        let end_time = chrono::Utc::now().timestamp();
+        manifest.duration = end_time - start_time;
+        manifest.save_to_file(&manifest_file)?;
 
         Ok(())
     }


### PR DESCRIPTION
Improve session recording file layout:

- use one directory per session id, rather than all files within same directory
- use regular file names within session directory (session.webm, session.trp)
- create session.json manifest file + update duration at session termination
- data not found in manifest file should be stored in DVLS database with id

![image](https://user-images.githubusercontent.com/295841/233746629-50f52e56-3f34-4855-b472-8d28e015a75a.png)
