### PR TITLE
fix(dgw): durations in seconds in ngrok config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ This document provides a list of notable changes introduced in Devolutions Gatew
 
 - _pwsh_: initial devolutions gateway updater tool ([#472](https://github.com/Devolutions/devolutions-gateway/issues/472)) ([d1f5e2053f](https://github.com/Devolutions/devolutions-gateway/commit/d1f5e2053fb001d80c569ab8be10c45e71fecfa7)) 
 
+### Improvements
+
+- _dgw_: durations in seconds in ngrok config ([#485](https://github.com/Devolutions/devolutions-gateway/issues/485))
+
+  Previously, a Duration was deserialized from a string
+  using the `humantime_serde` crate. With this patch, the duration
+  is specified in seconds using an integer.
+
+  In other words, this code:
+  ```rust
+  #[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde")]
+  pub heartbeat_interval: Option<Duration>,
+  ```
+
+  Is changed into this:
+  ```rust
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub heartbeat_interval: Option<u64>,
+  ```
+
 ### Bug Fixes
 
 - _dgw_: truncated payload after PCB reading ([#483](https://github.com/Devolutions/devolutions-gateway/issues/483)) ([875967f15b](https://github.com/Devolutions/devolutions-gateway/commit/875967f15bb3577e3ce211def9f8d42df3776b0e)) ([DGW-97](https://devolutions.atlassian.net/browse/DGW-97)) 
@@ -37,71 +57,15 @@ This document provides a list of notable changes introduced in Devolutions Gatew
 
 - _deps_: bump tokio-rustls from 0.24.0 to 0.24.1 ([#468](https://github.com/Devolutions/devolutions-gateway/issues/468)) ([5b86f4af33](https://github.com/Devolutions/devolutions-gateway/commit/5b86f4af33e245a40cd6f1873cfb7eca46d30bab)) 
 
-  Bumps [tokio-rustls](https://github.com/rustls/tokio-rustls) from 0.24.0 to 0.24.1.
-  - [Commits](https://github.com/rustls/tokio-rustls/commits)
-  
-  ---
-  updated-dependencies:
-  - dependency-name: tokio-rustls
-    dependency-type: direct:production
-    update-type: version-update:semver-patch
-  ...
-
 - _deps_: bump sysinfo from 0.29.0 to 0.29.2 ([#467](https://github.com/Devolutions/devolutions-gateway/issues/467)) ([dfc3e533b5](https://github.com/Devolutions/devolutions-gateway/commit/dfc3e533b5d2e74af50a511b2101d1012ee89318)) 
-
-  Bumps [sysinfo](https://github.com/GuillaumeGomez/sysinfo) from 0.29.0 to 0.29.2.
-  - [Changelog](https://github.com/GuillaumeGomez/sysinfo/blob/master/CHANGELOG.md)
-  - [Commits](https://github.com/GuillaumeGomez/sysinfo/commits)
-  
-  ---
-  updated-dependencies:
-  - dependency-name: sysinfo
-    dependency-type: direct:production
-    update-type: version-update:semver-patch
-  ...
 
 - _deps_: bump log from 0.4.18 to 0.4.19 ([#475](https://github.com/Devolutions/devolutions-gateway/issues/475)) ([c7bd46cd66](https://github.com/Devolutions/devolutions-gateway/commit/c7bd46cd6651e24d79677241202367b86c704143)) 
 
-  Bumps [log](https://github.com/rust-lang/log) from 0.4.18 to 0.4.19.
-  - [Release notes](https://github.com/rust-lang/log/releases)
-  - [Changelog](https://github.com/rust-lang/log/blob/master/CHANGELOG.md)
-  - [Commits](https://github.com/rust-lang/log/compare/0.4.18...0.4.19)
-  
-  ---
-  updated-dependencies:
-  - dependency-name: log
-    dependency-type: direct:production
-    update-type: version-update:semver-patch
-  ...
-
 - _deps_: bump serde_json from 1.0.96 to 1.0.97 ([#473](https://github.com/Devolutions/devolutions-gateway/issues/473)) ([ff301e7c2b](https://github.com/Devolutions/devolutions-gateway/commit/ff301e7c2b8849db2b977e5d86361b21f4d14ef5)) 
-
-  Bumps [serde_json](https://github.com/serde-rs/json) from 1.0.96 to 1.0.97.
-  - [Release notes](https://github.com/serde-rs/json/releases)
-  - [Commits](https://github.com/serde-rs/json/compare/v1.0.96...v1.0.97)
-  
-  ---
-  updated-dependencies:
-  - dependency-name: serde_json
-    dependency-type: direct:production
-    update-type: version-update:semver-patch
-  ...
 
 - Dependency bump and maintainance ([#476](https://github.com/Devolutions/devolutions-gateway/issues/476)) ([a0f8abc113](https://github.com/Devolutions/devolutions-gateway/commit/a0f8abc1137ac4ff289cadf34f0e82f8557e87c6)) 
 
 - _deps_: bump hyper from 0.14.26 to 0.14.27 ([#480](https://github.com/Devolutions/devolutions-gateway/issues/480)) ([3f8c6cac73](https://github.com/Devolutions/devolutions-gateway/commit/3f8c6cac737b13e5ba86cabb56b1aad5c9cefd3f)) 
-
-  Bumps [hyper](https://github.com/hyperium/hyper) from 0.14.26 to 0.14.27.
-  - [Release notes](https://github.com/hyperium/hyper/releases)
-  - [Changelog](https://github.com/hyperium/hyper/blob/v0.14.27/CHANGELOG.md)
-  - [Commits](https://github.com/hyperium/hyper/compare/v0.14.26...v0.14.27)
-  
-  ---
-  updated-dependencies:
-  - dependency-name: hyper
-    dependency-type: direct:production
-    update-type: version-update:semver-patch
-  ...
 
 ## 2023.2.1 (2023-06-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This document provides a list of notable changes introduced in Devolutions Gatew
   pub heartbeat_interval: Option<u64>,
   ```
 
+- _dgw_: make Ngrok listeners appear in configuration diagnostic ([#485](https://github.com/Devolutions/devolutions-gateway/issues/485))
+
 ### Bug Fixes
 
 - _dgw_: truncated payload after PCB reading ([#483](https://github.com/Devolutions/devolutions-gateway/issues/483)) ([875967f15b](https://github.com/Devolutions/devolutions-gateway/commit/875967f15bb3577e3ce211def9f8d42df3776b0e)) ([DGW-97](https://devolutions.atlassian.net/browse/DGW-97)) 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,6 @@ dependencies = [
  "embed-resource",
  "futures",
  "hostname",
- "humantime-serde",
  "hyper",
  "ironrdp-pdu",
  "ironrdp-rdcleanpath",
@@ -1473,16 +1472,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "humantime-serde"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
-dependencies = [
- "humantime",
- "serde",
-]
 
 [[package]]
 name = "hwaddr"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -29,7 +29,6 @@ serde = "1.0.164"
 serde_derive = "1.0.164"
 serde_json = "1.0.97"
 serde_urlencoded = "0.7.1"
-humantime-serde = "1.1.1"
 
 # Utils, misc
 hostname = "0.3.1"
@@ -102,6 +101,3 @@ tokio-test = "0.4.2"
 proptest = "1.2.0"
 rstest = "0.17.0"
 devolutions-gateway-generators = { path = "../crates/devolutions-gateway-generators" }
-
-[package.metadata.cargo-machete]
-ignored = ["humantime-serde"]

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -559,7 +559,7 @@ fn to_listener_urls(conf: &dto::ListenerConf, hostname: &str, auto_ipv6: bool) -
 }
 
 pub mod dto {
-    use std::{collections::HashMap, time::Duration};
+    use std::collections::HashMap;
 
     use serde::{de, ser};
 
@@ -870,10 +870,10 @@ pub mod dto {
     #[serde(rename_all = "PascalCase")]
     pub struct NgrokConf {
         pub authtoken: String,
-        #[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde")]
-        pub heartbeat_interval: Option<Duration>,
-        #[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde")]
-        pub heartbeat_tolerance: Option<Duration>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub heartbeat_interval: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub heartbeat_tolerance: Option<u64>,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub metadata: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/devolutions-gateway/src/ngrok.rs
+++ b/devolutions-gateway/src/ngrok.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Context as _;
 use async_trait::async_trait;
 use devolutions_gateway_task::{ChildTask, ShutdownSignal, Task};
@@ -22,11 +24,11 @@ impl NgrokSession {
         let mut builder = ngrok::Session::builder().authtoken(&conf.authtoken);
 
         if let Some(heartbeat_interval) = conf.heartbeat_interval {
-            builder = builder.heartbeat_interval(heartbeat_interval);
+            builder = builder.heartbeat_interval(Duration::from_secs(heartbeat_interval));
         }
 
         if let Some(heartbeat_tolerance) = conf.heartbeat_tolerance {
-            builder = builder.heartbeat_tolerance(heartbeat_tolerance);
+            builder = builder.heartbeat_tolerance(Duration::from_secs(heartbeat_tolerance));
         }
 
         if let Some(metadata) = &conf.metadata {
@@ -46,8 +48,7 @@ impl NgrokSession {
     }
 
     pub fn configure_endpoint(&self, name: &str, conf: &NgrokTunnelConf) -> NgrokTunnel {
-        use ngrok::config::ProxyProto;
-        use ngrok::config::Scheme;
+        use ngrok::config::{ProxyProto, Scheme};
         use std::str::FromStr as _;
 
         match conf {


### PR DESCRIPTION
Previously, a Duration was deserialized from a string using the `humantime_serde` crate. With this patch, the duration is specified in seconds using an integer.

In other words, this code:
```rust
#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde")]
pub heartbeat_interval: Option<Duration>,
```

Is changed into this:
```rust
#[serde(skip_serializing_if = "Option::is_none")]
pub heartbeat_interval: Option<u64>,
```