### PR TITLE
ci: remove explicit rustup commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
     outputs:
       ref: ${{ steps.get-commit.outputs.ref }}
       version: ${{ steps.get-version.outputs.version }}
-      rust-channel: ${{ steps.rust-toolchain.outputs.rust-channel }}
       rust-profile: ${{ steps.rust-profile.outputs.rust-profile }}
       jetsocat-build-matrix: ${{ steps.setup-matrix.outputs.jetsocat-build-matrix }}
       gateway-build-matrix: ${{ steps.setup-matrix.outputs.gateway-build-matrix }}
@@ -102,15 +101,6 @@ jobs:
           $Version = Get-Content VERSION -TotalCount 1
           echo "version=$Version" >> $Env:GITHUB_OUTPUT
 
-      - name: Configure rust toolchain
-        id: rust-toolchain
-        shell: pwsh
-        run: |
-          $Channel = (Get-Content 'rust-toolchain.toml' | Select -Skip 1 | ConvertFrom-StringData).channel
-          rustup toolchain install $Channel
-          rustup component add rustfmt
-          echo "rust-channel=$Channel" >> $Env:GITHUB_OUTPUT
-
       - name: Check formatting
         run: |
           cargo fmt --all -- --check
@@ -157,9 +147,6 @@ jobs:
           with:
             ref: ${{ needs.preflight.outputs.ref }}
 
-        - name: Configure rust toolchain
-          run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
-
         - name: Configure Linux runner
           if: matrix.os == 'linux'
           run: |
@@ -186,9 +173,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.preflight.outputs.ref }}
-
-      - name: Configure rust toolchain
-        run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
 
       - name: Configure Linux runner
         if: matrix.os == 'linux'
@@ -341,9 +325,6 @@ jobs:
           echo "staging-path=$StagingPath" >> $Env:GITHUB_OUTPUT
           echo "target-output-path=$TargetOutputPath" >> $Env:GITHUB_OUTPUT
           echo "dgateway-executable=$DGatewayExecutable" >> $Env:GITHUB_OUTPUT
-
-      - name: Configure rust toolchain
-        run: rustup toolchain install ${{ needs.preflight.outputs.rust-channel }}
 
       - name: Configure Linux runner
         if: matrix.os == 'linux'


### PR DESCRIPTION
Our CI is wonky: for Windows runners, `rustup` is _sometimes_ failing with this error:
```
error: failed to install component: 'clippy-preview-x86_64-pc-windows-msvc', detected conflict: 'bin/cargo-clippy.exe'
```

It looks like rustup is trying to re-install a toolchain that is already installed:
```
$ rustup toolchain install "1.73.0"
info: syncing channel updates for '1.73.0-x86_64-pc-windows-msvc'
info: latest update on 2023-10-05, rust version 1.73.0 (cc66ad468 2023-10-03)
info: downloading component 'cargo'
info: downloading component 'rust-std'
info: downloading component 'rustc'
info: installing component 'cargo'
info: installing component 'rust-std'
info: installing component 'rustc'

  1.73.0-x86_64-pc-windows-msvc installed - rustc 1.73.0 (cc66ad468 2023-10-03)

info: checking for self-update
warning: tool `rust-analyzer` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
warning: tool `rustfmt` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.
warning: tool `cargo-fmt` is already installed, remove it from `C:\Users\runneradmin\.cargo\bin`, then run `rustup update` to have rustup manage this tool.

[…]

$ cargo build --profile production --target x86_64-pc-windows-msvc --no-default-features --features native-tls
info: syncing channel updates for '1.73.0-x86_64-pc-windows-msvc'
info: latest update on 2023-10-05, rust version 1.73.0 (cc66ad468 2023-10-03)
info: downloading component 'clippy'
info: downloading component 'rustfmt'
info: installing component 'clippy'
info: rolling back changes
error: failed to install component: 'clippy-preview-x86_64-pc-windows-msvc', detected conflict: 'bin/cargo-clippy.exe'
```

There is seemingly a bad interaction with:
- the CI environment,
- the `rustup` commands we issue explicitly,
- and the `rust-toolchain.toml` file

It’s not clear what is the underlying problem, but `rustup` does not detect that the toolchain is already installed.
It appears that removing the explicit `rustup` commands (and rely on `rust-toolchain.toml`) is enough to fix the issue on our side:
![image](https://github.com/Devolutions/devolutions-gateway/assets/3809077/885cbbc0-1791-4d3a-913d-61de86eebe1e)