### PR TITLE
ci: remove redundant snupkg pushing

### DIFF
--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           Set-PSDebug -Trace 1
 
-          $Files = Get-ChildItem -Recurse nuget-packages/*
+          $Files = Get-ChildItem -Recurse nuget-packages/*.nupkg
     
           foreach ($File in $Files) {
             $PushCmd = @(


### PR DESCRIPTION
`npm push mylib.nupkg` will push both the nupkg and the snupkg if they are in the same folder.

Currently, we are redundantly attempting to push the snupkg files separately:
![image](https://github.com/Devolutions/devolutions-gateway/assets/3809077/5e575a66-c175-4b61-a827-c48b4e38a285)

Usually, we don’t need to "retry" pushing only the symbols, so it should be enough to only iterate on the nupkg files.

Note: I also renamed `publish-clients.yml` to `publish-libraries.yml`, so the filename is the same as the workflow name.