### PR TITLE
feat(dgw): support for PFX files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2384,21 +2384,26 @@ version = "7.0.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52cccdaffd2f361b4b4eb70b4249bd71d89bb66cb84b7f76483ecd1640c543ce"
 dependencies = [
+ "aes",
  "aes-gcm",
  "aes-kw",
  "base64 0.21.4",
  "cbc",
+ "des",
  "digest 0.10.7",
  "ed25519-dalek",
+ "hmac 0.12.1",
  "md-5 0.10.6",
  "num-bigint-dig",
  "p256",
  "p384",
+ "pbkdf2 0.12.2",
  "picky-asn1 0.8.0",
  "picky-asn1-der",
  "picky-asn1-x509 0.12.0",
  "rand",
  "rand_core",
+ "rc2",
  "rsa",
  "serde",
  "serde_json",
@@ -2827,6 +2832,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rc2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -80,9 +80,18 @@ Stable options are:
         * `Base64Url`
         * `Base64UrlPad`
 
-- **DelegationPrivateKeyFile** (_FilePath_): Path to the delegation private key (used to decipher sensitive data from tokens).
+- **DelegationPrivateKeyFile** (_FilePath_): Path to the delegation private key which is used to
+    decipher sensitive data from tokens.
 
-- **TlsCertificateSource** (_String_): Source for the TLS certificate. Possible values are: `External` (default), `System`.
+- **TlsCertificateSource** (_String_): Source for the TLS certificate.
+
+    Possible values:
+
+    * `External` (default): Retrieve a certificate stored on the file system.
+        See the options **TlsCertificateFile**, **TlsPrivateKeyFile** and **TlsPrivateKeyPassword**.
+    
+    * `System`: Retrieve the certificate managed by the system certificate store. 
+        See the options **TlsCertificateSubjectName**, **TlsCertificateStoreName** and **TlsCertificateStoreLocation**.
 
 - **TlsCertificateSubjectName** (_String_): Subject name of the certificate to use for TLS when using system source.
 
@@ -99,6 +108,17 @@ Stable options are:
 - **TlsCertificateFile** (_FilePath_): Path to the certificate to use for TLS.
 
 - **TlsPrivateKeyFile** (_FilePath_): Path to the private key to use for TLS.
+
+- **TlsPrivateKeyPassword** (_String_): Password to use for decrypting the TLS private key.
+
+    It's important to understand that using this option in order to use an encrypted private key
+    does not inherently enhance security beyond using a plain, unencrypted private key. In fact,
+    storing the password in plain text within the configuration file is _discouraged_ because it
+    provides minimal security advantages over the unencrypted private key. If an unauthorized person
+    gains access to both the configuration file and the private key, they can easily retrieve the
+    password, making it as vulnerable as an unencrypted private key. To bolster security, consider
+    additional measures like securing access to the files or using the system certificate store (see
+    **TlsCertificateSource** option).
 
 - **Listeners** (_Array_): Array of listener URLs.
 
@@ -207,9 +227,9 @@ anymore by default.
 
 See [this page from Microsoft documentation][microsoft_tls] to learn how to properly configure SChannel.
 
-### More
+## Knowledge base
 
-Read [our knowledge base](https://docs.devolutions.net/kb/devolutions-gateway/).
+Read more on [our knowledge base](https://docs.devolutions.net/kb/devolutions-gateway/).
 
 ## Cookbook
 

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -49,7 +49,7 @@ typed-builder = "0.17"
 backoff = "0.4"
 
 # Security, crypto…
-picky = { version = "7.0.0-rc.8", default-features = false, features = ["jose", "x509"] }
+picky = { version = "7.0.0-rc.8", default-features = false, features = ["jose", "x509", "pkcs12"] }
 zeroize = { version = "1.6", features = ["derive"] }
 multibase = "0.9"
 

--- a/devolutions-gateway/src/api/kdc_proxy.rs
+++ b/devolutions-gateway/src/api/kdc_proxy.rs
@@ -108,7 +108,7 @@ async fn kdc_proxy(
             .map_err(HttpError::internal().with_msg("unable to read KDC reply message").err())?
     } else {
         // we assume that ticket length is not greater than 2048
-        let mut buff = [0; 2048];
+        let mut buf = [0; 2048];
 
         let port = portpicker::pick_unused_port().ok_or_else(|| HttpError::internal().msg("No free ports"))?;
 
@@ -134,7 +134,7 @@ async fn kdc_proxy(
 
         trace!("Reading KDC reply...");
 
-        let n = udp_socket.recv(&mut buff).await.map_err(
+        let n = udp_socket.recv(&mut buf).await.map_err(
             HttpError::internal()
                 .with_msg("unable to read reply from the KDC server")
                 .err(),
@@ -142,7 +142,7 @@ async fn kdc_proxy(
 
         let mut reply_buf = Vec::new();
         reply_buf.extend_from_slice(&(n as u32).to_be_bytes());
-        reply_buf.extend_from_slice(&buff[0..n]);
+        reply_buf.extend_from_slice(&buf[0..n]);
         reply_buf
     };
 

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -58,6 +58,13 @@ impl GatewayService {
             );
         }
 
+        if conf_file.tls_private_key_password.is_some() {
+            warn!(
+                "Detected TlsPrivateKeyPassword option. This option doesn’t inherently enhance \
+                security beyond using a plain, unencrypted private key."
+            );
+        }
+
         if let Err(e) = devolutions_gateway::tls::sanity::check_default_configuration() {
             warn!("Anomality detected with TLS configuration: {e:#}");
         }

--- a/devolutions-gateway/src/tls.rs
+++ b/devolutions-gateway/src/tls.rs
@@ -78,7 +78,7 @@ pub fn build_server_config(cert_source: CertificateSource) -> anyhow::Result<rus
             private_key,
         } => builder
             .with_single_cert(certificates, private_key)
-            .context("couldn't set server config cert"),
+            .context("failed to set server config cert"),
 
         #[cfg(windows)]
         CertificateSource::SystemStore {

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -1131,7 +1131,7 @@ fn validate_token_impl(
         // No mitigation if token has no ID (might be disallowed in the future)
         AccessTokenClaims::Scope(ScopeTokenClaims { jti: None, .. }) => {}
 
-        // KDC tokens are long-lived and may be reused safely
+        // KDC tokens may be long-lived and reusing them is allowed
         AccessTokenClaims::Kdc(_) => {}
 
         // JRL token must be more recent than the current revocation list

--- a/devolutions-gateway/tests/config.rs
+++ b/devolutions-gateway/tests/config.rs
@@ -60,6 +60,7 @@ fn hub_sample() -> Sample {
             tls_certificate_source: None,
             tls_certificate_file: Some("/path/to/tls-certificate.pem".into()),
             tls_private_key_file: Some("/path/to/tls-private.key".into()),
+            tls_private_key_password: None,
             tls_certificate_subject_name: None,
             tls_certificate_store_location: None,
             tls_certificate_store_name: None,
@@ -107,6 +108,7 @@ fn legacy_sample() -> Sample {
             tls_certificate_source: None,
             tls_certificate_file: Some("/path/to/tls-certificate.pem".into()),
             tls_private_key_file: Some("/path/to/tls-private.key".into()),
+            tls_private_key_password: None,
             tls_certificate_subject_name: None,
             tls_certificate_store_location: None,
             tls_certificate_store_name: None,
@@ -131,7 +133,7 @@ fn system_store_sample() -> Sample {
             "TlsCertificateSource": "System",
             "TlsCertificateSubjectName": "localhost",
             "TlsCertificateStoreLocation": "LocalMachine",
-            "TlsCertificateStoreName": "my"
+            "TlsCertificateStoreName": "My"
         }"#,
         file_conf: ConfFile {
             id: None,
@@ -144,9 +146,10 @@ fn system_store_sample() -> Sample {
             tls_certificate_source: Some(CertSource::System),
             tls_certificate_file: None,
             tls_private_key_file: None,
+            tls_private_key_password: None,
             tls_certificate_subject_name: Some("localhost".to_owned()),
             tls_certificate_store_location: Some(CertStoreLocation::LocalMachine),
-            tls_certificate_store_name: Some("my".to_owned()),
+            tls_certificate_store_name: Some("My".to_owned()),
             listeners: vec![],
             subscriber: None,
             log_file: None,

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -2,6 +2,9 @@
 
 Developer-oriented cookbook for testing purposes.
 
+- [RDP routing](#rdp-routing)
+- [WebSocket-to-TCP tunnel using jetsocat](#websocket-to-tcp-tunnel-using-jetsocat)
+
 ## RDP routing
 
 Devolutions Gateway can redirect RDP traffic authorized by a JWT (Json Web Token) signed (JWS) and
@@ -119,5 +122,5 @@ Finally, run the following command to connect to the Devolutions Gateway service
 cargo run -p jetsocat -- forward - "ws://127.0.0.1:7171/jet/fwd/tcp/123e4567-e89b-12d3-a456-426614174000?token=<TOKEN>"
 ```
 
-Try to entering text and see it printed on the other side.
+Try entering text and see it printed on the other side.
 


### PR DESCRIPTION
PFX files may now be specified in the `TlsCertificateFile` option.
Furthermore, a new optional option is added: `TlsPrivateKeyPassword`.
This option may be used when the PFX file is encrypted using a passkey.

Issue: DGW-121