### PR TITLE
feat(dgw): improve HTTP error reporting

### DIFF
--- a/devolutions-gateway/src/http/controllers/health.rs
+++ b/devolutions-gateway/src/http/controllers/health.rs
@@ -1,5 +1,5 @@
 use crate::config::ConfHandle;
-use crate::http::HttpErrorStatus;
+use crate::http::HttpError;
 use saphir::body::Json;
 use saphir::controller::Controller;
 use saphir::http::Method;
@@ -28,7 +28,7 @@ impl HealthController {
 #[controller(name = "jet/health")]
 impl HealthController {
     #[get("/")]
-    fn get_health(&self, req: Request) -> Result<HealthResponse, HttpErrorStatus> {
+    fn get_health(&self, req: Request) -> Result<HealthResponse, HttpError> {
         get_health(self, req)
     }
 }
@@ -76,7 +76,7 @@ impl Responder for HealthResponse {
         (status = 400, description = "Invalid Accept header"),
     ),
 ))]
-fn get_health(controller: &HealthController, req: Request) -> Result<HealthResponse, HttpErrorStatus> {
+fn get_health(controller: &HealthController, req: Request) -> Result<HealthResponse, HttpError> {
     let conf = controller.conf_handle.get_conf();
 
     for hval in req
@@ -110,7 +110,7 @@ pub struct LegacyHealthController {
 #[controller(name = "health")]
 impl LegacyHealthController {
     #[get("/")]
-    fn get_health(&self, req: Request) -> Result<HealthResponse, HttpErrorStatus> {
+    fn get_health(&self, req: Request) -> Result<HealthResponse, HttpError> {
         get_health(&self.inner, req)
     }
 }

--- a/devolutions-gateway/src/http/controllers/recordings.rs
+++ b/devolutions-gateway/src/http/controllers/recordings.rs
@@ -1,6 +1,6 @@
 use crate::config::ConfHandle;
 use crate::http::guards::access::{AccessGuard, TokenType};
-use crate::http::HttpErrorStatus;
+use crate::http::HttpError;
 use crate::token::AccessScope;
 use saphir::body::json::Json;
 use saphir::controller::Controller;
@@ -19,7 +19,7 @@ pub struct RecordingsController {
 impl RecordingsController {
     #[get("/")]
     #[guard(AccessGuard, init_expr = r#"TokenType::Scope(AccessScope::RecordingsRead)"#)]
-    async fn get_recordings(&self) -> Result<Json<Vec<String>>, HttpErrorStatus> {
+    async fn get_recordings(&self) -> Result<Json<Vec<String>>, HttpError> {
         get_recordings(&self.conf_handle).await
     }
 }
@@ -54,7 +54,7 @@ fn list_uuid_dirs(dir_path: &Path) -> Vec<String> {
     ),
     security(("scope_token" = ["gateway.recordings.read"])),
 ))]
-pub(crate) async fn get_recordings(conf_handle: &ConfHandle) -> Result<Json<Vec<String>>, HttpErrorStatus> {
+pub(crate) async fn get_recordings(conf_handle: &ConfHandle) -> Result<Json<Vec<String>>, HttpError> {
     let conf = conf_handle.get_conf();
     let recording_path = conf.recording_path.to_owned();
     let dirs = list_uuid_dirs(recording_path.as_std_path());

--- a/devolutions-gateway/src/http/controllers/sessions.rs
+++ b/devolutions-gateway/src/http/controllers/sessions.rs
@@ -1,5 +1,5 @@
 use crate::http::guards::access::{AccessGuard, TokenType};
-use crate::http::HttpErrorStatus;
+use crate::http::HttpError;
 use crate::session::{SessionInfo, SessionManagerHandle};
 use crate::token::AccessScope;
 use saphir::controller::Controller;
@@ -15,7 +15,7 @@ pub struct SessionsController {
 impl SessionsController {
     #[get("/")]
     #[guard(AccessGuard, init_expr = r#"TokenType::Scope(AccessScope::SessionsRead)"#)]
-    async fn get_sessions(&self) -> Result<Json<Vec<SessionInfo>>, HttpErrorStatus> {
+    async fn get_sessions(&self) -> Result<Json<Vec<SessionInfo>>, HttpError> {
         get_sessions(&self.sessions).await
     }
 }
@@ -35,11 +35,11 @@ impl SessionsController {
     ),
     security(("scope_token" = ["gateway.sessions.read"])),
 ))]
-pub(crate) async fn get_sessions(sessions: &SessionManagerHandle) -> Result<Json<Vec<SessionInfo>>, HttpErrorStatus> {
+pub(crate) async fn get_sessions(sessions: &SessionManagerHandle) -> Result<Json<Vec<SessionInfo>>, HttpError> {
     let sessions_in_progress: Vec<SessionInfo> = sessions
         .get_running_sessions()
         .await
-        .map_err(HttpErrorStatus::internal)?
+        .map_err(HttpError::internal().err())?
         .into_values()
         .collect();
 
@@ -56,7 +56,7 @@ pub struct LegacySessionsController {
 impl LegacySessionsController {
     #[get("/")]
     #[guard(AccessGuard, init_expr = r#"TokenType::Scope(AccessScope::SessionsRead)"#)]
-    async fn get_sessions(&self) -> Result<Json<Vec<SessionInfo>>, HttpErrorStatus> {
+    async fn get_sessions(&self) -> Result<Json<Vec<SessionInfo>>, HttpError> {
         get_sessions(&self.sessions).await
     }
 }

--- a/devolutions-gateway/src/http/guards/access.rs
+++ b/devolutions-gateway/src/http/guards/access.rs
@@ -1,4 +1,4 @@
-use crate::http::HttpErrorStatus;
+use crate::http::HttpError;
 use crate::token::{AccessScope, AccessTokenClaims};
 use saphir::prelude::*;
 
@@ -21,11 +21,11 @@ impl AccessGuard {
         AccessGuard { token_type }
     }
 
-    async fn validate(&self, req: Request) -> Result<Request, HttpErrorStatus> {
+    async fn validate(&self, req: Request) -> Result<Request, HttpError> {
         let claims = req
             .extensions()
             .get::<AccessTokenClaims>()
-            .ok_or_else(|| HttpErrorStatus::unauthorized("identity missing (no token provided)"))?;
+            .ok_or_else(|| HttpError::unauthorized().msg("identity missing (no token provided)"))?;
 
         let allowed = match (&self.token_type, claims) {
             (TokenType::Association, AccessTokenClaims::Association(_)) => true,
@@ -43,7 +43,7 @@ impl AccessGuard {
         if allowed {
             Ok(req)
         } else {
-            Err(HttpErrorStatus::forbidden("token not allowed"))
+            Err(HttpError::forbidden().msg("token not allowed"))
         }
     }
 }

--- a/devolutions-gateway/src/http/middlewares/auth.rs
+++ b/devolutions-gateway/src/http/middlewares/auth.rs
@@ -1,5 +1,5 @@
 use crate::config::{Conf, ConfHandle};
-use crate::http::HttpErrorStatus;
+use crate::http::HttpError;
 use crate::token::{AccessTokenClaims, CurrentJrl, TokenCache, TokenValidator};
 use futures::future::{BoxFuture, FutureExt};
 use saphir::error::SaphirError;
@@ -108,7 +108,7 @@ async fn auth_middleware(
         .peer_addr()
         .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "peer address missing"))?;
 
-    match authenticate(*source_addr, token, &config, &token_cache, &jrl).map_err(HttpErrorStatus::unauthorized) {
+    match authenticate(*source_addr, token, &config, &token_cache, &jrl).map_err(HttpError::unauthorized().err()) {
         Ok(token) => {
             request.extensions_mut().insert(token);
             chain.next(ctx).await

--- a/devolutions-gateway/src/listener.rs
+++ b/devolutions-gateway/src/listener.rs
@@ -359,12 +359,7 @@ where
 
     let service = service_fn(move |req| {
         let mut ws_serve = websocket_service.clone();
-        async move {
-            ws_serve.handle(req, remote_addr).await.map_err(|e| {
-                debug!("WebSocket HTTP server error: {}", e);
-                e
-            })
-        }
+        async move { ws_serve.handle(req, remote_addr).await }
     });
 
     hyper::server::conn::Http::new()

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -724,55 +724,55 @@ fn is_encrypted(token: &str) -> bool {
 
 #[derive(Error, Debug)]
 pub enum TokenError {
-    #[error("Delegation key is missing")]
+    #[error("delegation key is missing")]
     MissingDelegationKey,
-    #[error("Invalid JWE token")]
+    #[error("invalid JWE token")]
     Jwe {
         #[from]
         source: picky::jose::jwe::JweError,
     },
-    #[error("Invalid JWE token payload")]
+    #[error("invalid JWE token payload")]
     JwePayload { source: std::str::Utf8Error },
-    #[error("Invalid JWS token")]
+    #[error("invalid JWS token")]
     Jws {
         #[from]
         source: picky::jose::jws::JwsError,
     },
-    #[error("Failed to verify token signature using {key}")]
+    #[error("failed to verify token signature using {key}")]
     SignatureVerification {
         source: picky::jose::jws::JwsError,
         key: &'static str,
     },
-    #[error("Key ID (kid) {provided_kid} in token is referring to an unknown subkey")]
+    #[error("key ID (kid) {provided_kid} in token is referring to an unknown subkey")]
     UnknownSubkey { provided_kid: String },
-    #[error("Invalid content type for token")]
+    #[error("invalid content type for token")]
     BadContentType {
         #[from]
         source: BadContentType,
     },
-    #[error("Invalid JWT")]
+    #[error("invalid JWT")]
     Jwt {
         #[from]
         source: picky::jose::jwt::JwtError,
     },
-    #[error("Subkey can't be used to sign a {content_type:?} token")]
+    #[error("subkey can't be used to sign a {content_type:?} token")]
     ContentTypeNotAllowedForSubkey { content_type: ContentType },
-    #[error("Invalid `nbf` and `exp` claims for subkey-signed token")]
+    #[error("invalid `nbf` and `exp` claims for subkey-signed token")]
     InvalidValidityForSubkey,
-    #[error("Claim `{name}` is malformed")]
+    #[error("claim `{name}` is malformed")]
     MalformedClaim { name: &'static str, source: anyhow::Error },
-    #[error("Gateway ID scope mismatch")]
+    #[error("gateway ID scope mismatch")]
     GatewayIdScopeMismatch,
-    #[error("A revoked value is contained")]
+    #[error("a revoked value is contained")]
     Revoked,
-    #[error("Invalid claims for {content_type:?} token")]
+    #[error("invalid claims for {content_type:?} token")]
     InvalidClaimScheme {
         content_type: ContentType,
         source: serde_json::Error,
     },
-    #[error("Payload contains secrets that were not encrypted inside a JWE token")]
+    #[error("payload contains secrets that were not encrypted inside a JWE token")]
     PlaintextSecrets,
-    #[error("Previously used token unexpectedly reused ({reason})")]
+    #[error("previously used token unexpectedly reused ({reason})")]
     UnexpectedReplay { reason: &'static str },
     #[error("JSON Revocation List")]
     OldJrl,


### PR DESCRIPTION
Before:

```
2023-04-26T16:21:19.242218Z ERROR
listener{url=ws://0.0.0.0:7171/}:ws{client=127.0.0.1:56058}:http:request
{request_id=84e4946b-9af4-448f-8292-5d8c4f191578 method=GET uri=/
jet/heartbeat}: devolutions_gateway::http: 401 Unauthorized at /
rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/ops/
function.rs:250:5 [Invalid claims for Scope token]
```

Now:

```
2023-04-26T16:16:19.968334Z ERROR
listener{url=ws://0.0.0.0:7171/}:ws{client=127.0.0.1:55024}:http:request
{request_id=f92c01fc-90de-4ca5-b2cd-e6c9e6d42be8 method=GET uri=/
jet/heartbeat}: devolutions_gateway::http: error=401 Unauthorized
at devolutions-gateway/src/http/middlewares/auth.rs:111:82
[source: invalid claims for Scope token, because unknown variant
`gateway.heartbeat.ready`, expected one of `*`, `gateway.sessions.read`,
`gateway.session.terminate`, `gateway.associations.read`,
`gateway.diagnostics.read`, `gateway.jrl.read`, `gateway.config.write`,
`gateway.heartbeat.read`, `gateway.recordings.read`]
```