### PR TITLE
feat(installer): add Windows sytem certificate support to managed installer

### DIFF
--- a/package/WindowsManaged/.editorconfig
+++ b/package/WindowsManaged/.editorconfig
@@ -2,3 +2,6 @@
 [*]
 end_of_line = lf
 insert_final_newline = true
+
+[*.tt]
+end_of_line = crlf

--- a/package/WindowsManaged/Actions/CustomActions.cs
+++ b/package/WindowsManaged/Actions/CustomActions.cs
@@ -58,21 +58,35 @@ namespace DevolutionsGateway.Actions
 
             try
             {
-                if (string.IsNullOrEmpty(session.Get(GatewayProperties._CertificatePassword)))
+                Constants.CertificateMode mode = session.Get(GatewayProperties._CertificateMode);
+
+                if (mode == Constants.CertificateMode.External)
                 {
-                    command = string.Format(
-                        Constants.ImportDGatewayCertificateWithPrivateKeyCommandFormat,
-                        session.Get(GatewayProperties._CertificateFile),
-                        session.Get(GatewayProperties._CertificatePrivateKeyFile));
+                    if (string.IsNullOrEmpty(session.Get(GatewayProperties._CertificatePassword)))
+                    {
+                        command = string.Format(
+                            Constants.ImportDGatewayCertificateWithPrivateKeyCommandFormat,
+                            session.Get(GatewayProperties._CertificateFile),
+                            session.Get(GatewayProperties._CertificatePrivateKeyFile));
+                    }
+                    else
+                    {
+                        command = string.Format(
+                            Constants.ImportDGatewayCertificateWithPasswordCommandFormat,
+                            session.Get(GatewayProperties._CertificateFile),
+                            session.Get(GatewayProperties._CertificatePassword));
+                    }
                 }
                 else
                 {
                     command = string.Format(
-                        Constants.ImportDGatewayCertificateWithPasswordCommandFormat,
-                        session.Get(GatewayProperties._CertificateFile),
-                        session.Get(GatewayProperties._CertificatePassword));
+                        Constants.ImportDGatewayCertificateFromSystemFormat,
+                        session.Get(GatewayProperties._CertificateMode),
+                        session.Get(GatewayProperties._CertificateName),
+                        session.Get(GatewayProperties._CertificateStore),
+                        session.Get(GatewayProperties._CertificateLocation));
                 }
-
+                
                 command = FormatPowerShellCommand(session, command);
             }
             catch (Exception e)

--- a/package/WindowsManaged/Actions/GatewayActions.cs
+++ b/package/WindowsManaged/Actions/GatewayActions.cs
@@ -225,9 +225,13 @@ namespace DevolutionsGateway.Actions
             When.After, new Step(configureListeners.Id),
             new IWixProperty[]
             {
+                    GatewayProperties._CertificateMode,
                     GatewayProperties._CertificateFile,
                     GatewayProperties._CertificatePassword,
                     GatewayProperties._CertificatePrivateKeyFile,
+                    GatewayProperties._CertificateLocation,
+                    GatewayProperties._CertificateStore,
+                    GatewayProperties._CertificateName,
             },
             "HideTarget=yes", // Don't print the custom action data to logs, it might contain a password
             $" AND ({new Condition(GatewayProperties._HttpListenerScheme.Id, Constants.HttpsProtocol)})"); // Only if the HTTP listener uses https

--- a/package/WindowsManaged/DevolutionsGateway.csproj
+++ b/package/WindowsManaged/DevolutionsGateway.csproj
@@ -14,7 +14,6 @@
     <None Remove="*.wixpdb" />
     <None Remove="*.wixobj" />
     <None Remove="Build\**" />
-    <None Remove="App.config" />
     <None Remove="Resources\DevolutionsGateway_en-us.wxl" />
     <None Remove="Resources\DevolutionsGateway_fr-fr.wxl" />
   </ItemGroup>
@@ -28,6 +27,7 @@
     <PackageReference Include="WixSharp.wix.bin" Version="3.14.0.1" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="System.Security" />
     <Reference Include="System.ServiceProcess">
       <HintPath>..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5.1\System.ServiceProcess.dll</HintPath>
     </Reference>
@@ -52,6 +52,7 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>GatewayProperties.g.tt</DependentUpon>
     </None>
+    <None Remove="wix\DevolutionsGateway.g.wxs" />
     <None Include="wix\$(ProjectName).g.wxs" />
   </ItemGroup>
   <ItemGroup>

--- a/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
@@ -20,6 +20,9 @@ namespace WixSharpSetup.Dialogs
             {
                 components.Dispose();
             }
+
+            //this.SelectedCertificate?.Dispose(); TODO: .net48
+
             base.Dispose(disposing);
         }
 
@@ -35,7 +38,8 @@ namespace WixSharpSetup.Dialogs
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.middlePanel = new System.Windows.Forms.Panel();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.gbExternal = new System.Windows.Forms.GroupBox();
+            this.pnlExternal = new System.Windows.Forms.TableLayoutPanel();
             this.butBrowsePrivateKeyFile = new System.Windows.Forms.Button();
             this.txtPrivateKeyFile = new System.Windows.Forms.TextBox();
             this.txtCertificatePassword = new System.Windows.Forms.TextBox();
@@ -44,6 +48,23 @@ namespace WixSharpSetup.Dialogs
             this.label3 = new System.Windows.Forms.Label();
             this.txtCertificateFile = new System.Windows.Forms.TextBox();
             this.butBrowseCertificateFile = new System.Windows.Forms.Button();
+            this.lblHint = new System.Windows.Forms.Label();
+            this.gbSystem = new System.Windows.Forms.GroupBox();
+            this.pnlSystem = new System.Windows.Forms.TableLayoutPanel();
+            this.lblCertificateDescription = new System.Windows.Forms.Label();
+            this.lblSelectedCertificate = new System.Windows.Forms.Label();
+            this.cmbSearchBy = new System.Windows.Forms.ComboBox();
+            this.label9 = new System.Windows.Forms.Label();
+            this.cmbStoreLocation = new System.Windows.Forms.ComboBox();
+            this.cmbStore = new System.Windows.Forms.ComboBox();
+            this.label8 = new System.Windows.Forms.Label();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label6 = new System.Windows.Forms.Label();
+            this.txtSearch = new System.Windows.Forms.TextBox();
+            this.butSearchCertificate = new System.Windows.Forms.Button();
+            this.butViewCertificate = new System.Windows.Forms.Button();
+            this.label5 = new System.Windows.Forms.Label();
+            this.cmbCertificateSource = new System.Windows.Forms.ComboBox();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
@@ -57,7 +78,10 @@ namespace WixSharpSetup.Dialogs
             this.border1 = new System.Windows.Forms.Panel();
             this.contextMenuStrip1.SuspendLayout();
             this.middlePanel.SuspendLayout();
-            this.tableLayoutPanel2.SuspendLayout();
+            this.gbExternal.SuspendLayout();
+            this.pnlExternal.SuspendLayout();
+            this.gbSystem.SuspendLayout();
+            this.pnlSystem.SuspendLayout();
             this.topPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).BeginInit();
             this.bottomPanel.SuspendLayout();
@@ -82,41 +106,59 @@ namespace WixSharpSetup.Dialogs
             this.middlePanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.middlePanel.Controls.Add(this.tableLayoutPanel2);
-            this.middlePanel.Location = new System.Drawing.Point(22, 75);
+            this.middlePanel.Controls.Add(this.gbExternal);
+            this.middlePanel.Controls.Add(this.gbSystem);
+            this.middlePanel.Controls.Add(this.label5);
+            this.middlePanel.Controls.Add(this.cmbCertificateSource);
+            this.middlePanel.Location = new System.Drawing.Point(0, 58);
             this.middlePanel.Name = "middlePanel";
-            this.middlePanel.Size = new System.Drawing.Size(449, 139);
+            this.middlePanel.Size = new System.Drawing.Size(494, 261);
             this.middlePanel.TabIndex = 16;
             // 
-            // tableLayoutPanel2
+            // gbExternal
             // 
-            this.tableLayoutPanel2.ColumnCount = 2;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.butBrowsePrivateKeyFile, 1, 5);
-            this.tableLayoutPanel2.Controls.Add(this.txtPrivateKeyFile, 0, 5);
-            this.tableLayoutPanel2.Controls.Add(this.txtCertificatePassword, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.lblPrivateKeyFile, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.lblCertificatePassword, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.txtCertificateFile, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.butBrowseCertificateFile, 1, 1);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 6;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 139);
-            this.tableLayoutPanel2.TabIndex = 8;
+            this.gbExternal.Controls.Add(this.pnlExternal);
+            this.gbExternal.Location = new System.Drawing.Point(12, 34);
+            this.gbExternal.Name = "gbExternal";
+            this.gbExternal.Size = new System.Drawing.Size(470, 224);
+            this.gbExternal.TabIndex = 8;
+            this.gbExternal.TabStop = false;
+            this.gbExternal.Text = "Browse for a certificate to use";
+            // 
+            // pnlExternal
+            // 
+            this.pnlExternal.ColumnCount = 3;
+            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.pnlExternal.Controls.Add(this.butBrowsePrivateKeyFile, 2, 5);
+            this.pnlExternal.Controls.Add(this.txtPrivateKeyFile, 1, 5);
+            this.pnlExternal.Controls.Add(this.txtCertificatePassword, 1, 3);
+            this.pnlExternal.Controls.Add(this.lblPrivateKeyFile, 0, 5);
+            this.pnlExternal.Controls.Add(this.lblCertificatePassword, 0, 3);
+            this.pnlExternal.Controls.Add(this.label3, 0, 1);
+            this.pnlExternal.Controls.Add(this.txtCertificateFile, 1, 1);
+            this.pnlExternal.Controls.Add(this.butBrowseCertificateFile, 2, 1);
+            this.pnlExternal.Controls.Add(this.lblHint, 1, 6);
+            this.pnlExternal.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlExternal.Location = new System.Drawing.Point(3, 16);
+            this.pnlExternal.Name = "pnlExternal";
+            this.pnlExternal.RowCount = 7;
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.pnlExternal.Size = new System.Drawing.Size(464, 205);
+            this.pnlExternal.TabIndex = 8;
             // 
             // butBrowsePrivateKeyFile
             // 
-            this.butBrowsePrivateKeyFile.Location = new System.Drawing.Point(393, 112);
+            this.butBrowsePrivateKeyFile.Location = new System.Drawing.Point(434, 65);
+            this.butBrowsePrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.butBrowsePrivateKeyFile.Name = "butBrowsePrivateKeyFile";
             this.butBrowsePrivateKeyFile.Size = new System.Drawing.Size(27, 20);
             this.butBrowsePrivateKeyFile.TabIndex = 4;
@@ -126,17 +168,21 @@ namespace WixSharpSetup.Dialogs
             // 
             // txtPrivateKeyFile
             // 
-            this.txtPrivateKeyFile.Location = new System.Drawing.Point(3, 112);
+            this.txtPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtPrivateKeyFile.Location = new System.Drawing.Point(153, 65);
+            this.txtPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.txtPrivateKeyFile.Name = "txtPrivateKeyFile";
-            this.txtPrivateKeyFile.Size = new System.Drawing.Size(384, 20);
+            this.txtPrivateKeyFile.Size = new System.Drawing.Size(275, 20);
             this.txtPrivateKeyFile.TabIndex = 3;
             // 
             // txtCertificatePassword
             // 
-            this.tableLayoutPanel2.SetColumnSpan(this.txtCertificatePassword, 2);
-            this.txtCertificatePassword.Location = new System.Drawing.Point(3, 67);
+            this.pnlExternal.SetColumnSpan(this.txtCertificatePassword, 2);
+            this.txtCertificatePassword.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtCertificatePassword.Location = new System.Drawing.Point(153, 31);
+            this.txtCertificatePassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.txtCertificatePassword.Name = "txtCertificatePassword";
-            this.txtCertificatePassword.Size = new System.Drawing.Size(384, 20);
+            this.txtCertificatePassword.Size = new System.Drawing.Size(308, 20);
             this.txtCertificatePassword.TabIndex = 2;
             this.txtCertificatePassword.UseSystemPasswordChar = true;
             this.txtCertificatePassword.Visible = false;
@@ -144,54 +190,276 @@ namespace WixSharpSetup.Dialogs
             // lblPrivateKeyFile
             // 
             this.lblPrivateKeyFile.AutoSize = true;
-            this.tableLayoutPanel2.SetColumnSpan(this.lblPrivateKeyFile, 2);
-            this.lblPrivateKeyFile.Location = new System.Drawing.Point(3, 93);
-            this.lblPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3);
+            this.lblPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblPrivateKeyFile.Location = new System.Drawing.Point(3, 65);
+            this.lblPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.lblPrivateKeyFile.Name = "lblPrivateKeyFile";
-            this.lblPrivateKeyFile.Size = new System.Drawing.Size(155, 13);
+            this.lblPrivateKeyFile.Size = new System.Drawing.Size(144, 26);
             this.lblPrivateKeyFile.TabIndex = 4;
             this.lblPrivateKeyFile.Text = "[CertificateDlgCertKeyFileLabel]";
+            this.lblPrivateKeyFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // lblCertificatePassword
             // 
             this.lblCertificatePassword.AutoSize = true;
-            this.tableLayoutPanel2.SetColumnSpan(this.lblCertificatePassword, 2);
-            this.lblCertificatePassword.Location = new System.Drawing.Point(3, 48);
-            this.lblCertificatePassword.Margin = new System.Windows.Forms.Padding(3);
+            this.lblCertificatePassword.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblCertificatePassword.Location = new System.Drawing.Point(3, 31);
+            this.lblCertificatePassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.lblCertificatePassword.Name = "lblCertificatePassword";
-            this.lblCertificatePassword.Size = new System.Drawing.Size(167, 13);
+            this.lblCertificatePassword.Size = new System.Drawing.Size(144, 26);
             this.lblCertificatePassword.TabIndex = 7;
             this.lblCertificatePassword.Text = "[CertificateDlgCertPasswordLabel]";
+            this.lblCertificatePassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.lblCertificatePassword.Visible = false;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.tableLayoutPanel2.SetColumnSpan(this.label3, 2);
+            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.label3.Location = new System.Drawing.Point(3, 3);
-            this.label3.Margin = new System.Windows.Forms.Padding(3);
+            this.label3.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(137, 13);
+            this.label3.Size = new System.Drawing.Size(144, 20);
             this.label3.TabIndex = 1;
             this.label3.Text = "[CertificateDlgCertFileLabel]";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // txtCertificateFile
             // 
-            this.txtCertificateFile.Location = new System.Drawing.Point(3, 22);
+            this.txtCertificateFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtCertificateFile.Location = new System.Drawing.Point(153, 3);
+            this.txtCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.txtCertificateFile.Name = "txtCertificateFile";
-            this.txtCertificateFile.Size = new System.Drawing.Size(384, 20);
+            this.txtCertificateFile.Size = new System.Drawing.Size(275, 20);
             this.txtCertificateFile.TabIndex = 0;
             this.txtCertificateFile.TextChanged += new System.EventHandler(this.txtCertificateFile_TextChanged);
             // 
             // butBrowseCertificateFile
             // 
-            this.butBrowseCertificateFile.Location = new System.Drawing.Point(393, 22);
+            this.butBrowseCertificateFile.Location = new System.Drawing.Point(434, 3);
+            this.butBrowseCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.butBrowseCertificateFile.Name = "butBrowseCertificateFile";
             this.butBrowseCertificateFile.Size = new System.Drawing.Size(27, 20);
             this.butBrowseCertificateFile.TabIndex = 1;
             this.butBrowseCertificateFile.Text = "...";
             this.butBrowseCertificateFile.UseVisualStyleBackColor = true;
             this.butBrowseCertificateFile.Click += new System.EventHandler(this.butBrowseCertificateFile_Click);
+            // 
+            // lblHint
+            // 
+            this.lblHint.AutoSize = true;
+            this.lblHint.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lblHint.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblHint.ForeColor = System.Drawing.Color.Blue;
+            this.lblHint.Location = new System.Drawing.Point(153, 96);
+            this.lblHint.Name = "lblHint";
+            this.lblHint.Size = new System.Drawing.Size(275, 13);
+            this.lblHint.TabIndex = 8;
+            // 
+            // gbSystem
+            // 
+            this.gbSystem.Controls.Add(this.pnlSystem);
+            this.gbSystem.Location = new System.Drawing.Point(12, 34);
+            this.gbSystem.Name = "gbSystem";
+            this.gbSystem.Size = new System.Drawing.Size(470, 224);
+            this.gbSystem.TabIndex = 18;
+            this.gbSystem.TabStop = false;
+            this.gbSystem.Text = "Search for a certificate to use";
+            this.gbSystem.Visible = false;
+            // 
+            // pnlSystem
+            // 
+            this.pnlSystem.ColumnCount = 3;
+            this.pnlSystem.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.pnlSystem.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlSystem.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.pnlSystem.Controls.Add(this.lblCertificateDescription, 1, 5);
+            this.pnlSystem.Controls.Add(this.lblSelectedCertificate, 0, 5);
+            this.pnlSystem.Controls.Add(this.cmbSearchBy, 1, 2);
+            this.pnlSystem.Controls.Add(this.label9, 0, 2);
+            this.pnlSystem.Controls.Add(this.cmbStoreLocation, 1, 0);
+            this.pnlSystem.Controls.Add(this.cmbStore, 1, 1);
+            this.pnlSystem.Controls.Add(this.label8, 0, 3);
+            this.pnlSystem.Controls.Add(this.label7, 0, 1);
+            this.pnlSystem.Controls.Add(this.label6, 0, 0);
+            this.pnlSystem.Controls.Add(this.txtSearch, 1, 3);
+            this.pnlSystem.Controls.Add(this.butSearchCertificate, 1, 4);
+            this.pnlSystem.Controls.Add(this.butViewCertificate, 2, 5);
+            this.pnlSystem.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlSystem.Location = new System.Drawing.Point(3, 16);
+            this.pnlSystem.Name = "pnlSystem";
+            this.pnlSystem.RowCount = 6;
+            this.pnlSystem.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlSystem.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlSystem.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlSystem.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlSystem.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlSystem.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlSystem.Size = new System.Drawing.Size(464, 205);
+            this.pnlSystem.TabIndex = 9;
+            // 
+            // lblCertificateDescription
+            // 
+            this.lblCertificateDescription.AutoSize = true;
+            this.lblCertificateDescription.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblCertificateDescription.Location = new System.Drawing.Point(153, 179);
+            this.lblCertificateDescription.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblCertificateDescription.Name = "lblCertificateDescription";
+            this.lblCertificateDescription.Size = new System.Drawing.Size(246, 21);
+            this.lblCertificateDescription.TabIndex = 17;
+            this.lblCertificateDescription.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lblSelectedCertificate
+            // 
+            this.lblSelectedCertificate.AutoSize = true;
+            this.lblSelectedCertificate.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblSelectedCertificate.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblSelectedCertificate.Location = new System.Drawing.Point(3, 179);
+            this.lblSelectedCertificate.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblSelectedCertificate.Name = "lblSelectedCertificate";
+            this.lblSelectedCertificate.Size = new System.Drawing.Size(144, 21);
+            this.lblSelectedCertificate.TabIndex = 16;
+            this.lblSelectedCertificate.Text = "Selected Certificate:";
+            this.lblSelectedCertificate.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.lblSelectedCertificate.Visible = false;
+            // 
+            // cmbSearchBy
+            // 
+            this.pnlSystem.SetColumnSpan(this.cmbSearchBy, 2);
+            this.cmbSearchBy.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.cmbSearchBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbSearchBy.FormattingEnabled = true;
+            this.cmbSearchBy.Location = new System.Drawing.Point(153, 61);
+            this.cmbSearchBy.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.cmbSearchBy.Name = "cmbSearchBy";
+            this.cmbSearchBy.Size = new System.Drawing.Size(308, 21);
+            this.cmbSearchBy.TabIndex = 14;
+            // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label9.Location = new System.Drawing.Point(3, 61);
+            this.label9.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(144, 21);
+            this.label9.TabIndex = 13;
+            this.label9.Text = "Search By:";
+            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // cmbStoreLocation
+            // 
+            this.pnlSystem.SetColumnSpan(this.cmbStoreLocation, 2);
+            this.cmbStoreLocation.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.cmbStoreLocation.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbStoreLocation.FormattingEnabled = true;
+            this.cmbStoreLocation.Location = new System.Drawing.Point(153, 3);
+            this.cmbStoreLocation.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.cmbStoreLocation.Name = "cmbStoreLocation";
+            this.cmbStoreLocation.Size = new System.Drawing.Size(308, 21);
+            this.cmbStoreLocation.TabIndex = 10;
+            // 
+            // cmbStore
+            // 
+            this.pnlSystem.SetColumnSpan(this.cmbStore, 2);
+            this.cmbStore.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.cmbStore.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbStore.FormattingEnabled = true;
+            this.cmbStore.Location = new System.Drawing.Point(153, 32);
+            this.cmbStore.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.cmbStore.Name = "cmbStore";
+            this.cmbStore.Size = new System.Drawing.Size(308, 21);
+            this.cmbStore.TabIndex = 11;
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label8.Location = new System.Drawing.Point(3, 90);
+            this.label8.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(144, 20);
+            this.label8.TabIndex = 2;
+            this.label8.Text = "Search:";
+            this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label7.Location = new System.Drawing.Point(3, 32);
+            this.label7.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(144, 21);
+            this.label7.TabIndex = 1;
+            this.label7.Text = "Certificate Store:";
+            this.label7.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.label6.Location = new System.Drawing.Point(3, 3);
+            this.label6.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(144, 21);
+            this.label6.TabIndex = 0;
+            this.label6.Text = "Store Location:";
+            this.label6.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // txtSearch
+            // 
+            this.pnlSystem.SetColumnSpan(this.txtSearch, 2);
+            this.txtSearch.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtSearch.Location = new System.Drawing.Point(153, 90);
+            this.txtSearch.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtSearch.Name = "txtSearch";
+            this.txtSearch.Size = new System.Drawing.Size(308, 20);
+            this.txtSearch.TabIndex = 12;
+            this.txtSearch.TextChanged += new System.EventHandler(this.txtSubjectName_TextChanged);
+            // 
+            // butSearchCertificate
+            // 
+            this.butSearchCertificate.AutoSize = true;
+            this.pnlSystem.SetColumnSpan(this.butSearchCertificate, 2);
+            this.butSearchCertificate.Location = new System.Drawing.Point(153, 118);
+            this.butSearchCertificate.Name = "butSearchCertificate";
+            this.butSearchCertificate.Size = new System.Drawing.Size(73, 23);
+            this.butSearchCertificate.TabIndex = 3;
+            this.butSearchCertificate.Text = "Search";
+            this.butSearchCertificate.UseVisualStyleBackColor = true;
+            this.butSearchCertificate.Click += new System.EventHandler(this.butSearchCertificate_Click);
+            // 
+            // butViewCertificate
+            // 
+            this.butViewCertificate.AutoSize = true;
+            this.butViewCertificate.Location = new System.Drawing.Point(405, 179);
+            this.butViewCertificate.Name = "butViewCertificate";
+            this.butViewCertificate.Size = new System.Drawing.Size(56, 23);
+            this.butViewCertificate.TabIndex = 15;
+            this.butViewCertificate.Text = "View";
+            this.butViewCertificate.UseVisualStyleBackColor = true;
+            this.butViewCertificate.Visible = false;
+            this.butViewCertificate.Click += new System.EventHandler(this.butViewCertificate_Click);
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(11, 10);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(92, 13);
+            this.label5.TabIndex = 4;
+            this.label5.Text = "Certificate source:";
+            // 
+            // cmbCertificateSource
+            // 
+            this.cmbCertificateSource.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbCertificateSource.FormattingEnabled = true;
+            this.cmbCertificateSource.Location = new System.Drawing.Point(123, 7);
+            this.cmbCertificateSource.Name = "cmbCertificateSource";
+            this.cmbCertificateSource.Size = new System.Drawing.Size(178, 21);
+            this.cmbCertificateSource.TabIndex = 3;
+            this.cmbCertificateSource.SelectedIndexChanged += new System.EventHandler(this.cmbCertificateSource_SelectedIndexChanged);
             // 
             // topBorder
             // 
@@ -341,8 +609,13 @@ namespace WixSharpSetup.Dialogs
             this.Load += new System.EventHandler(this.OnLoad);
             this.contextMenuStrip1.ResumeLayout(false);
             this.middlePanel.ResumeLayout(false);
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.tableLayoutPanel2.PerformLayout();
+            this.middlePanel.PerformLayout();
+            this.gbExternal.ResumeLayout(false);
+            this.pnlExternal.ResumeLayout(false);
+            this.pnlExternal.PerformLayout();
+            this.gbSystem.ResumeLayout(false);
+            this.pnlSystem.ResumeLayout(false);
+            this.pnlSystem.PerformLayout();
             this.topPanel.ResumeLayout(false);
             this.topPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).EndInit();
@@ -377,6 +650,24 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.TextBox txtPrivateKeyFile;
         private System.Windows.Forms.Label lblPrivateKeyFile;
         private System.Windows.Forms.Button butBrowsePrivateKeyFile;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.TableLayoutPanel pnlExternal;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.ComboBox cmbCertificateSource;
+        private System.Windows.Forms.TableLayoutPanel pnlSystem;
+        private System.Windows.Forms.Label label8;
+        private System.Windows.Forms.Label label7;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Button butSearchCertificate;
+        private System.Windows.Forms.ComboBox cmbStoreLocation;
+        private System.Windows.Forms.ComboBox cmbStore;
+        private System.Windows.Forms.TextBox txtSearch;
+        private System.Windows.Forms.ComboBox cmbSearchBy;
+        private System.Windows.Forms.Label label9;
+        private System.Windows.Forms.Label lblSelectedCertificate;
+        private System.Windows.Forms.Button butViewCertificate;
+        private System.Windows.Forms.Label lblCertificateDescription;
+        private System.Windows.Forms.GroupBox gbSystem;
+        private System.Windows.Forms.GroupBox gbExternal;
+        private System.Windows.Forms.Label lblHint;
     }
 }

--- a/package/WindowsManaged/Dialogs/CertificateDialog.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.cs
@@ -1,49 +1,115 @@
-using System;
-using System.IO;
-using System.Linq;
-using System.Windows.Forms;
 using DevolutionsGateway.Dialogs;
 using DevolutionsGateway.Properties;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.RegularExpressions;
+using System.Windows.Forms;
 using WixSharp;
+using static DevolutionsGateway.Properties.Constants;
 using File = System.IO.File;
+using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
+using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
 
 namespace WixSharpSetup.Dialogs;
 
 public partial class CertificateDialog : GatewayDialog
 {
+    private static readonly string[] Locations =
+    {
+        "Current User", // StoreLocation.currentUser
+        "Local Machine", // StoreLocation.localMachine
+    };
+
+    private static readonly List<KeyValuePair<StoreName, string>> Stores = new()
+    {
+        new KeyValuePair<StoreName, string>(StoreName.My, "Personal"),
+        new KeyValuePair<StoreName, string>(StoreName.Root, "Trusted Root Certification Authorities"),
+        new KeyValuePair<StoreName, string>(StoreName.CertificateAuthority, "Intermediate Certification Authorities"),
+        new KeyValuePair<StoreName, string>(StoreName.TrustedPublisher, "Trusted Publishers"),
+        new KeyValuePair<StoreName, string>(StoreName.Disallowed, "Untrusted Certificates"),
+        new KeyValuePair<StoreName, string>(StoreName.AuthRoot, "Third-Party Root Certification Authorities"),
+        new KeyValuePair<StoreName, string>(StoreName.TrustedPeople, "Trusted People"),
+        new KeyValuePair<StoreName, string>(StoreName.AddressBook, "Other People")
+    };
+
+    private static string[] StoreNames => Stores.Select(x => x.Value).ToArray();
+
+    private static readonly List<KeyValuePair<Constants.CertificateFindType, string>> CertificateFindTypes = new()
+    {
+        new KeyValuePair<CertificateFindType, string>(CertificateFindType.Thumbprint, "Thumbprint"),
+        new KeyValuePair<CertificateFindType, string>(CertificateFindType.SubjectName, "Subject Name")
+    };
+
+    private static readonly string[] FindTypes = CertificateFindTypes.Select(x => x.Value).ToArray();
+    
+    private bool UseExternalCertificate => (Constants.CertificateMode)this.cmbCertificateSource.SelectedIndex == Constants.CertificateMode.External;
+
+    private bool UseSystemCertificate => (Constants.CertificateMode)this.cmbCertificateSource.SelectedIndex == Constants.CertificateMode.System;
+
+    private X509Certificate2 SelectedCertificate
+    {
+        get;
+        set;
+    }
+
     public CertificateDialog()
     {
         InitializeComponent();
         label1.MakeTransparentOn(banner);
         label2.MakeTransparentOn(banner);
+
+        this.cmbCertificateSource.DataSource = Enum.GetValues(typeof(Constants.CertificateMode));
+        this.cmbCertificateSource.SelectedIndex = 0;
+
+        this.cmbStoreLocation.DataSource = Locations;
+        this.cmbCertificateSource.SelectedIndex = 0;
+
+        this.cmbStore.DataSource = StoreNames;
+        this.cmbStore.SelectedIndex = 0;
+
+        this.cmbSearchBy.DataSource = FindTypes;
+        this.cmbSearchBy.SelectedIndex = 0;
     }
 
     public override bool DoValidate()
     {
-        if (string.IsNullOrWhiteSpace(this.txtCertificateFile.Text) ||
-            !File.Exists(this.txtCertificateFile.Text.Trim()))
+        if (this.UseExternalCertificate)
         {
-            ShowValidationError("Error29995");
-            return false;
-        }
-
-
-        if (this.NeedsPassword())
-        {
-            // We could validate the certificate directly at this point....
-            // Empty password might be valid
-            if (string.IsNullOrEmpty(this.txtCertificatePassword.Text))
+            if (string.IsNullOrWhiteSpace(this.txtCertificateFile.Text) ||
+                !File.Exists(this.txtCertificateFile.Text.Trim()))
             {
                 ShowValidationError("Error29995");
                 return false;
             }
+
+            if (this.NeedsPassword())
+            {
+                // We could validate the certificate directly at this point....
+                // Empty password might be valid
+                if (string.IsNullOrEmpty(this.txtCertificatePassword.Text))
+                {
+                    ShowValidationError("Error29995");
+                    return false;
+                }
+            }
+            else
+            {
+                if (string.IsNullOrWhiteSpace(this.txtPrivateKeyFile.Text) ||
+                    !File.Exists(this.txtPrivateKeyFile.Text.Trim()))
+                {
+                    ShowValidationError("Error29995");
+                    return false;
+                }
+            }
         }
         else
         {
-            if (string.IsNullOrWhiteSpace(this.txtPrivateKeyFile.Text) ||
-                !File.Exists(this.txtPrivateKeyFile.Text.Trim()))
+            if (this.SelectedCertificate is null)
             {
-                ShowValidationError("Error29995");
+                ShowValidationError("You must select a certificate from the system certificate store");
                 return false;
             }
         }
@@ -54,9 +120,33 @@ public partial class CertificateDialog : GatewayDialog
     public override void FromProperties()
     {
         GatewayProperties properties = new(this.Runtime.Session);
+
+        this.cmbCertificateSource.SelectedIndex = (int) properties.CertificateMode;
         this.txtCertificateFile.Text = properties.CertificateFile;
         this.txtPrivateKeyFile.Text = properties.CertificatePrivateKeyFile;
         this.txtCertificatePassword.Text = properties.CertificatePassword;
+        this.cmbStoreLocation.SelectedIndex = (int)properties.CertificateLocation - 1;
+        this.cmbStore.SelectedIndex = Stores.IndexOf(Stores.First(x => x.Key == properties.CertificateStore));
+        this.cmbSearchBy.SelectedIndex =
+            CertificateFindTypes.IndexOf(CertificateFindTypes.First(x => x.Key == properties.CertificateFindType));
+        this.txtSearch.Text = properties.CertificateSearchText;
+
+        try
+        {
+            X509Certificate2Collection certificates = this.SearchCertificate(
+                (StoreLocation) this.cmbStoreLocation.SelectedIndex + 1,
+                Stores[this.cmbStore.SelectedIndex].Key,
+                CertificateFindType.Thumbprint,
+                properties.CertificateThumbprint);
+
+            if (certificates?.Count == 1)
+            {
+                this.SetSelectedCertificate(certificates[0]);
+            }
+        }
+        catch // Failed to restore state, don't crash
+        {
+        }
 
         this.SetControlStates();
     }
@@ -65,19 +155,34 @@ public partial class CertificateDialog : GatewayDialog
     {
         GatewayProperties properties = new(this.Runtime.Session)
         {
-            CertificateFile = this.txtCertificateFile.Text.Trim()
+            CertificateMode = (Constants.CertificateMode)this.cmbCertificateSource.SelectedIndex
         };
 
-        if (this.NeedsPassword())
+        if (this.UseExternalCertificate)
         {
-            properties.CertificatePassword = this.txtCertificatePassword.Text;
-            properties.CertificatePrivateKeyFile = string.Empty;
+            properties.CertificateFile = this.txtCertificateFile.Text.Trim();
+
+            if (this.NeedsPassword())
+            {
+                properties.CertificatePassword = this.txtCertificatePassword.Text;
+                properties.CertificatePrivateKeyFile = string.Empty;
+            }
+            else
+            {
+                properties.CertificatePassword = string.Empty;
+                properties.CertificatePrivateKeyFile = this.txtPrivateKeyFile.Text.Trim();
+            }
         }
         else
         {
-            properties.CertificatePassword = string.Empty;
-            properties.CertificatePrivateKeyFile = this.txtPrivateKeyFile.Text.Trim();
+            properties.CertificateLocation = (StoreLocation)(this.cmbStoreLocation.SelectedIndex + 1);
+            properties.CertificateStore = Stores[this.cmbStore.SelectedIndex].Key;
+            properties.CertificateName = this.SelectedCertificate?.GetNameInfo(X509NameType.SimpleName, false);
+            properties.CertificateThumbprint = this.SelectedCertificate?.Thumbprint;
         }
+
+        properties.CertificateFindType = CertificateFindTypes[this.cmbSearchBy.SelectedIndex].Key;
+        properties.CertificateSearchText = this.txtSearch.Text;
 
         return true;
     }
@@ -100,8 +205,8 @@ public partial class CertificateDialog : GatewayDialog
 
     private void butBrowseCertificateFile_Click(object sender, EventArgs e)
     {
-        // TODO: (rmarkiewicz) localization
-        const string filter = "PFX Files (*.pfx, *.p12)|*.pfx;*.p12|Certificate Files (*.pem, *.crt, *.cer)|*.pem;*.crt;*.cer|All Files|*.*";
+        const string filter =
+            "PFX Files (*.pfx, *.p12)|*.pfx;*.p12|Certificate Files (*.pem, *.crt, *.cer)|*.pem;*.crt;*.cer|All Files|*.*";
         string file = this.BrowseForFile(filter);
 
         if (!string.IsNullOrEmpty(file))
@@ -114,7 +219,6 @@ public partial class CertificateDialog : GatewayDialog
 
     private void butBrowsePrivateKeyFile_Click(object sender, EventArgs e)
     {
-        // TODO: (rmarkiewicz) localization
         const string filter = "Private Key Files (*.key)|*.key|All Files|*.*";
         string file = this.BrowseForFile(filter);
 
@@ -152,26 +256,130 @@ public partial class CertificateDialog : GatewayDialog
         string extension = Path.GetExtension(certificatePath);
 
         return !string.IsNullOrEmpty(extension) &&
-               new[] { ".pfx", ".p12" }.Any(x => x.Equals(extension, StringComparison.CurrentCultureIgnoreCase));
+               new[] {".pfx", ".p12"}.Any(x => x.Equals(extension, StringComparison.CurrentCultureIgnoreCase));
     }
 
     private void SetControlStates()
     {
-        this.SuspendLayout();
+        if (this.UseExternalCertificate)
+        {
+            this.gbExternal.Visible = true;
+            this.gbSystem.Visible = false;
 
-        try
-        {
-            this.lblCertificatePassword.Visible = this.txtCertificatePassword.Visible = this.NeedsPassword();
-            this.lblPrivateKeyFile.Visible = this.txtPrivateKeyFile.Visible = this.butBrowsePrivateKeyFile.Visible = !this.NeedsPassword();
+            bool needsPassword = this.NeedsPassword();
+
+            this.lblCertificatePassword.Visible = this.txtCertificatePassword.Visible = needsPassword;
+            this.lblPrivateKeyFile.Visible = this.txtPrivateKeyFile.Visible = this.butBrowsePrivateKeyFile.Visible = !needsPassword;
+            this.lblHint.Text = needsPassword ? 
+                string.Empty : 
+                "Encrypted private keys are not supported";
         }
-        finally
+
+        else
         {
-            this.ResumeLayout(true);
+            this.gbExternal.Visible = false;
+            this.gbSystem.Visible = true;
+
+            this.butSearchCertificate.Enabled = !string.IsNullOrWhiteSpace(this.txtSearch.Text);
         }
     }
 
     private void txtCertificateFile_TextChanged(object sender, EventArgs e)
     {
         this.SetControlStates();
+    }
+
+    private void cmbCertificateSource_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+
+    private void txtSubjectName_TextChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+
+    private X509Certificate2Collection SearchCertificate(StoreLocation location, StoreName storeName,
+        CertificateFindType findType, string findValue)
+    {
+        X509Store store = null;
+
+        try
+        {
+            store = new X509Store(storeName, location);
+            store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+
+            X509FindType x509FindType = findType == CertificateFindType.Thumbprint
+                ? X509FindType.FindByThumbprint
+                : X509FindType.FindBySubjectName;
+
+            if (x509FindType == X509FindType.FindByThumbprint)
+            {
+                findValue = Regex.Replace(findValue.ToUpper(), @"[^0-9A-F]+", string.Empty);
+            }
+
+            return store.Certificates.Find(x509FindType, findValue, true);
+        }
+        finally
+        {
+            store?.Close();
+        }
+    }
+
+    private void butSearchCertificate_Click(object sender, EventArgs e)
+    {
+        try
+        {
+            X509Certificate2Collection certificates = SearchCertificate(
+                (StoreLocation) this.cmbStoreLocation.SelectedIndex + 1,
+                Stores[this.cmbStore.SelectedIndex].Key,
+                CertificateFindTypes[this.cmbSearchBy.SelectedIndex].Key,
+                this.txtSearch.Text);
+            
+            if (certificates.Count == 0)
+            {
+                this.SetSelectedCertificate(null);
+
+                MessageBox.Show("No matching certificates found", base.Localize("CertificateDlg_Title"));
+            }
+            else if (certificates.Count == 1)
+            {
+                this.SetSelectedCertificate(certificates[0]);
+            }
+            else
+            {
+                X509Certificate2Collection selection = X509Certificate2UI.SelectFromCollection(certificates,
+                    base.Localize("CertificateDlg_Title"),
+                    "Select the certificate to use", X509SelectionFlag.SingleSelection, this.Handle);
+
+                if (selection.Count > 0)
+                {
+                    this.SetSelectedCertificate(selection[0]);
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            ShowValidationErrorString($"An unexpected error occurred accessing the system certificate store: {exception}");
+        }
+    }
+
+    private void SetSelectedCertificate(X509Certificate2 certificate)
+    {
+        // this.SelectedCertificate?.Dispose(); TODO: .net48
+        this.SelectedCertificate = certificate;
+
+        this.lblCertificateDescription.Text = string.Empty;
+        this.lblSelectedCertificate.Visible = this.lblCertificateDescription.Visible = this.butViewCertificate.Visible = this.SelectedCertificate is not null;
+
+        if (this.SelectedCertificate is not null)
+        {
+            this.lblCertificateDescription.Text = this.SelectedCertificate?.GetNameInfo(X509NameType.SimpleName, false);
+        }
+    }
+
+    private void butViewCertificate_Click(object sender, EventArgs e)
+    {
+        X509Certificate2UI.DisplayCertificate(this.SelectedCertificate, this.Handle);
     }
 }

--- a/package/WindowsManaged/Dialogs/GatewayDialog.cs
+++ b/package/WindowsManaged/Dialogs/GatewayDialog.cs
@@ -63,8 +63,13 @@ public class GatewayDialog : ManagedForm
     {
         string errorMessage = this.Localize(string.IsNullOrEmpty(message) ? "InvalidConfigurationDlgInfoLabel" : message);
 
+        this.ShowValidationErrorString(errorMessage);
+    }
+
+    protected void ShowValidationErrorString(string message)
+    {
         MessageBox.Show(
-            errorMessage,
+            message,
             this.Localize("InvalidConfigurationDlg_Title"),
             MessageBoxButtons.OK,
             MessageBoxIcon.Warning);

--- a/package/WindowsManaged/Dialogs/Wizard.cs
+++ b/package/WindowsManaged/Dialogs/Wizard.cs
@@ -54,6 +54,11 @@ internal static class Wizard
             }
         }
 
+        if (dialog == typeof(SummaryDialog))
+        {
+            return true;
+        }
+
         if (dialog == typeof(CertificateDialog))
         {
             if (properties.HttpListenerScheme == Constants.HttpProtocol)

--- a/package/WindowsManaged/Program.cs
+++ b/package/WindowsManaged/Program.cs
@@ -158,7 +158,7 @@ internal class Program
         {
             project.CandleOptions = "-fips";
         }
-
+        
         project.Dirs = new Dir[]
         {
             new ("%ProgramFiles%", new Dir(Includes.VENDOR_NAME, new InstallDir(Includes.SHORT_NAME)
@@ -248,12 +248,13 @@ internal class Program
             .Add<MaintenanceTypeDialog>()
             .Add<ProgressDialog>()
             .Add<ExitDialog>();
-
+        
         project.UIInitialized += Project_UIInitialized;
 
         project.Language = enUS.Key;
         project.LocalizationFile = $"Resources/{enUS.Value}";
         project.PreserveTempFiles = true;
+        
         string msi = project.BuildMsi();
 
         project.Language = frFR.Key;

--- a/package/WindowsManaged/Properties/Constants.cs
+++ b/package/WindowsManaged/Properties/Constants.cs
@@ -8,6 +8,18 @@ namespace DevolutionsGateway.Properties
 {
     internal class Constants
     {
+        internal enum CertificateMode
+        {
+            External,
+            System
+        }
+
+        internal enum CertificateFindType
+        {
+            Thumbprint,
+            SubjectName
+        }
+
         internal const string HttpProtocol = "http";
 
         internal const string HttpsProtocol = "https";
@@ -21,6 +33,8 @@ namespace DevolutionsGateway.Properties
         internal const string ImportDGatewayCertificateWithPasswordCommandFormat = "Import-DGatewayCertificate -CertificateFile '{0}' -Password '{1}'";
 
         internal const string ImportDGatewayCertificateWithPrivateKeyCommandFormat = "Import-DGatewayCertificate -CertificateFile '{0} -PrivateKeyFile '{1}'";
+
+        internal const string ImportDGatewayCertificateFromSystemFormat = "Set-DGatewayConfig -TlsCertificateSource {0} -TlsCertificateSubjectName {1} -TlsCertificateStoreName {2} -TlsCertificateStoreLocation {3}";
 
         internal const string ImportDGatewayProvisionerKeyCommandFormat = "Import-DGatewayProvisionerKey -PublicKeyFile '{0}'";
     }

--- a/package/WindowsManaged/Properties/GatewayProperties.g.cs
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.cs
@@ -1,4 +1,7 @@
 ﻿
+using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
+using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
+
 namespace DevolutionsGateway.Properties
 {
     internal partial class GatewayProperties
@@ -76,6 +79,30 @@ namespace DevolutionsGateway.Properties
             }
         }
  
+        internal static readonly WixProperty<Constants.CertificateMode> _CertificateMode = new()
+        {
+            Id = "P.CERTIFICATEMODE",
+            Default = Constants.CertificateMode.External,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public Constants.CertificateMode CertificateMode
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateMode.Id);
+                return WixProperties.GetPropertyValue<Constants.CertificateMode>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateMode, value); 
+                }
+            }
+        }
+ 
         internal static readonly WixProperty<string> _CertificateFile = new()
         {
             Id = "P.CERTIFICATEFILE",
@@ -144,6 +171,150 @@ namespace DevolutionsGateway.Properties
                 if (this.runtimeSession is not null)
                 {
                     this.runtimeSession.Set(_CertificatePrivateKeyFile, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<StoreLocation> _CertificateLocation = new()
+        {
+            Id = "P.CERTIFICATELOCATION",
+            Default = StoreLocation.CurrentUser,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public StoreLocation CertificateLocation
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateLocation.Id);
+                return WixProperties.GetPropertyValue<StoreLocation>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateLocation, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<StoreName> _CertificateStore = new()
+        {
+            Id = "P.CERTIFICATESTORE",
+            Default = StoreName.My,
+            Secure = true,
+            Hidden = true,
+        };
+
+        public StoreName CertificateStore
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateStore.Id);
+                return WixProperties.GetPropertyValue<StoreName>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateStore, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<string> _CertificateName = new()
+        {
+            Id = "P.CERTIFICATENAME",
+            Default = string.Empty,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public string CertificateName
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateName.Id);
+                return WixProperties.GetPropertyValue<string>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateName, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<Constants.CertificateFindType> _CertificateFindType = new()
+        {
+            Id = "P.CERTIFICATEFINDTYPE",
+            Default = Constants.CertificateFindType.Thumbprint,
+            Secure = false,
+            Hidden = false,
+        };
+
+        public Constants.CertificateFindType CertificateFindType
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateFindType.Id);
+                return WixProperties.GetPropertyValue<Constants.CertificateFindType>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateFindType, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<string> _CertificateSearchText = new()
+        {
+            Id = "P.CERTIFICATESEARCHTEXT",
+            Default = string.Empty,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public string CertificateSearchText
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateSearchText.Id);
+                return WixProperties.GetPropertyValue<string>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateSearchText, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<string> _CertificateThumbprint = new()
+        {
+            Id = "P.CERTIFICATETHUMBPRINT",
+            Default = string.Empty,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public string CertificateThumbprint
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_CertificateThumbprint.Id);
+                return WixProperties.GetPropertyValue<string>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_CertificateThumbprint, value); 
                 }
             }
         }
@@ -269,26 +440,26 @@ namespace DevolutionsGateway.Properties
             }
         }
  
-        internal static readonly WixProperty<string> _NoStartService = new()
+        internal static readonly WixProperty<string> _PublicKeyFile = new()
         {
-            Id = "P.DGW.NO_START_SERVICE",
+            Id = "P.PUBLICKEYFILE",
             Default = string.Empty,
             Secure = true,
             Hidden = false,
         };
 
-        public string NoStartService
+        public string PublicKeyFile
         {
             get
             {
-                string stringValue = this.FnGetPropValue(_NoStartService.Id);
+                string stringValue = this.FnGetPropValue(_PublicKeyFile.Id);
                 return WixProperties.GetPropertyValue<string>(stringValue);
             }
             set 
             { 
                 if (this.runtimeSession is not null)
                 {
-                    this.runtimeSession.Set(_NoStartService, value); 
+                    this.runtimeSession.Set(_PublicKeyFile, value); 
                 }
             }
         }
@@ -317,26 +488,26 @@ namespace DevolutionsGateway.Properties
             }
         }
  
-        internal static readonly WixProperty<string> _PublicKeyFile = new()
+        internal static readonly WixProperty<string> _NoStartService = new()
         {
-            Id = "P.PUBLICKEYFILE",
+            Id = "P.DGW.NO_START_SERVICE",
             Default = string.Empty,
             Secure = true,
             Hidden = false,
         };
 
-        public string PublicKeyFile
+        public string NoStartService
         {
             get
             {
-                string stringValue = this.FnGetPropValue(_PublicKeyFile.Id);
+                string stringValue = this.FnGetPropValue(_NoStartService.Id);
                 return WixProperties.GetPropertyValue<string>(stringValue);
             }
             set 
             { 
                 if (this.runtimeSession is not null)
                 {
-                    this.runtimeSession.Set(_PublicKeyFile, value); 
+                    this.runtimeSession.Set(_NoStartService, value); 
                 }
             }
         }
@@ -567,11 +738,25 @@ namespace DevolutionsGateway.Properties
  
             _AccessUriScheme,
  
+            _CertificateMode,
+ 
             _CertificateFile,
  
             _CertificatePassword,
  
             _CertificatePrivateKeyFile,
+ 
+            _CertificateLocation,
+ 
+            _CertificateStore,
+ 
+            _CertificateName,
+ 
+            _CertificateFindType,
+ 
+            _CertificateSearchText,
+ 
+            _CertificateThumbprint,
  
             _ConfigureGateway,
  
@@ -583,11 +768,11 @@ namespace DevolutionsGateway.Properties
  
             _HttpListenerScheme,
  
-            _NoStartService,
+            _PublicKeyFile,
  
             _PowerShellPath,
  
-            _PublicKeyFile,
+            _NoStartService,
  
             _ServiceStart,
  

--- a/package/WindowsManaged/Properties/GatewayProperties.g.tt
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.tt
@@ -5,6 +5,9 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 
+using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
+using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
+
 namespace DevolutionsGateway.Properties
 {
     internal partial class GatewayProperties
@@ -54,21 +57,38 @@ namespace DevolutionsGateway.Properties
 <#+      
   string[,] properties = {     
     // type name default secure hidden id comment
+
     {"string", "AccessUriHost", "string.Empty", "true", "false", "", ""},
     {"uint", "AccessUriPort", "443", "true", "false", "", ""},
     {"string", "AccessUriScheme", "Constants.HttpsProtocol", "true", "false", "", ""},
+
+    {"Constants.CertificateMode", "CertificateMode", "Constants.CertificateMode.External", "true", "false", "", ""},
+    // External certificate mode
     {"string", "CertificateFile", "string.Empty", "true", "false", "", ""},
     {"string", "CertificatePassword", "string.Empty", "true", "true", "", ""},
     {"string", "CertificatePrivateKeyFile", "string.Empty", "true", "false", "", ""},
+    // System certificate mode
+    {"StoreLocation", "CertificateLocation", "StoreLocation.CurrentUser", "true", "false", "", ""},
+    {"StoreName", "CertificateStore", "StoreName.My", "true", "true", "", ""},
+    {"string", "CertificateName", "string.Empty", "true", "false", "", ""},
+    // UI Helpers
+    {"Constants.CertificateFindType", "CertificateFindType", "Constants.CertificateFindType.Thumbprint", "false", "false", "", ""},
+    {"string", "CertificateSearchText", "string.Empty", "true", "false", "", ""},
+    {"string", "CertificateThumbprint", "string.Empty", "true", "false", "", ""},
+
     {"bool", "ConfigureGateway", "false", "false", "false", "", "`true` to configure the Gateway interactively"},    
     {"bool", "HasPowerShell", "false", "false", "false", "", ""},
+
     {"string", "HttpListenerHost", "0.0.0.0", "true", "false", "", ""},
     {"uint", "HttpListenerPort", "7171", "true", "false", "", ""},
     {"string", "HttpListenerScheme", "Constants.HttpsProtocol", "true", "false", "", ""},
-    {"string", "NoStartService", "string.Empty", "true", "false", "dgw.no_start_service", ""},
-    {"string", "PowerShellPath", "string.Empty", "true", "false", "", ""},
+
     {"string", "PublicKeyFile", "string.Empty", "true", "false", "", ""},
+
+    {"string", "PowerShellPath", "string.Empty", "true", "false", "", ""},
+    {"string", "NoStartService", "string.Empty", "true", "false", "dgw.no_start_service", ""},
     {"int", "ServiceStart", "3", "true", "false", "", ""},
+
     {"string", "TcpListenerHost", "0.0.0.0", "true", "false", "", ""},
     {"uint", "TcpListenerPort", "8181", "true", "false", "", ""},
     {"string", "TcpListenerScheme", "Constants.TcpProtocol", "true", "false", "", ""},
@@ -77,6 +97,7 @@ namespace DevolutionsGateway.Properties
     {"bool", "Upgrading", "false", "true", "false", "", ""},
     {"bool", "RemovingForUpgrade", "false", "true", "false", "", ""},
     {"bool", "Uninstalling", "false", "true", "false", "", ""},
+
     {"bool", "Maintenance", "false", "true", "false", "", ""},
   };               
 #>

--- a/package/WindowsManaged/Properties/WixProperty.cs
+++ b/package/WindowsManaged/Properties/WixProperty.cs
@@ -31,7 +31,7 @@ namespace DevolutionsGateway.Properties
 
         public static void Set<T>(this ISession session, WixProperty<T> prop, T value)
         {
-            session[prop.Id] = value.ToString();
+            session[prop.Id] = value?.ToString();
         }
 
         public static Property ToWixSharpProperty(this IWixProperty property)
@@ -49,6 +49,11 @@ namespace DevolutionsGateway.Properties
             if (string.IsNullOrWhiteSpace(propertyValue))
             {
                 return default;
+            }
+
+            if (typeof(T).IsEnum)
+            {
+                return (T) Enum.Parse(typeof(T), propertyValue);
             }
 
             var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);

--- a/powershell/DevolutionsGateway/DevolutionsGateway.psd1
+++ b/powershell/DevolutionsGateway/DevolutionsGateway.psd1
@@ -22,7 +22,7 @@
     CompanyName = 'Devolutions'
 
     # Copyright statement for this module
-    Copyright = '(c) 2019-2023 Devolutions Inc. All rights reserved.'
+    Copyright = '(c) 2019-2024 Devolutions Inc. All rights reserved.'
 
     # Description of the functionality provided by this module
     Description = 'Devolutions Gateway PowerShell Module'


### PR DESCRIPTION
Adds support for using Windows certificate store parameters in the managed Windows installer.

If certificate selection is required (i.e. an https listener is being created), the user will now be prompted with "External" and "System" options for certificate selection. "External" functions as before; "System" allows the user to select the store location and name, and search for certificates by thumbprint or subject name.

The user must select _one_ certificate in this mode. If multiple certificates match their search, they will be forced to choose one. The certificate mode, store location, name and certificate subject will be configured in the Gateway .cfg file.

https://github.com/Devolutions/devolutions-gateway/assets/2573400/c342785d-f221-43e8-bec6-7307458a3530

Notes:

- The "Search" screen was easier to implement than a generic certificate browser, hopefully it's use is intuitive enough.
- The `CurrentService` store location isn't available; there's no .NET API to interact with this certificate store. If this is a requirement then the user should configure the certificate using PowerShell. I'm not sure if this is a niche use case (why wouldn't the user just put the certificate in the local machine store?).
- Only the .NET built-in [store names](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename?view=net-8.0) are exposed. We could allow the user to input their own store name?
- Additionally, I'm trusting that these values are what the Gateway expects (I assume so as, for example "StoreName.My" maps to the default "My" value in the Gateway readme)
- Finally, the certificate subject name in .NET is a full distinguished name. I don't think this is what the configuration file wants, so I'm calling [X509Certificate2.GetNameInfo](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.getnameinfo?view=net-8.0) with a value of `X509NameType.SimpleName`. It _appears_ to be correct.

This is an incremental PR: the managed installer is not currently published. Several localizations are missing and the summary install page is temporarily disabled. 