### PR TITLE
fix(dgw): error 500 when recording folder is missing

### DIFF
--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -129,8 +129,15 @@ pub(crate) async fn list_recordings(
     _scope: RecordingsReadScope,
 ) -> Result<Json<Vec<Uuid>>, HttpError> {
     let conf = conf_handle.get_conf();
-    let dirs = list_uuid_dirs(conf.recording_path.as_std_path())
-        .map_err(HttpError::internal().with_msg("failed recording listing").err())?;
+    let recording_path = conf.recording_path.as_std_path();
+
+    let dirs = if recording_path.exists() {
+        list_uuid_dirs(recording_path).map_err(HttpError::internal().with_msg("failed recording listing").err())?
+    } else {
+        // If the recording directory does not exist, it means that there is no recording yet
+        Vec::new()
+    };
+
     Ok(Json(dirs))
 }
 


### PR DESCRIPTION
When listing the recordings, if the recording directory does not exist, it means that there is no recording yet (and the folder will be created later). However, Devolutions Gateway is attempting to read this folder anyway and the HTTP error 500 (Internal Server Error) is returned. This patch fixes this by returning an empty list as appropriate.

Issue: DGW-99