### PR TITLE
Pre-release hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "devolutions-gateway-generators",
+ "devolutions-gateway-task",
  "dlopen",
  "dlopen_derive",
  "embed-resource",
@@ -896,6 +897,14 @@ dependencies = [
  "proptest",
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "devolutions-gateway-task"
+version = "0.0.0"
+dependencies = [
+ "async-trait",
+ "tokio",
 ]
 
 [[package]]
@@ -3633,6 +3642,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
 ]
 

--- a/crates/devolutions-gateway-task/Cargo.toml
+++ b/crates/devolutions-gateway-task/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "devolutions-gateway-task"
+version = "0.0.0"
+authors = ["Devolutions Inc. <infos@devolutions.net>"]
+edition = "2021"
+publish = false
+
+[features]
+default = []
+named_tasks = ["tokio/tracing"]
+
+[dependencies]
+tokio = { version = "1.28.1", features = ["sync", "rt", "tracing"] }
+async-trait = "0.1.68"

--- a/crates/devolutions-gateway-task/src/lib.rs
+++ b/crates/devolutions-gateway-task/src/lib.rs
@@ -1,0 +1,115 @@
+use std::future::Future;
+
+use async_trait::async_trait;
+use tokio::task::JoinHandle;
+
+#[derive(Debug)]
+pub struct ShutdownHandle(tokio::sync::watch::Sender<()>);
+
+impl ShutdownHandle {
+    pub fn new() -> (Self, ShutdownSignal) {
+        let (sender, receiver) = tokio::sync::watch::channel(());
+        (Self(sender), ShutdownSignal(receiver))
+    }
+
+    pub fn signal(&self) {
+        let _ = self.0.send(());
+    }
+
+    pub async fn all_closed(&self) {
+        self.0.closed().await;
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ShutdownSignal(tokio::sync::watch::Receiver<()>);
+
+impl ShutdownSignal {
+    pub async fn wait(&mut self) {
+        let _ = self.0.changed().await;
+    }
+}
+
+/// Aborts the running task when dropped.
+/// Also see https://github.com/tokio-rs/tokio/issues/1830 for some background.
+#[must_use]
+pub struct ChildTask<T>(JoinHandle<T>);
+
+impl<T> ChildTask<T> {
+    pub fn spawn<F>(future: F) -> Self
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        ChildTask(tokio::task::spawn(future))
+    }
+
+    pub async fn join(mut self) -> Result<T, tokio::task::JoinError> {
+        (&mut self.0).await
+    }
+
+    /// Immediately abort the task
+    pub fn abort(&self) {
+        self.0.abort()
+    }
+
+    /// Drop without aborting the task
+    pub fn detach(self) {
+        core::mem::forget(self);
+    }
+}
+
+impl<T> From<JoinHandle<T>> for ChildTask<T> {
+    fn from(value: JoinHandle<T>) -> Self {
+        Self(value)
+    }
+}
+
+impl<T> Drop for ChildTask<T> {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
+#[async_trait]
+pub trait Task {
+    type Output: Send;
+
+    const NAME: &'static str;
+
+    async fn run(self, shutdown_signal: ShutdownSignal) -> Self::Output;
+}
+
+pub fn spawn_task<T>(task: T, shutdown_signal: ShutdownSignal) -> ChildTask<T::Output>
+where
+    T: Task + 'static,
+{
+    let task_fut = task.run(shutdown_signal);
+    let handle = spawn_task_impl(task_fut, T::NAME);
+    ChildTask(handle)
+}
+
+#[cfg(not(all(feature = "named_tasks", tokio_unstable)))]
+#[track_caller]
+fn spawn_task_impl<T>(future: T, _name: &str) -> JoinHandle<T::Output>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    tokio::task::spawn(future)
+}
+
+#[cfg(all(feature = "named_tasks", tokio_unstable))]
+#[track_caller]
+fn spawn_task_impl<T>(future: T, name: &str) -> JoinHandle<T::Output>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    // NOTE: To enable this code, this crate must be built using a command similar to:
+    // > RUSTFLAGS="--cfg tokio_unstable" cargo check --features named_tasks
+
+    // NOTE: unwrap because as of now (tokio 1.28), this never returns an error,
+    // and production build never enable tokio-console instrumentation anyway (unstable).
+    tokio::task::Builder::new().name(name).spawn(future).unwrap()
+}

--- a/crates/sogar-registry/src/lib.rs
+++ b/crates/sogar-registry/src/lib.rs
@@ -1,5 +1,3 @@
-// TODO: extract this module into another crate
-
 mod push_files;
 mod sogar_auth;
 mod sogar_token;

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -20,6 +20,7 @@ transport = { path = "../crates/transport" }
 jmux-proxy = { path = "../crates/jmux-proxy" }
 ironrdp-pdu = { version = "0.1.0", git = "https://github.com/Devolutions/IronRDP", rev = "f11131b18afa5f8ff9" }
 ironrdp-rdcleanpath = { version = "0.1.0", git = "https://github.com/Devolutions/IronRDP", rev = "f11131b18afa5f8ff9" }
+devolutions-gateway-task = { path = "../crates/devolutions-gateway-task" }
 ceviche = "0.5.2"
 picky-krb = "0.6.0"
 

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -16,7 +16,7 @@ use crate::config::Conf;
 use crate::extract::AssociationToken;
 use crate::http::HttpError;
 use crate::proxy::Proxy;
-use crate::session::{ConnectionModeDetails, SessionInfo, SessionManagerHandle};
+use crate::session::{ConnectionModeDetails, SessionInfo, SessionMessageSender};
 use crate::subscriber::SubscriberSender;
 use crate::token::{AssociationTokenClaims, ConnectionMode};
 use crate::{utils, DgwState};
@@ -54,7 +54,7 @@ async fn fwd_tcp(
 async fn handle_fwd_tcp(
     ws: WebSocket,
     conf: Arc<Conf>,
-    sessions: SessionManagerHandle,
+    sessions: SessionMessageSender,
     subscriber_tx: SubscriberSender,
     claims: AssociationTokenClaims,
     source_addr: SocketAddr,
@@ -104,7 +104,7 @@ async fn fwd_tls(
 async fn handle_fwd_tls(
     ws: WebSocket,
     conf: Arc<Conf>,
-    sessions: SessionManagerHandle,
+    sessions: SessionMessageSender,
     subscriber_tx: SubscriberSender,
     claims: AssociationTokenClaims,
     source_addr: SocketAddr,
@@ -134,7 +134,7 @@ pub struct PlainForward<S> {
     claims: AssociationTokenClaims,
     client_stream: S,
     client_addr: SocketAddr,
-    sessions: SessionManagerHandle,
+    sessions: SessionMessageSender,
     subscriber_tx: SubscriberSender,
     #[builder(default = false)]
     with_tls: bool,

--- a/devolutions-gateway/src/api/jmux.rs
+++ b/devolutions-gateway/src/api/jmux.rs
@@ -7,7 +7,7 @@ use tracing::Instrument as _;
 
 use crate::extract::JmuxToken;
 use crate::http::HttpError;
-use crate::session::SessionManagerHandle;
+use crate::session::SessionMessageSender;
 use crate::subscriber::SubscriberSender;
 use crate::token::JmuxTokenClaims;
 use crate::DgwState;
@@ -29,7 +29,7 @@ pub async fn handler(
 
 async fn handle_socket(
     ws: WebSocket,
-    sessions: SessionManagerHandle,
+    sessions: SessionMessageSender,
     subscriber_tx: SubscriberSender,
     claims: JmuxTokenClaims,
     source_addr: SocketAddr,

--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -62,7 +62,7 @@ async fn handle_jrec_push(
 ) {
     let stream = crate::ws::websocket_compat(ws);
 
-    let result = crate::jrec::ClientPush::builder()
+    let result = crate::recording::ClientPush::builder()
         .client_stream(stream)
         .conf(conf)
         .claims(claims)

--- a/devolutions-gateway/src/interceptor/pcap.rs
+++ b/devolutions-gateway/src/interceptor/pcap.rs
@@ -1,6 +1,7 @@
 use crate::interceptor::{Dissector, Inspector, PeerSide};
 use anyhow::Context as _;
 use bytes::BytesMut;
+use devolutions_gateway_task::ChildTask;
 use packet::builder::Builder;
 use packet::ether::{Builder as BuildEthernet, Protocol};
 use packet::ip::v6::Builder as BuildV6;
@@ -40,7 +41,7 @@ impl PcapInspector {
 
         let (sender, receiver) = mpsc::unbounded_channel();
 
-        tokio::spawn(writer_task(receiver, pcap_writer, client_addr, server_addr, dissector));
+        ChildTask::spawn(writer_task(receiver, pcap_writer, client_addr, server_addr, dissector)).detach();
 
         Ok((
             Self {

--- a/devolutions-gateway/src/interceptor/plugin_recording.rs
+++ b/devolutions-gateway/src/interceptor/plugin_recording.rs
@@ -1,6 +1,7 @@
 use crate::interceptor::{Inspector, PeerSide};
 use crate::plugin_manager::{PacketsParser, Recorder, PLUGIN_MANAGER};
 use anyhow::Context as _;
+use devolutions_gateway_task::ChildTask;
 use parking_lot::{Condvar, Mutex};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -80,13 +81,14 @@ impl PluginRecordingInspector {
             move || timeout_task(recorder, condition_timeout)
         });
 
-        tokio::spawn(inspector_task(
+        ChildTask::spawn(inspector_task(
             receiver,
             handle,
             packet_parser,
             recorder,
             condition_timeout,
-        ));
+        ))
+        .detach();
 
         Ok(InitResult {
             client_inspector: Self {

--- a/devolutions-gateway/src/jmux.rs
+++ b/devolutions-gateway/src/jmux.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::session::{ConnectionModeDetails, SessionInfo, SessionManagerHandle};
+use crate::session::{ConnectionModeDetails, SessionInfo, SessionMessageSender};
 use crate::subscriber::SubscriberSender;
 use crate::token::JmuxTokenClaims;
 
@@ -15,7 +15,7 @@ use transport::{ErasedRead, ErasedWrite};
 pub async fn handle(
     stream: impl AsyncRead + AsyncWrite + Send + 'static,
     claims: JmuxTokenClaims,
-    sessions: SessionManagerHandle,
+    sessions: SessionMessageSender,
     subscriber_tx: SubscriberSender,
 ) -> anyhow::Result<()> {
     use jmux_proxy::{FilteringRule, JmuxConfig};

--- a/devolutions-gateway/src/jmux.rs
+++ b/devolutions-gateway/src/jmux.rs
@@ -5,6 +5,7 @@ use crate::subscriber::SubscriberSender;
 use crate::token::JmuxTokenClaims;
 
 use anyhow::Context as _;
+use devolutions_gateway_task::ChildTask;
 use jmux_proxy::JmuxProxy;
 use tap::prelude::*;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -17,7 +18,6 @@ pub async fn handle(
     sessions: SessionManagerHandle,
     subscriber_tx: SubscriberSender,
 ) -> anyhow::Result<()> {
-    use futures::future::Either;
     use jmux_proxy::{FilteringRule, JmuxConfig};
 
     let (reader, writer) = tokio::io::split(stream);
@@ -58,20 +58,19 @@ pub async fn handle(
     crate::session::add_session_in_progress(&sessions, &subscriber_tx, info, notify_kill.clone()).await?;
 
     let proxy_fut = JmuxProxy::new(reader, writer).with_config(config).run();
-
-    let proxy_handle = tokio::spawn(proxy_fut);
-    tokio::pin!(proxy_handle);
+    let proxy_handle = ChildTask::spawn(proxy_fut);
+    let join_fut = proxy_handle.join();
+    tokio::pin!(join_fut);
 
     let kill_notified = notify_kill.notified();
     tokio::pin!(kill_notified);
 
-    let res = match futures::future::select(proxy_handle, kill_notified).await {
-        Either::Left((Ok(res), _)) => res.context("JMUX proxy error"),
-        Either::Left((Err(e), _)) => anyhow::Error::new(e).context("Failed to wait for proxy task").pipe(Err),
-        Either::Right((_, proxy_handle)) => {
-            proxy_handle.abort();
-            Ok(())
-        }
+    let res = tokio::select! {
+        res = join_fut => match res {
+            Ok(res) => res.context("JMUX proxy error"),
+            Err(e) => anyhow::Error::new(e).context("Failed to wait for proxy task").pipe(Err),
+        },
+        _ = kill_notified => Ok(()),
     };
 
     crate::session::remove_session_in_progress(&sessions, &subscriber_tx, session_id).await?;

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -15,7 +15,6 @@ pub mod generic_client;
 pub mod http;
 pub mod interceptor;
 pub mod jmux;
-pub mod jrec;
 pub mod listener;
 pub mod log;
 pub mod middleware;
@@ -24,6 +23,7 @@ pub mod plugin_manager;
 pub mod proxy;
 pub mod rdp_extension;
 pub mod rdp_pcb;
+pub mod recording;
 pub mod session;
 pub mod subscriber;
 pub mod target_addr;
@@ -39,6 +39,7 @@ pub struct DgwState {
     pub jrl: Arc<token::CurrentJrl>,
     pub sessions: session::SessionManagerHandle,
     pub subscriber_tx: subscriber::SubscriberSender,
+    pub shutdown_signal: devolutions_gateway_task::ShutdownSignal,
 }
 
 pub fn make_http_service(state: DgwState) -> axum::Router<()> {

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -37,9 +37,10 @@ pub struct DgwState {
     pub conf_handle: config::ConfHandle,
     pub token_cache: Arc<token::TokenCache>,
     pub jrl: Arc<token::CurrentJrl>,
-    pub sessions: session::SessionManagerHandle,
+    pub sessions: session::SessionMessageSender,
     pub subscriber_tx: subscriber::SubscriberSender,
     pub shutdown_signal: devolutions_gateway_task::ShutdownSignal,
+    pub recordings: recording::RecordingMessageSender,
 }
 
 pub fn make_http_service(state: DgwState) -> axum::Router<()> {

--- a/devolutions-gateway/src/listener.rs
+++ b/devolutions-gateway/src/listener.rs
@@ -151,6 +151,7 @@ async fn handle_tcp_peer(stream: TcpStream, state: DgwState, peer_addr: SocketAd
                 .jrl(state.jrl)
                 .sessions(state.sessions)
                 .subscriber_tx(state.subscriber_tx)
+                .active_recordings(state.recordings.active_recordings)
                 .build()
                 .serve()
                 .instrument(info_span!("generic-client"))

--- a/devolutions-gateway/src/main.rs
+++ b/devolutions-gateway/src/main.rs
@@ -10,7 +10,6 @@ use cfg_if::cfg_if;
 use devolutions_gateway::config::ConfHandle;
 use std::sync::mpsc;
 use tap::prelude::*;
-use tracing::info;
 
 use crate::service::{GatewayService, DESCRIPTION, DISPLAY_NAME, SERVICE_NAME};
 
@@ -101,9 +100,7 @@ fn main() -> anyhow::Result<()> {
                 let conf_handle = ConfHandle::init().context("unable to initialize configuration")?;
                 let mut service = GatewayService::load(conf_handle).context("Service loading failed")?;
 
-                service
-                    .start()
-                    .tap_err(|error| tracing::error!(?error, "Failed to start"))?;
+                service.start().tap_err(|error| error!(?error, "Failed to start"))?;
 
                 // Waiting for some stop signal (CTRL-C…)
                 let rt = tokio::runtime::Builder::new_current_thread()
@@ -140,7 +137,7 @@ fn gateway_service_main(
 
     service
         .start()
-        .tap_err(|error| tracing::error!(?error, "Failed to start"))
+        .tap_err(|error| error!(?error, "Failed to start"))
         .expect("start service");
 
     loop {

--- a/devolutions-gateway/src/ngrok.rs
+++ b/devolutions-gateway/src/ngrok.rs
@@ -184,6 +184,7 @@ async fn run_tcp_tunnel(mut tunnel: ngrok::tunnel::TcpTunnel, state: DgwState) {
                         .jrl(state.jrl)
                         .sessions(state.sessions)
                         .subscriber_tx(state.subscriber_tx)
+                        .active_recordings(state.recordings.active_recordings)
                         .build()
                         .serve()
                         .instrument(info_span!("generic-client"))

--- a/devolutions-gateway/src/rdp_pcb.rs
+++ b/devolutions-gateway/src/rdp_pcb.rs
@@ -7,6 +7,7 @@ use ironrdp_pdu::pcb::PreconnectionBlob;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 
 use crate::config::Conf;
+use crate::recording::ActiveRecordings;
 use crate::token::{AccessTokenClaims, AssociationTokenClaims, CurrentJrl, TokenCache, TokenValidator};
 
 pub fn extract_association_claims(
@@ -15,6 +16,7 @@ pub fn extract_association_claims(
     conf: &Conf,
     token_cache: &TokenCache,
     jrl: &CurrentJrl,
+    active_recordings: &ActiveRecordings,
 ) -> anyhow::Result<AssociationTokenClaims> {
     let token = pcb.v2_payload.as_deref().context("V2 payload missing from RDP PCB")?;
 
@@ -36,6 +38,7 @@ pub fn extract_association_claims(
             .revocation_list(jrl)
             .gw_id(conf.id)
             .subkey(conf.sub_provisioner_public_key.as_ref())
+            .active_recordings(active_recordings)
             .build()
             .validate(token)
     }

--- a/devolutions-gateway/src/recording.rs
+++ b/devolutions-gateway/src/recording.rs
@@ -1,17 +1,27 @@
+use core::fmt;
+use std::cmp;
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::config::Conf;
-use crate::token::{JrecTokenClaims, RecordingFileType};
-
 use anyhow::Context as _;
+use async_trait::async_trait;
+use camino::Utf8PathBuf;
+use devolutions_gateway_task::{ShutdownSignal, Task};
+use parking_lot::Mutex;
 use serde::Serialize;
-use tokio::io::{AsyncRead, AsyncWrite, BufWriter};
-use tokio::{fs, io};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufWriter};
+use tokio::sync::{mpsc, oneshot};
+use tokio::{fs, io, time};
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Serialize, Deserialize)]
+use crate::token::{JrecTokenClaims, RecordingFileType};
+
+const DISCONNECTED_TTL_SECS: i64 = 10;
+const DISCONNECTED_TTL_DURATION: time::Duration = time::Duration::from_secs(DISCONNECTED_TTL_SECS as u64);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct JrecFile {
     file_name: String,
@@ -19,7 +29,7 @@ struct JrecFile {
     duration: i64,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct JrecManifest {
     session_id: Uuid,
@@ -44,15 +54,13 @@ impl JrecManifest {
 
 #[derive(TypedBuilder)]
 pub struct ClientPush<S> {
-    conf: Arc<Conf>,
+    recordings: RecordingMessageSender,
     claims: JrecTokenClaims,
     client_stream: S,
     file_type: RecordingFileType,
     session_id: Uuid,
+    shutdown_signal: ShutdownSignal,
 }
-
-// TODO: harden this!!!
-// FIXME: at some point, we should track ongoing recordings and make sure there is no data race to write the manifest file
 
 impl<S> ClientPush<S>
 where
@@ -60,40 +68,293 @@ where
 {
     pub async fn run(self) -> anyhow::Result<()> {
         let Self {
-            conf,
+            recordings,
             claims,
             mut client_stream,
             file_type,
             session_id,
+            mut shutdown_signal,
         } = self;
 
         if session_id != claims.jet_aid {
             anyhow::bail!("inconsistent session ID (ID in token: {})", claims.jet_aid);
         }
 
-        let recording_path = conf.recording_path.join(session_id.to_string());
-        let manifest_file = recording_path.join("recording.json");
+        let recording_file = match recordings.connect(session_id, file_type).await {
+            Ok(recording_file) => recording_file,
+            Err(e) => {
+                warn!(error = format!("{e:#}"), "Unable to start recording");
+                client_stream.shutdown().await.context("shutdown")?;
+                return Ok(());
+            }
+        };
 
-        let (file_idx, mut manifest) = if recording_path.exists() {
+        debug!(path = %recording_file, "Opening file");
+
+        let res = match fs::OpenOptions::new()
+            .read(false)
+            .write(true)
+            .create(true)
+            .open(&recording_file)
+            .await
+        {
+            Ok(file) => {
+                let mut file = BufWriter::new(file);
+
+                let shutdown_signal = shutdown_signal.wait();
+                let copy_fut = io::copy(&mut client_stream, &mut file);
+
+                tokio::select! {
+                    res = copy_fut => {
+                        res.context("JREC streaming to file").map(|_| ())
+                    },
+                    _ = shutdown_signal => {
+                        trace!("Received shutdown signal");
+                        client_stream.shutdown().await.context("shutdown")
+                    },
+                }
+            }
+            Err(e) => Err(anyhow::Error::new(e).context(format!("failed to open file at {recording_file}"))),
+        };
+
+        recordings.disconnect(session_id).await.context("disconnect")?;
+
+        res
+    }
+}
+
+/// A set containing IDs of currently active recordings.
+///
+/// The ID is inserted at the initial recording
+///
+/// The purpose of this set is to provide a quick way of checking if a recording
+/// is on-going for a given session ID in non-async context.
+/// If you are looking for the the detailled recording state, you can use the
+/// the `get_state` method provided by `RecordingMessageSender`.
+#[derive(Debug)]
+pub struct ActiveRecordings(Mutex<HashSet<Uuid>>);
+
+impl ActiveRecordings {
+    pub fn contains(&self, id: Uuid) -> bool {
+        self.0.lock().contains(&id)
+    }
+
+    fn insert(&self, id: Uuid) -> usize {
+        let mut guard = self.0.lock();
+        guard.insert(id);
+        guard.len()
+    }
+
+    fn remove(&self, id: Uuid) {
+        self.0.lock().remove(&id);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum OnGoingRecordingState {
+    Connected,
+    LastSeen { timestamp: i64 },
+}
+
+#[derive(Debug, Clone)]
+struct OnGoingRecording {
+    state: OnGoingRecordingState,
+    manifest: JrecManifest,
+    manifest_path: Utf8PathBuf,
+}
+
+enum RecordingManagerMessage {
+    Connect {
+        id: Uuid,
+        file_type: RecordingFileType,
+        channel: oneshot::Sender<Utf8PathBuf>,
+    },
+    Disconnect {
+        id: Uuid,
+    },
+    GetState {
+        id: Uuid,
+        channel: oneshot::Sender<Option<OnGoingRecordingState>>,
+    },
+    GetCount {
+        channel: oneshot::Sender<usize>,
+    },
+}
+
+impl fmt::Debug for RecordingManagerMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RecordingManagerMessage::Connect {
+                id,
+                file_type,
+                channel: _,
+            } => f
+                .debug_struct("Connect")
+                .field("id", id)
+                .field("file_type", file_type)
+                .finish_non_exhaustive(),
+            RecordingManagerMessage::Disconnect { id } => f.debug_struct("Disconnect").field("id", id).finish(),
+            RecordingManagerMessage::GetState { id, channel: _ } => {
+                f.debug_struct("GetState").field("id", id).finish_non_exhaustive()
+            }
+            RecordingManagerMessage::GetCount { channel: _ } => f.debug_struct("GetCount").finish_non_exhaustive(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RecordingMessageSender {
+    channel: mpsc::Sender<RecordingManagerMessage>,
+    pub active_recordings: Arc<ActiveRecordings>,
+}
+
+impl RecordingMessageSender {
+    async fn connect(&self, id: Uuid, file_type: RecordingFileType) -> anyhow::Result<Utf8PathBuf> {
+        let (tx, rx) = oneshot::channel();
+        self.channel
+            .send(RecordingManagerMessage::Connect {
+                id,
+                file_type,
+                channel: tx,
+            })
+            .await
+            .ok()
+            .context("couldn't send New message")?;
+        rx.await
+            .context("couldn't receive recording file path for this recording")
+    }
+
+    async fn disconnect(&self, id: Uuid) -> anyhow::Result<()> {
+        self.channel
+            .send(RecordingManagerMessage::Disconnect { id })
+            .await
+            .ok()
+            .context("couldn't send Remove message")
+    }
+
+    pub async fn get_state(&self, id: Uuid) -> anyhow::Result<Option<OnGoingRecordingState>> {
+        let (tx, rx) = oneshot::channel();
+        self.channel
+            .send(RecordingManagerMessage::GetState { id, channel: tx })
+            .await
+            .ok()
+            .context("couldn't send GetState message")?;
+        rx.await.context("couldn't receive recording state")
+    }
+
+    pub async fn get_count(&self) -> anyhow::Result<usize> {
+        let (tx, rx) = oneshot::channel();
+        self.channel
+            .send(RecordingManagerMessage::GetCount { channel: tx })
+            .await
+            .ok()
+            .context("couldn't send GetCount message")?;
+        rx.await.context("couldn't receive ongoing recording count")
+    }
+}
+
+pub struct RecordingMessageReceiver {
+    channel: mpsc::Receiver<RecordingManagerMessage>,
+    active_recordings: Arc<ActiveRecordings>,
+}
+
+pub fn recording_message_channel() -> (RecordingMessageSender, RecordingMessageReceiver) {
+    let ongoing_recordings = Arc::new(ActiveRecordings(Mutex::new(HashSet::new())));
+
+    let (tx, rx) = mpsc::channel(64);
+
+    let handle = RecordingMessageSender {
+        channel: tx,
+        active_recordings: ongoing_recordings.clone(),
+    };
+
+    let receiver = RecordingMessageReceiver {
+        channel: rx,
+        active_recordings: ongoing_recordings,
+    };
+
+    (handle, receiver)
+}
+
+struct DisconnectedTtl {
+    deadline: time::Instant,
+    id: Uuid,
+}
+
+impl PartialEq for DisconnectedTtl {
+    fn eq(&self, other: &Self) -> bool {
+        self.deadline.eq(&other.deadline) && self.id.eq(&other.id)
+    }
+}
+
+impl Eq for DisconnectedTtl {}
+
+impl PartialOrd for DisconnectedTtl {
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DisconnectedTtl {
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        match self.deadline.cmp(&other.deadline) {
+            cmp::Ordering::Less => cmp::Ordering::Greater,
+            cmp::Ordering::Equal => self.id.cmp(&other.id),
+            cmp::Ordering::Greater => cmp::Ordering::Less,
+        }
+    }
+}
+
+pub struct RecordingManagerTask {
+    rx: RecordingMessageReceiver,
+    ongoing_recordings: HashMap<Uuid, OnGoingRecording>,
+    recordings_path: Utf8PathBuf,
+}
+
+impl RecordingManagerTask {
+    pub fn new(rx: RecordingMessageReceiver, recordings_path: Utf8PathBuf) -> Self {
+        Self {
+            rx,
+            ongoing_recordings: HashMap::new(),
+            recordings_path,
+        }
+    }
+
+    async fn handle_connect(&mut self, id: Uuid, file_type: RecordingFileType) -> anyhow::Result<Utf8PathBuf> {
+        const LENGTH_WARNING_THRESHOLD: usize = 1000;
+
+        if let Some(ongoing) = self.ongoing_recordings.get(&id) {
+            if matches!(ongoing.state, OnGoingRecordingState::Connected) {
+                anyhow::bail!("concurrent recording for the same session is not supported");
+            }
+        }
+
+        let recording_path = self.recordings_path.join(id.to_string());
+        let manifest_path = recording_path.join("recording.json");
+
+        let (manifest, recording_file) = if recording_path.exists() {
             debug!(path = %recording_path, "Recording directory already exists");
 
             let mut existing_manifest =
-                JrecManifest::read_from_file(&manifest_file).context("read manifest from disk")?;
+                JrecManifest::read_from_file(&manifest_path).context("read manifest from disk")?;
             let next_file_idx = existing_manifest.files.len();
 
             let start_time = chrono::Utc::now().timestamp();
 
+            let file_name = format!("recording-{next_file_idx}.{file_type}");
+            let recording_file = recording_path.join(&file_name);
+
             existing_manifest.files.push(JrecFile {
                 start_time,
                 duration: 0,
-                file_name: format!("recording-{next_file_idx}.{file_type}"),
+                file_name,
             });
 
             existing_manifest
-                .save_to_file(&manifest_file)
+                .save_to_file(&manifest_path)
                 .context("override existing manifest")?;
 
-            (next_file_idx, existing_manifest)
+            (existing_manifest, recording_file)
         } else {
             debug!(path = %recording_path, "Create recording directory");
 
@@ -102,60 +363,209 @@ where
                 .with_context(|| format!("failed to create recording path: {recording_path}"))?;
 
             let start_time = chrono::Utc::now().timestamp();
+            let file_name = format!("recording-0.{file_type}");
+            let recording_file = recording_path.join(&file_name);
 
             let first_file = JrecFile {
                 start_time,
                 duration: 0,
-                file_name: format!("recording-0.{file_type}"),
+                file_name,
             };
 
             let initial_manifest = JrecManifest {
-                session_id,
+                session_id: id,
                 start_time,
                 duration: 0,
                 files: vec![first_file],
             };
 
             initial_manifest
-                .save_to_file(&manifest_file)
+                .save_to_file(&manifest_path)
                 .context("write initial manifest to disk")?;
 
-            (0, initial_manifest)
+            (initial_manifest, recording_file)
         };
 
-        let current_file = manifest
-            .files
-            .get_mut(file_idx)
-            .context("this is a bug: invalid file index")?;
+        let active_recording_count = self.rx.active_recordings.insert(id);
 
-        let recording_file = recording_path.join(&current_file.file_name);
+        self.ongoing_recordings.insert(
+            id,
+            OnGoingRecording {
+                state: OnGoingRecordingState::Connected,
+                manifest,
+                manifest_path,
+            },
+        );
+        let ongoing_recording_count = self.ongoing_recordings.len();
 
-        debug!(path = %recording_file, "Opening file");
+        // Sanity check
+        if active_recording_count > LENGTH_WARNING_THRESHOLD || ongoing_recording_count > LENGTH_WARNING_THRESHOLD {
+            warn!(
+                active_recording_count,
+                ongoing_recording_count,
+                "length threshold exceeded (either the load is very high or the list is growing uncontrollably)"
+            );
+        }
 
-        let mut file = fs::OpenOptions::new()
-            .read(false)
-            .write(true)
-            .create(true)
-            .open(&recording_file)
-            .await
-            .with_context(|| format!("failed to open file at {recording_file}"))
-            .map(BufWriter::new)?;
-
-        io::copy(&mut client_stream, &mut file)
-            .await
-            .context("JREC streaming to file")?;
-
-        let end_time = chrono::Utc::now().timestamp();
-
-        current_file.duration = end_time - current_file.start_time;
-        manifest.duration = end_time - manifest.start_time;
-
-        debug!(path = %manifest_file, "Write updated manifest to disk");
-
-        manifest
-            .save_to_file(&manifest_file)
-            .context("write updated manifest to disk")?;
-
-        Ok(())
+        Ok(recording_file)
     }
+
+    fn handle_disconnect(&mut self, id: Uuid) -> anyhow::Result<()> {
+        if let Some(ongoing) = self.ongoing_recordings.get_mut(&id) {
+            if !matches!(ongoing.state, OnGoingRecordingState::Connected) {
+                anyhow::bail!("a recording not connected can’t be disconnected (there is probably a bug)");
+            }
+
+            let end_time = chrono::Utc::now().timestamp();
+
+            ongoing.state = OnGoingRecordingState::LastSeen { timestamp: end_time };
+
+            let current_file = ongoing
+                .manifest
+                .files
+                .last_mut()
+                .context("no recording file (this is a bug)")?;
+            current_file.duration = end_time - current_file.start_time;
+
+            ongoing.manifest.duration = end_time - ongoing.manifest.start_time;
+
+            debug!(path = %ongoing.manifest_path, "Write updated manifest to disk");
+
+            ongoing
+                .manifest
+                .save_to_file(&ongoing.manifest_path)
+                .with_context(|| format!("write manifest at {}", ongoing.manifest_path))?;
+
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!("unknown recording for ID {id}"))
+        }
+    }
+
+    fn handle_remove(&mut self, id: Uuid) {
+        if let Some(ongoing) = self.ongoing_recordings.get(&id) {
+            let now = chrono::Utc::now().timestamp();
+
+            match ongoing.state {
+                // NOTE: Comparing with DISCONNECTED_TTL_SECS - 1 just in case the sleep returns faster than expected.
+                // (I don’t know if this can actually happen in practice, but it’s better to be safe than sorry.)
+                OnGoingRecordingState::LastSeen { timestamp } if now >= timestamp + DISCONNECTED_TTL_SECS - 1 => {
+                    debug!(%id, "Mark recording as terminated");
+                    self.rx.active_recordings.remove(id);
+                    self.ongoing_recordings.remove(&id);
+
+                    // TODO(DGW-86): now is a good timing to kill sessions that _must_ be recorded
+                }
+                _ => {
+                    trace!(%id, "Recording should not be removed yet");
+                }
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Task for RecordingManagerTask {
+    type Output = anyhow::Result<()>;
+
+    const NAME: &'static str = "recording manager";
+
+    async fn run(self, shutdown_signal: ShutdownSignal) -> Self::Output {
+        recording_manager_task(self, shutdown_signal).await
+    }
+}
+
+#[instrument(skip_all)]
+async fn recording_manager_task(
+    mut manager: RecordingManagerTask,
+    mut shutdown_signal: ShutdownSignal,
+) -> anyhow::Result<()> {
+    debug!("Task started");
+
+    let mut disconnected = BinaryHeap::<DisconnectedTtl>::new();
+
+    let next_remove_sleep = time::sleep_until(time::Instant::now());
+    tokio::pin!(next_remove_sleep);
+
+    // Consume initial sleep
+    (&mut next_remove_sleep).await;
+
+    loop {
+        tokio::select! {
+            () = &mut next_remove_sleep, if !disconnected.is_empty() => {
+                // Will never panic since we check for non-emptiness before entering this block
+                let to_remove = disconnected.pop().unwrap();
+
+                manager.handle_remove(to_remove.id);
+
+                // Re-arm the Sleep instance with the next deadline if required
+                if let Some(next) = disconnected.peek() {
+                    next_remove_sleep.as_mut().reset(next.deadline)
+                }
+            }
+            msg = manager.rx.channel.recv() => {
+                let Some(msg) = msg else {
+                    warn!("All senders are dead");
+                    break;
+                };
+
+                debug!(?msg, "Received message");
+
+                match msg {
+                    RecordingManagerMessage::Connect { id, file_type, channel  } => {
+                        match manager.handle_connect(id, file_type).await {
+                            Ok(recording_file) => {
+                                let _ = channel.send(recording_file);
+                            }
+                            Err(e) => error!(error = format!("{e:#}"), "handle_connect"),
+                        }
+                    },
+                    RecordingManagerMessage::Disconnect { id } => {
+                        if let Err(e) = manager.handle_disconnect(id) {
+                            error!(error = format!("{e:#}"), "handle_disconnect");
+                        }
+
+                        let now = time::Instant::now();
+                        let deadline = now + DISCONNECTED_TTL_DURATION;
+
+                        disconnected.push(DisconnectedTtl {
+                            deadline,
+                            id,
+                        });
+
+                        // Reset the Sleep instance if the new deadline is sooner or it is already elapsed
+                        if next_remove_sleep.is_elapsed() || deadline < next_remove_sleep.deadline() {
+                            next_remove_sleep.as_mut().reset(deadline);
+                        }
+                    }
+                    RecordingManagerMessage::GetState { id, channel } => {
+                        let response = manager.ongoing_recordings.get(&id).map(|ongoing| ongoing.state.clone());
+                        let _ = channel.send(response);
+                    }
+                    RecordingManagerMessage::GetCount { channel } => {
+                        let _ = channel.send(manager.ongoing_recordings.len());
+                    }
+                }
+            }
+            _ = shutdown_signal.wait() => {
+                break;
+            }
+        }
+    }
+
+    debug!("Task is stopping; wait for disconnect messages");
+
+    while let Some(msg) = manager.rx.channel.recv().await {
+        debug!(?msg, "Received message");
+        if let RecordingManagerMessage::Disconnect { id } = msg {
+            if let Err(e) = manager.handle_disconnect(id) {
+                error!(error = format!("{e:#}"), "handle_disconnect");
+            }
+            manager.ongoing_recordings.remove(&id);
+        }
+    }
+
+    debug!("Task terminated");
+
+    Ok(())
 }

--- a/devolutions-gateway/src/recording.rs
+++ b/devolutions-gateway/src/recording.rs
@@ -51,6 +51,7 @@ pub struct ClientPush<S> {
     session_id: Uuid,
 }
 
+// TODO: harden this!!!
 // FIXME: at some point, we should track ongoing recordings and make sure there is no data race to write the manifest file
 
 impl<S> ClientPush<S>

--- a/devolutions-gateway/tests/dvls_compatibility.rs
+++ b/devolutions-gateway/tests/dvls_compatibility.rs
@@ -1,3 +1,4 @@
+use devolutions_gateway::recording::ActiveRecordings;
 use devolutions_gateway::token::{CurrentJrl, JrlTokenClaims, TokenCache};
 use devolutions_gateway_generators::*;
 use parking_lot::Mutex;
@@ -47,6 +48,7 @@ fn encode_decode_round_trip<C>(
     gw_id: Option<Uuid>,
     token_cache: &TokenCache,
     jrl: &CurrentJrl,
+    active_recordings: &ActiveRecordings,
 ) -> anyhow::Result<()>
 where
     C: serde::ser::Serialize,
@@ -67,6 +69,7 @@ where
         .revocation_list(jrl)
         .gw_id(gw_id)
         .subkey(None)
+        .active_recordings(active_recordings)
         .build()
         .validate(&token)?;
 
@@ -81,6 +84,12 @@ fn token_cache() -> TokenCache {
 #[fixture]
 fn jrl() -> Mutex<JrlTokenClaims> {
     Mutex::new(JrlTokenClaims::default())
+}
+
+#[fixture]
+fn active_recordings() -> ActiveRecordings {
+    let (rx, _) = devolutions_gateway::recording::recording_message_channel();
+    std::sync::Arc::try_unwrap(rx.active_recordings).unwrap()
 }
 
 #[fixture]
@@ -166,6 +175,7 @@ mod as_of_v2022_3_0_0 {
     fn scope_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -179,7 +189,8 @@ mod as_of_v2022_3_0_0 {
                 Some(CTY_SCOPE.to_owned()),
                 Some(jet_gw_id),
                 &token_cache,
-                &jrl
+                &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -243,6 +254,7 @@ mod as_of_v2022_3_0_0 {
     fn association_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -257,6 +269,7 @@ mod as_of_v2022_3_0_0 {
                 Some(jet_gw_id),
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -307,6 +320,7 @@ mod as_of_v2022_3_0_0 {
     fn jmux_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -321,6 +335,7 @@ mod as_of_v2022_3_0_0 {
                 Some(jet_gw_id),
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -367,6 +382,7 @@ mod as_of_v2022_3_0_0 {
     fn kdc_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -381,6 +397,7 @@ mod as_of_v2022_3_0_0 {
                 Some(jet_gw_id),
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -423,6 +440,7 @@ mod as_of_v2022_3_0_0 {
     fn jrl_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -437,6 +455,7 @@ mod as_of_v2022_3_0_0 {
                 Some(jet_gw_id),
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -518,6 +537,7 @@ mod as_of_v2022_2_0_0 {
     fn association_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -530,7 +550,8 @@ mod as_of_v2022_2_0_0 {
                 Some(CTY_ASSOCIATION.to_owned()),
                 None,
                 &token_cache,
-                &jrl
+                &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -578,6 +599,7 @@ mod as_of_v2022_2_0_0 {
     fn jmux_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -591,6 +613,7 @@ mod as_of_v2022_2_0_0 {
                 None,
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -666,6 +689,7 @@ mod as_of_v2021_2_13_0 {
     fn association_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -679,6 +703,7 @@ mod as_of_v2021_2_13_0 {
                 None,
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -746,6 +771,7 @@ mod as_of_v2021_2_4 {
     fn scope_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -759,6 +785,7 @@ mod as_of_v2021_2_4 {
                 None,
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }
@@ -804,6 +831,7 @@ mod as_of_v2021_1_7_0 {
     fn association_token_validation(
         token_cache: TokenCache,
         jrl: Mutex<JrlTokenClaims>,
+        active_recordings: ActiveRecordings,
         priv_key: PrivateKey,
         pub_key: PublicKey,
         now: i64,
@@ -817,6 +845,7 @@ mod as_of_v2021_1_7_0 {
                 None,
                 &token_cache,
                 &jrl,
+                &active_recordings,
             ).map_err(|e| TestCaseError::fail(format!("{e:#}")))?;
         });
     }

--- a/jetsocat/src/lib.rs
+++ b/jetsocat/src/lib.rs
@@ -41,7 +41,7 @@ pub async fn forward(cfg: ForwardCfg) -> anyhow::Result<()> {
         )
         .instrument(info_span!("open_pipe_a"))
         .await
-        .context("Couldn't open pipe A")?;
+        .context("couldn't open pipe A")?;
 
         let pipe_b = utils::timeout(
             cfg.pipe_timeout,
@@ -49,13 +49,13 @@ pub async fn forward(cfg: ForwardCfg) -> anyhow::Result<()> {
         )
         .instrument(info_span!("open_pipe_b"))
         .await
-        .context("Couldn't open pipe B")?;
+        .context("couldn't open pipe B")?;
 
         let pipe_fut = pipe(pipe_a, pipe_b);
 
         utils::while_process_is_running(cfg.watch_process, pipe_fut)
             .await
-            .context("Failed to pipe")?;
+            .context("failed to pipe")?;
     }
 
     Ok(())

--- a/jetsocat/src/listener.rs
+++ b/jetsocat/src/listener.rs
@@ -129,7 +129,7 @@ async fn socks5_process_socket(
             Ok(()) => {}
             Err(error) => {
                 warn!(%error, "Couldn’t send JMUX API request");
-                anyhow::bail!("Couldn't send JMUX request");
+                anyhow::bail!("couldn't send JMUX request");
             }
         }
 
@@ -137,7 +137,7 @@ async fn socks5_process_socket(
             JmuxApiResponse::Success { id } => id,
             JmuxApiResponse::Failure { id, reason_code } => {
                 let _ = acceptor.failed(jmux_to_socks_error(reason_code)).await;
-                anyhow::bail!("Channel {} failure: {}", id, reason_code);
+                anyhow::bail!("channel {} failure: {}", id, reason_code);
             }
         };
 
@@ -218,7 +218,7 @@ async fn http_process_socket(api_request_tx: ApiRequestSender, incoming: TcpStre
         Err(error) => {
             warn!(%error, "Couldn’t send JMUX API request");
             let _ = acceptor.failure(proxy_http::ErrorCode::InternalServerError).await;
-            anyhow::bail!("Couldn't send JMUX request");
+            anyhow::bail!("couldn't send JMUX request");
         }
     }
 
@@ -226,7 +226,7 @@ async fn http_process_socket(api_request_tx: ApiRequestSender, incoming: TcpStre
         JmuxApiResponse::Success { id } => id,
         JmuxApiResponse::Failure { id, reason_code } => {
             let _ = acceptor.failure(jmux_to_http_error_code(reason_code)).await;
-            anyhow::bail!("Channel {} failure: {}", id, reason_code);
+            anyhow::bail!("channel {} failure: {}", id, reason_code);
         }
     };
 
@@ -284,7 +284,7 @@ where
 
     let listener = TcpListener::bind(&bind_addr)
         .await
-        .with_context(|| format!("Couldn’t bind listener to {bind_addr}"))?;
+        .with_context(|| format!("couldn’t bind listener to {bind_addr}"))?;
 
     info!("Start listener");
 


### PR DESCRIPTION
# Pre-release hardening

This hardens Devolutions Gateway service before cutting the next release.

## Graceful shutdown

It is now very important to handle service shutdown in a graceful way.

Indeed, ongoing recording manifests should not get lost when restarting the service.

To that end, I figured it was easier to refactor how tasks and futures are handled in Devolutions Gateway.
On current master, listener and task futures are all box-pinned and collected into a vector that is then
wrapped into a `futures::future::SelectAll` that is then polled by the async runtime.

Relevant code:

- https://github.com/Devolutions/devolutions-gateway/blob/3a869f924c1089fc60b3b0ae85a9ce8cf640fd59/devolutions-gateway/src/service.rs#L116
- https://github.com/Devolutions/devolutions-gateway/blob/3a869f924c1089fc60b3b0ae85a9ce8cf640fd59/devolutions-gateway/src/service.rs#L75

This patch is changing this so that:
- a `tokio` task is spawned for each of these futures,
- a new wrapper struct `ChildTask` is used to explicitly handle whether a task should be "detached" or not, and
- all tasks are given a `ShutdownSignal` watcher in order to gracefully terminate themselves.

Since this change may impact performance, I performed a simple benchmark just for sanity.
(We should build a benchmark suite at some point to be more accurate.)

## Basic benchmark

In this benchmark (a stress test, really), [`oha`](https://github.com/hatoo/oha) is used to generate the HTTP load.

### Procedure

Gateway configuration:

```json
{
  "Id": "aa0b2a02-ba9d-4e87-b707-03c6391b86fb",
  "ProvisionerPublicKeyFile": "provisioner.pub.key",
  "ProvisionerPrivateKeyFile": "provisioner.priv.key",
  "Listeners": [
    {
      "InternalUrl": "tcp://*:8080",
      "ExternalUrl": "tcp://*:8080"
    },
    {
      "InternalUrl": "ws://*:7171",
      "ExternalUrl": "wss://*:7171"
    }
  ],
  "LogDirective": "error",
  "__debug__": {
    "disable_token_validation": true
  }
}  
```

Build and run using `cargo run --release`.

The `/jet/heartbeat` route will be used because it’s one of the most used, and is performing
message passing to obtain the number of running sessions (always 0 in this benchmark).

Make sure other applications such a web browsers are closed.

Then, warm up for a few seconds:

```shell
$ oha -z 10s -H "Authorization: Bearer <REDACTED>" http://localhost:7171/jet/heartbeat
```

And run again for 5 minutes with a few additional arguments:

```shell
$ oha -z 5m -c 50 --no-tui -q 15000 --latency-correction --disable-keepalive -H "Authorization: Bearer <REDACTED>" http://localhost:7171/jet/heartbeat
```

`--disable-keepalive` is for disabling HTTP keep-alive (connection reuse), and `--latency-correction`
along with `-q`, the number of query per second desired, to avoid / mitigate the "Coordinated Omission Problem".

### Results against `master`

```
Summary:
  Success rate: 1.0000
  Total:        300.0001 secs
  Slowest:      0.0155 secs
  Fastest:      0.0003 secs
  Average:      0.0015 secs
  Requests/sec: 14999.9157

  Total data:   549.31 MiB
  Size/request: 128 B
  Size/sec:     1.83 MiB

Response time histogram:
  0.000 [1]       |
  0.002 [3410547] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.003 [986302]  |■■■■■■■■■
  0.005 [93311]   |
  0.006 [7806]    |
  0.008 [1157]    |
  0.009 [454]     |
  0.011 [252]     |
  0.012 [83]      |
  0.014 [49]      |
  0.016 [14]      |

Latency distribution:
  10% in 0.0009 secs
  25% in 0.0010 secs
  50% in 0.0014 secs
  75% in 0.0018 secs
  90% in 0.0024 secs
  95% in 0.0028 secs
  99% in 0.0038 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0002 secs, 0.0000 secs, 0.0103 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0036 secs

Status code distribution:
  [200] 4499976 responses
```

### Results against this patch

```
Summary:
  Success rate: 1.0000
  Total:        300.0004 secs
  Slowest:      0.0170 secs
  Fastest:      0.0003 secs
  Average:      0.0013 secs
  Requests/sec: 14999.9229

  Total data:   549.31 MiB
  Size/request: 128 B
  Size/sec:     1.83 MiB

Response time histogram:
  0.000 [1]       |
  0.002 [4079329] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.004 [401430]  |■■■
  0.005 [16952]   |
  0.007 [1142]    |
  0.009 [398]     |
  0.010 [399]     |
  0.012 [205]     |
  0.014 [110]     |
  0.015 [15]      |
  0.017 [2]       |

Latency distribution:
  10% in 0.0009 secs
  25% in 0.0010 secs
  50% in 0.0012 secs
  75% in 0.0016 secs
  90% in 0.0020 secs
  95% in 0.0023 secs
  99% in 0.0032 secs

Details (average, fastest, slowest):
  DNS+dialup:   0.0001 secs, 0.0000 secs, 0.0103 secs
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0034 secs

Status code distribution:
  [200] 4499983 responses
```

### Discussion

- Average response time: 0.0015s → 0.0013s
- Slowest request time: 0.0155s → 0.0170s

It seems the performance is not significantly impacted by this change.

Again, the benchmark is really simple and is only performing a simple API request.

That being said, I think this patch can be merged with a fair degree of confidence that no outstanding
regression has been introduced.

## Responsible recording manifest flushing

A single task ("actor") is now responsible for managing manifest files so that we ensure there is no
data race in a sane way.

When shutting down the service, all pending manifest files are flushed (written).
