### PR TITLE
switch from PemUtils to Picky in PowerShell module

### DIFF
--- a/powershell/DevolutionsGateway/DevolutionsGateway.psd1
+++ b/powershell/DevolutionsGateway/DevolutionsGateway.psd1
@@ -49,7 +49,7 @@
     # RequiredModules = @()
     
     # Assemblies that must be loaded prior to importing this module
-    RequiredAssemblies = @('bin\PemUtils.dll')
+    RequiredAssemblies = @('bin\Devolutions.Picky.dll')
     
     # Script files (.ps1) that are run in the caller's environment prior to importing this module.
     # ScriptsToProcess = @()

--- a/powershell/DevolutionsGateway/DevolutionsGateway.psm1
+++ b/powershell/DevolutionsGateway/DevolutionsGateway.psm1
@@ -10,6 +10,22 @@ if ($IsWindows) {
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
 }
 
+if ($IsWindows -and ($PSEdition -eq 'Desktop')) {
+    Add-Type -TypeDefinition @"
+        using System;
+        using System.Runtime.InteropServices;
+
+        public class NativeMethods {
+            [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+            public static extern IntPtr LoadLibrary(string libname);
+        }
+"@ -PassThru
+
+    $NativeDirName = if ($Env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { "win-arm64" } else { "win-x64" }
+    $PickyDllPath = "$PSScriptRoot\bin\$NativeDirName\DevolutionsPicky.dll"
+    [NativeMethods]::LoadLibrary($PickyDllPath) | Out-Null
+}
+
 Export-ModuleMember -Cmdlet @($manifest.CmdletsToExport)
 
 $Public = @(Get-ChildItem -Path "$PSScriptRoot/Public/*.ps1" -Recurse)

--- a/powershell/DevolutionsGateway/src/DevolutionsGateway.csproj
+++ b/powershell/DevolutionsGateway/src/DevolutionsGateway.csproj
@@ -3,10 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>DevolutionsGateway</RootNamespace>
+    <IsPowerShell>true</IsPowerShell>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PemUtils" Version="3.0.0.81" />
+    <PackageReference Include="Devolutions.Picky" Version="2023.9.20" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />

--- a/powershell/build.ps1
+++ b/powershell/build.ps1
@@ -23,6 +23,14 @@ $Env:NUGET_CERT_REVOCATION_MODE='offline'
 
 & dotnet publish "$PSScriptRoot\$ModuleName\src\$ModuleName.csproj" -f netstandard2.0 -c Release -o "$PSScriptRoot\$ModuleName\bin"
 
+$ManagedBasePath = "$PSScriptRoot\$ModuleName\bin"
+Get-Item "$ManagedBasePath\runtimes\*\native*" | ForEach-Object {
+	$NativeDirName = $_.Parent.Name
+    Remove-Item "$ManagedBasePath\$NativeDirName" -Recurse -ErrorAction SilentlyContinue
+	Move-Item $_ "$ManagedBasePath\$NativeDirName" -Force
+}
+Remove-Item "$ManagedBasePath\runtimes" -Recurse -ErrorAction SilentlyContinue
+
 Copy-Item "$PSScriptRoot\$ModuleName\bin" -Destination "$PSModuleOutputPath\$ModuleName" -Recurse -Force
 
 Copy-Item "$PSScriptRoot\$ModuleName\Private" -Destination "$PSModuleOutputPath\$ModuleName" -Recurse -Force


### PR DESCRIPTION
Remove dependency on PemUtils for RSA key operations in the PowerShell module, which was important for New-RsaKeyPair to work properly even in Windows PowerShell, given that the new Devolutions Gateway standalone needs a generated key pair at installation. The current module would already detect PowerShell 7 and use the newer APIs, but the fallback was still PemUtils in Windows PowerShell.

The remaining internal function that won't work in Windows PowerShell is ConvertTo-RsaPrivateKey which converts a PEM private key to System.Security.Cryptography.RSA which we then use to sign tokens in New-JwtRs256, called from New-DGatewayToken. We don't need to sign tokens from the installer, so I just throw an exception for now if we're trying to use it from Windows PowerShell. However, porting would likely require loading the RSA key from Picky and doing the token signature from Picky as well, rather than load the key into a .NET RSA object.

This change introduces native libraries into the PowerShell module. I already convert from the .NET runtimes directory structure to the one used in PowerShell 7, and I added a conditional DLL preloading hack for Windows PowerShell. We'll need to remove all unneeded native libraries from the PowerShell module which we copy into the MSI installer to save space, only win-x64 would be required (well, that is until we start shipping win-arm64 as well!).

Other than that, the changes should be transparent.