### PR TITLE
fix(dgw): improve logs quality for JMUX proxy

### DIFF
--- a/devolutions-gateway/src/log.rs
+++ b/devolutions-gateway/src/log.rs
@@ -46,7 +46,7 @@ impl<'a> LogPathCfg<'a> {
 fn profile_to_directives(profile: VerbosityProfile) -> &'static str {
     match profile {
         VerbosityProfile::Default => "info",
-        VerbosityProfile::Debug => "info,devolutions_gateway=debug,devolutions_gateway::api=trace",
+        VerbosityProfile::Debug => "info,devolutions_gateway=debug,devolutions_gateway::api=trace,jmux_proxy=debug",
         VerbosityProfile::Tls => {
             "info,devolutions_gateway=debug,devolutions_gateway::tls=trace,rustls=trace,tokio_rustls=debug"
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.1"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Notably, status codes like ECONNRESET or ECONNABORTED are not considered anymore as actual errors, and will be logged accordingly.