### PR TITLE
fix(dgw): use all resolved addresses when connecting

### DIFF
--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -394,7 +394,7 @@ fn read_pfx_file(
 
     let crypto_context = password
         .map(|pwd| Pkcs12CryptoContext::new_with_password(pwd.get()))
-        .unwrap_or_else(|| Pkcs12CryptoContext::new_without_password());
+        .unwrap_or_else(Pkcs12CryptoContext::new_without_password);
     let parsing_params = Pkcs12ParsingParams::default();
 
     let pfx_contents = normalize_data_path(path, &get_data_dir())


### PR DESCRIPTION
This patch ensures Devolutions Gateway does not immediately discard resolved addresses which are not emitted first by Tokio’s `lookup_host`.

Typically, the first address is enough and there is no need to try subsequent ones. Therefore, it is not expected for this change to cause any additional latence in the the vast majority of the cases. However, just to be on the safe side and enable easier troubleshooting, a WARN-level log is emitted when failing at connecting to a resolved address. If latence were to be introduced by this patch, we can easily be made aware of the problem and investigate further (network configuration, etc).

If this proves to be a problem in the future, we can add filtering options. For instance, on a network where IPv4 is not supported or disabled, we may want to filter out all the IPv4 addresses which may be resolved by the Devolutions Gateway.

The timeout for any specific destination remains unchanged, regardless of the number of resolved addresses.