### PR TITLE
fix(dgw): upgrade Windows store resolve error log

### DIFF
--- a/devolutions-gateway/src/tls.rs
+++ b/devolutions-gateway/src/tls.rs
@@ -190,7 +190,7 @@ pub mod windows {
             match self.resolve(client_hello) {
                 Ok(certified_key) => Some(certified_key),
                 Err(error) => {
-                    debug!(error = format!("{error:#?}"), "Failed to resolve TLS certificate");
+                    error!(error = format!("{error:#?}"), "Failed to resolve TLS certificate");
                     None
                 }
             }


### PR DESCRIPTION
This can help with troubleshooting configuration problems with Windows system certificate store.