### PR TITLE
fix(ci): limit builds on forked PRs, optimize CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ env:
   conan-version: 1.43.4
 
 jobs:
-
   preflight:
     name: preflight
     runs-on: ubuntu-20.04
@@ -27,8 +26,59 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
       rust-channel: ${{ steps.rust-toolchain.outputs.rust-channel }}
       rust-profile: ${{ steps.rust-profile.outputs.rust-profile }}
+      jetsocat-build-matrix: ${{ steps.setup-matrix.outputs.jetsocat-build-matrix }}
+      gateway-build-matrix: ${{ steps.setup-matrix.outputs.gateway-build-matrix }}
 
     steps:
+      - name: Setup matrix
+        id: setup-matrix
+        shell: pwsh
+        env:
+          SECRET_VALUE: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
+        run: |
+          $Jobs = @()
+          $Archs = @( 'x86_64' )
+          $Platforms = @( 'linux' )
+          if ($Env:SECRET_VALUE -Eq '') {
+            echo "::warning::Secrets not available, some jobs will be skipped"
+          } else {
+              $Platforms += 'windows'
+          }
+          
+          $Platforms | ForEach-Object {
+              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'linux' { 'ubuntu-20.04' } }
+              foreach ($Arch in $Archs) {
+                  $Jobs += @{ 
+                      arch = $Arch 
+                      os = $_ 
+                      runner = $Runner }
+              }
+          }
+          
+          $GatewayMatrix = ConvertTo-JSON $Jobs -Compress
+          echo "gateway-build-matrix=$GatewayMatrix" >> $Env:GITHUB_OUTPUT
+          
+          $Jobs = @()
+          $Archs += 'arm64'
+          $Platforms += 'macos'
+          
+          $Platforms | ForEach-Object {
+              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'macos' { 'macos-11' } 'linux' { 'ubuntu-20.04' } }
+              foreach ($Arch in $Archs) {
+                  if ($Arch -Eq 'arm64' -And $_ -Eq 'linux') {
+                      continue
+                  }
+          
+                  $Jobs += @{ 
+                      arch = $Arch 
+                      os = $_ 
+                      runner = $Runner }
+              }
+          }
+          
+          $JetsocatMatrix = ConvertTo-JSON $Jobs -Compress
+          echo "jetsocat-build-matrix=$JetsocatMatrix" >> $Env:GITHUB_OUTPUT
+
       ## The SHA to build might be passed via workflow_call, otherwise the current commit is used
       - name: Get commit
         id: get-commit
@@ -126,25 +176,10 @@ jobs:
     needs: preflight
     env:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
     strategy:
       matrix:
-        arch: [ x86, x86_64, arm64 ]
-        os: [ windows, macos, linux ]
-        include:
-          - os: windows
-            runner: windows-2022
-          - os: macos
-            runner: macos-11
-          - os: linux
-            runner: ubuntu-20.04
-        exclude:
-          - arch: x86
-            os: macos
-          - arch: x86
-            os: linux
-          - arch: arm64
-            os: linux
+        include: ${{ fromJson(needs.preflight.outputs.jetsocat-build-matrix) }}
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -160,10 +195,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -o Acquire::Retries=3 install python3-wget python3-setuptools
-
-      - name: Configure Windows runner
-        if: matrix.os == 'windows' && matrix.arch == 'x86'
-        run: rustup target add i686-pc-windows-msvc
 
       - name: Fix ring dependency for Windows ARM64
         if: runner.os == 'Windows' && matrix.arch == 'arm64'
@@ -200,6 +231,7 @@ jobs:
           rustup target add aarch64-apple-darwin
 
       - name: Configure conan
+        if: matrix.os == 'windows'
         run: |
           pip3 install conan==${{ env.conan-version }} --upgrade
           conan config install --type=git -sf settings https://github.com/Devolutions/conan-public
@@ -273,16 +305,10 @@ jobs:
     needs: preflight
     env:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+      CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
     strategy:
       matrix:
-        arch: [ x86_64 ]
-        os: [ windows, linux ]
-        include:
-          - os: windows
-            runner: windows-2022
-          - os: linux
-            runner: ubuntu-20.04
+        include: ${{ fromJson(needs.preflight.outputs.gateway-build-matrix) }}
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -331,6 +357,7 @@ jobs:
         run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Configure conan
+        if: matrix.os == 'windows'
         run: |
           pip3 install conan==${{ env.conan-version }} --upgrade
           conan config install --type=git -sf settings https://github.com/Devolutions/conan-public

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -248,6 +248,10 @@ class TlkRecipe
     }
 
     [void] BootstrapOpenSSL() {
+        if (-Not $this.Target.IsWindows()) {
+            return
+        }
+
         $OPENSSL_VERSION = '1.1.1l'
         $ConanPackage = "openssl/${OPENSSL_VERSION}@devolutions/stable"
         $ConanProfile = "$($this.Target.Platform)-$($this.Target.Architecture)"


### PR DESCRIPTION
- Although it's possible to check if we're on a fork (and even to check for `dependabot` builds by checking `github.actor`), it's not possible to exclude a job based on a matrix condition. Instead, generate the build matrices dynamically using PowerShell. This allows us to drop the Windows builds in case secrets are not available (e.g. a PR from a fork). A warning will be printed in this case.
- Revert to using `secrets.ARTIFACTORY_READ_TOKEN`. This token is now available for builds from `dependabot`.
- Don't bootstrap conan or OpenSSL when building for non-Windows.
- Drop the `jetsocat` build for the Windows x86 target.