### PR TITLE
fix(jmux): ignore case for hosts and schemes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,7 +844,6 @@ dependencies = [
  "dlopen",
  "dlopen_derive",
  "embed-resource",
- "focaccia",
  "futures",
  "hostname",
  "humantime-serde",
@@ -1086,12 +1085,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "focaccia"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e415e05c1870775d4ccef03519c171fac5bf7be3e32b175390df8a85e757b9be"
 
 [[package]]
 name = "foreign-types"

--- a/crates/jmux-proxy/src/config.rs
+++ b/crates/jmux-proxy/src/config.rs
@@ -66,6 +66,7 @@ impl JmuxConfig {
 ///
 /// assert!(elaborated_rule.validate_destination_str("tcp://doc.rust-lang.org:80").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("ws://devolutions.net:80").is_ok());
+/// assert!(elaborated_rule.validate_destination_str("ws://DeVoLUTiONS.net:80").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("wss://dvls.devolutions.net:80").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("tcp://dvls.devolutions.ninja:80").is_err());
 /// assert!(elaborated_rule.validate_destination_str("tcp://devolutions.bad.ninja:80").is_err());
@@ -73,6 +74,7 @@ impl JmuxConfig {
 ///
 /// assert!(elaborated_rule.validate_destination_str("tcp://vps.my-web-site.com:22").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("tcp://vps.rust-lang.org:22").is_ok());
+/// assert!(elaborated_rule.validate_destination_str("TCP://VPS.RUST-LANG.ORG:22").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("tcp://super.vps.ninja:22").is_err());
 /// assert!(elaborated_rule.validate_destination_str("tcp://vps.super.devolutions.ninja:22").is_err());
 /// assert!(elaborated_rule.validate_destination_str("tcp://vps.my-web-site.com:2222").is_err());
@@ -83,9 +85,11 @@ impl JmuxConfig {
 /// assert!(elaborated_rule.validate_destination_str("tcp://sekai.net:80").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("tcp://sekai.net:8080").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("tcp://sekai.net:22").is_ok());
+/// assert!(elaborated_rule.validate_destination_str("tCp://sEkAi.nEt:22").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("tcp://sekai.net:1080").is_err());
 ///
 /// assert!(elaborated_rule.validate_destination_str("wss://127.0.0.1:8080").is_ok());
+/// assert!(elaborated_rule.validate_destination_str("WSS://127.0.0.1:8080").is_ok());
 /// assert!(elaborated_rule.validate_destination_str("wss://doc.rust-lang.org:8080").is_err());
 /// assert!(elaborated_rule.validate_destination_str("wss://127.0.0.1:80").is_err());
 /// assert!(elaborated_rule.validate_destination_str("tcp://127.0.0.1:8080").is_err());
@@ -232,16 +236,16 @@ fn is_valid(rule: &FilteringRule, target_scheme: &str, target_host: &str, target
         FilteringRule::Any(rules) => rules
             .iter()
             .any(|r| is_valid(r, target_scheme, target_host, target_port)),
-        FilteringRule::Host(host) => target_host == host,
+        FilteringRule::Host(host) => target_host.eq_ignore_ascii_case(host),
         FilteringRule::Port(port) => target_port == *port,
-        FilteringRule::Scheme(scheme) => target_scheme == scheme,
-        FilteringRule::HostAndPort { host, port } => target_host == host && target_port == *port,
+        FilteringRule::Scheme(scheme) => target_scheme.eq_ignore_ascii_case(scheme),
+        FilteringRule::HostAndPort { host, port } => target_host.eq_ignore_ascii_case(host) && target_port == *port,
         FilteringRule::WildcardHost(host) => {
             let mut expected_it = host.rsplit('.');
             let mut actual_it = target_host.rsplit('.');
             loop {
                 match (expected_it.next(), actual_it.next()) {
-                    (Some(expected), Some(actual)) if expected == actual => {}
+                    (Some(expected), Some(actual)) if expected.eq_ignore_ascii_case(actual) => {}
                     (Some("*"), Some(_)) => {}
                     (None, None) => return true,
                     _ => return false,

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -49,8 +49,6 @@ parking_lot = "0.12.1"
 anyhow = "1.0.71"
 thiserror = "1"
 typed-builder = "0.14.0"
-# Unicode case folding comparisons
-focaccia = "1.3.2"
 backoff = "0.4.0"
 
 # Security, crypto…

--- a/devolutions-gateway/src/api/kdc_proxy.rs
+++ b/devolutions-gateway/src/api/kdc_proxy.rs
@@ -19,8 +19,6 @@ async fn kdc_proxy(
     KdcToken(claims): KdcToken,
     body: axum::body::Bytes,
 ) -> Result<Vec<u8>, HttpError> {
-    use focaccia::unicode_full_case_eq;
-
     let conf = conf_handle.get_conf();
 
     let kdc_proxy_message = KdcProxyMessage::from_raw(&body).map_err(HttpError::bad_request().err())?;
@@ -41,7 +39,7 @@ async fn kdc_proxy(
 
     debug!("Request is for realm (target_domain): {realm}");
 
-    if !unicode_full_case_eq(&claims.krb_realm, &realm) {
+    if !claims.krb_realm.eq_ignore_ascii_case(&realm) {
         if conf.debug.disable_token_validation {
             warn!("**DEBUG OPTION** Allowed a KDC request towards a KDC whose Kerberos realm differs from what's inside the KDC token");
         } else {

--- a/devolutions-gateway/src/api/rdp.rs
+++ b/devolutions-gateway/src/api/rdp.rs
@@ -45,6 +45,7 @@ pub async fn handler(
     Ok(response)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_socket(
     ws: WebSocket,
     conf: Arc<Conf>,

--- a/devolutions-gateway/src/rdp_extension.rs
+++ b/devolutions-gateway/src/rdp_extension.rs
@@ -240,6 +240,7 @@ async fn process_cleanpath(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle(
     mut client_stream: impl AsyncRead + AsyncWrite + Unpin + Send,
     client_addr: SocketAddr,


### PR DESCRIPTION
Case is irrelevant when comparing hostnames and schemes.

Note: using eq_ignore_ascii_case is okay because we don’t really expect unicode in such context.