### PR TITLE
migrate to use AzureSignTool + Azure Key Vault for code signing

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -91,7 +91,7 @@ jobs:
     name: sign ${{ matrix.tool }} [${{ matrix.platform }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
     needs: [ build, lipo ]
-    environment: build-and-publish
+    environment: publish-prod
     strategy:
       matrix:
         arch: [ x86_64, aarch64, universal ]
@@ -121,17 +121,11 @@ jobs:
             $Path += ".exe"
           }
           echo "binary-path=$Path" >> $Env:GITHUB_OUTPUT
-          
-      - name: Configure certificates
+
+      - name: Install AzureSignTool
         if: matrix.platform == 'pc-windows-msvc'
-        env:
-          CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
-          CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
         run: |
-          $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
-          [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
-          $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
-          Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+          dotnet tool install --global AzureSignTool
 
       - name: Configure certificates
         if: matrix.platform == 'apple-darwin'
@@ -160,16 +154,15 @@ jobs:
         shell: pwsh
         run: |
           if ('${{ matrix.platform }}' -Eq 'pc-windows-msvc') {
-            $SignCmd = $(@(
-              'signtool', 
-              'sign', 
-              '/fd', 'SHA256', 
-              '/v', 
-              '/n', 'Devolutions', 
-              '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-              '/td', 'sha256',
-              '${{ steps.get-binary-path.outputs.binary-path }}'
-            )) -Join ' '
+            $Params = @('sign',
+              '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+              '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+              '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+              '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+              '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+              '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+              '-v')
+            AzureSignTool @Params '${{ steps.get-binary-path.outputs.binary-path }}'
           } elseif ('${{ matrix.platform }}' -Eq 'apple-darwin') {
             $SignCmd = $(@(
               'codesign', 
@@ -180,10 +173,9 @@ jobs:
               '-v',
               '${{ steps.get-binary-path.outputs.binary-path }}'
             )) -Join ' '
+            Write-Host $SignCmd
+            Invoke-Expression $SignCmd
           }
-
-          Write-Host $SignCmd
-          Invoke-Expression $SignCmd
 
       - name: Verification
         shell: pwsh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -130,7 +130,7 @@ jobs:
   codesign:
     name: Codesign
     runs-on: ${{ matrix.runner }}
-    environment: build-and-publish
+    environment: publish-prod
     needs: preflight
     strategy:
       matrix:
@@ -179,18 +179,12 @@ jobs:
           $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
           if ('${{ matrix.project }}' -Eq 'jetsocat') {
             Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse 
-          }    
+          }
 
-      - name: Configure certificates (Windows)
+      - name: Install AzureSignTool
         if: matrix.os == 'windows'
-        env:
-          CODE_SIGN_CERT: ${{ secrets.WINDOWS_CODE_SIGNING_CERTIFICATE }}
-          CODE_SIGN_CERT_PASSWORD: ${{ secrets.WINDOWS_CODE_SIGNING_PASSWORD }}
         run: |
-          $CertificatePath = Join-Path -Path $Env:RUNNER_TEMP -ChildPath CodeSigningCertificate.pfx
-          [IO.File]::WriteAllBytes($CertificatePath, ([Convert]::FromBase64String($Env:CODE_SIGN_CERT)))
-          $SecurePassword = ConvertTo-SecureString "$Env:CODE_SIGN_CERT_PASSWORD" -AsPlainText -Force
-          Import-PfxCertificate -FilePath "$CertificatePath" -CertStoreLocation Cert:\CurrentUser\My -Password $SecurePassword
+          dotnet tool install --global AzureSignTool
 
       - name: Configure certificates (macOS)
         if: matrix.os == 'macos'
@@ -227,16 +221,15 @@ jobs:
           }
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include "$Pattern" | % {
             if ('${{ matrix.os }}' -Eq 'windows') {
-              $SignCmd = $(@(
-                'signtool', 
-                'sign', 
-                '/fd', 'SHA256', 
-                '/v', 
-                '/n', 'Devolutions', 
-                '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-                '/td', 'sha256',
-                $_.FullName
-              )) -Join ' '
+              $Params = @('sign',
+                '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+                '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+                '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+                '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+                '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+                '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+                '-v')
+              AzureSignTool @Params $_.FullName
             } elseif ('${{ matrix.os }}' -Eq 'macos') {
               $SignCmd = $(@(
                 'codesign', 
@@ -246,13 +239,10 @@ jobs:
                 '-v',
                 $_.FullName
               )) -Join ' '
+              Write-Host $SignCmd
+              Invoke-Expression $SignCmd
             } else {
               echo "::debug::nothing to do for ${{ matrix.os }}"
-            }
-
-            if ($SignCmd) {
-              Write-Host $SignCmd
-              Invoke-Expression $SignCmd            
             }
           }
 
@@ -280,21 +270,17 @@ jobs:
         if: matrix.project == 'devolutions-gateway'
         shell: pwsh
         run: |
-          Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*.msi' | % { 
-            $SignCmd = $(@(
-              'signtool', 
-              'sign', 
-              '/fd', 'SHA256', 
-              '/v', 
-              '/n', 'Devolutions', 
-              '/tr', 'http://timestamp.comodoca.com/?td=sha256',
-              '/d', '"Devolutions Gateway"',
-              '/td', 'sha256',
-              $_.FullName
-            )) -Join ' '
-
-            Write-Host $SignCmd
-            Invoke-Expression $SignCmd
+          Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*.msi' | % {
+            $Params = @('sign',
+              '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+              '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+              '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+              '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+              '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+              '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+              '-d', 'Devolutions Gateway',
+              '-v')
+            AzureSignTool @Params $_.FullName
           }
 
       - name: Verification

--- a/.github/workflows/publish-clients.yml
+++ b/.github/workflows/publish-clients.yml
@@ -98,7 +98,7 @@ jobs:
   nuget-publish:
     name: Publish NuGet packages
     runs-on: ubuntu-20.04
-    environment: build-and-publish
+    environment: publish-prod
     if: needs.preflight.outputs.dry-run == 'false'
     needs:
       - preflight
@@ -139,7 +139,7 @@ jobs:
   npm-publish:
     name: Publish NPM packages
     runs-on: ubuntu-20.04
-    environment: build-and-publish
+    environment: publish-prod
     if: needs.preflight.outputs.dry-run == 'false'
     needs:
       - preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
   containers:
     name: Containers [${{ matrix.os }} ${{ matrix.base-image }}]
     runs-on: ${{ matrix.runner }}
-    environment: build-and-publish
+    environment: publish-prod
     needs: preflight
     if: needs.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
     strategy:
@@ -209,7 +209,7 @@ jobs:
   github-release:
     name: GitHub release
     runs-on: ubuntu-20.04
-    environment: build-and-publish
+    environment: publish-prod
     needs: preflight
     if: needs.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
 
@@ -286,7 +286,7 @@ jobs:
   psgallery-release:
     name: PowerShell release
     runs-on: ubuntu-20.04
-    environment: build-and-publish
+    environment: publish-prod
     needs: preflight
     if: needs.preflight.outputs.skip-publishing == 'false' || github.event.inputs.dry-run == 'true'
 

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -336,19 +336,6 @@ class TlkRecipe
 
         if ($DestinationExecutable) {
             Copy-Item -Path $SrcExecutablePath -Destination $DestinationExecutable
-
-            if (Test-Path Env:SIGNTOOL_NAME) {
-                $SignToolName = $Env:SIGNTOOL_NAME
-                $TimestampServer = 'http://timestamp.comodoca.com/?td=sha256'
-                $SignToolArgs = @(
-                    'sign', '/fd', 'SHA256', '/v',
-                    '/n', $SignToolName,
-                    '/tr', $TimestampServer,
-                    '/td', 'sha256',
-                    $DestinationExecutable
-                )
-                & 'signtool' $SignToolArgs | Out-Host
-            }
         }
 
         Pop-Location
@@ -449,19 +436,6 @@ class TlkRecipe
         if (Test-Path Env:DGATEWAY_PACKAGE) {
             $DGatewayPackage = $Env:DGATEWAY_PACKAGE
             Copy-Item -Path "$($this.PackageName).msi" -Destination $DGatewayPackage
-
-            if (Test-Path Env:SIGNTOOL_NAME) {
-                $SignToolName = $Env:SIGNTOOL_NAME
-                $TimestampServer = 'http://timestamp.comodoca.com/?td=sha256'
-                $SignToolArgs = @(
-                    'sign', '/fd', 'SHA256', '/v',
-                    '/n', $SignToolName,
-                    '/tr', $TimestampServer,
-                    '/td', 'sha256',
-                    $DGatewayPackage
-                )
-                & 'signtool' $SignToolArgs | Out-Host
-            }
         }
 
         Pop-Location
@@ -471,7 +445,7 @@ class TlkRecipe
         $DebianArchitecture = $this.Target.DebianArchitecture()
         $Packager = "Devolutions Inc."
         $Email = "support@devolutions.net"
-        $Website = "http://wayk.devolutions.net"
+        $Website = "https://devolutions.net"
         $PackageVersion = $this.Version
         $DistroCodeName = "xenial" # Ubuntu 16.04
         $Dependencies = @('liblzma5', 'liblz4-1', '${shlibs:Depends}', '${misc:Depends}')


### PR DESCRIPTION
this is an attempt to migrate our workflows to use AzureSignTool + Azure Key Vault, but it's totally untested. I'm not even sure we have dry run options on the part that we'd need. However it *should* work, but we'd only known by running it