### PR TITLE
add basic webapp configuration to PowerShell module

### DIFF
--- a/powershell/DevolutionsGateway/DevolutionsGateway.psd1
+++ b/powershell/DevolutionsGateway/DevolutionsGateway.psd1
@@ -76,6 +76,7 @@
         'New-DGatewayProvisionerKeyPair', 'Import-DGatewayProvisionerKey',
         'New-DGatewayDelegationKeyPair', 'Import-DGatewayDelegationKey',
         'New-DGatewayToken',
+        'New-DGatewayWebAppConfig',
         'Start-DGateway', 'Stop-DGateway', 'Restart-DGateway',
         'Get-DGatewayVersion', 'Get-DGatewayPackage',
         'Install-DGatewayPackage', 'Uninstall-DGatewayPackage')

--- a/powershell/DevolutionsGateway/Public/DGateway.ps1
+++ b/powershell/DevolutionsGateway/Public/DGateway.ps1
@@ -253,6 +253,32 @@ function New-DGatewayNgrokConfig() {
     $ngrok
 }
 
+class DGatewayWebAppConfig {
+    [bool] $Enabled
+    [string] $Authentication
+    [System.Nullable[System.UInt32]] $AppTokenMaximumLifetime
+    [System.Nullable[System.UInt32]] $LoginLimitRate
+
+    DGatewayWebAppConfig() { }
+}
+
+function New-DGatewayWebAppConfig() {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [bool] $Enabled,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("None", "Custom")]
+        [string] $Authentication
+    )
+
+    $webapp = [DGatewayWebAppConfig]::new()
+    $webapp.Enabled = $Enabled
+    $webapp.Authentication = $Authentication
+    $webapp
+}
+
 enum VerbosityProfile {
     Default
     Debug
@@ -286,6 +312,8 @@ class DGatewayConfig {
     [DGatewaySubscriber] $Subscriber
 
     [DGatewayNgrokConfig] $Ngrok
+    
+    [DGatewayWebAppConfig] $WebApp
 
     [string] $LogDirective
     [string] $VerbosityProfile
@@ -359,6 +387,8 @@ function Set-DGatewayConfig {
         [DGatewaySubProvisionerKey] $SubProvisionerPublicKey,
 
         [DGatewayNgrokConfig] $Ngrok,
+
+        [DGatewayWebAppConfig] $WebApp,
 
         [VerbosityProfile] $VerbosityProfile
     )

--- a/powershell/pester/Config.Tests.ps1
+++ b/powershell/pester/Config.Tests.ps1
@@ -111,6 +111,31 @@ Describe 'Devolutions Gateway config' {
 				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).TlsCertificateStoreName | Should -Be "My"
 				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).TlsCertificateStoreLocation | Should -Be "LocalMachine"
 			}
+
+			It 'Sets web app configuration' {
+				$Params = @{
+					Enabled = $true
+					Authentication = "None"
+				}
+				$WebApp = New-DGatewayWebAppConfig @Params
+				Set-DGatewayConfig -ConfigPath:$ConfigPath -WebApp $WebApp
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.Enabled | Should -Be $true
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.Authentication | Should -Be "None"
+
+				$WebApp.Enabled = $false
+				Set-DGatewayConfig -ConfigPath:$ConfigPath -WebApp $WebApp
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.Enabled | Should -Be $false
+
+				$WebApp.Enabled = $true
+				$WebApp.Authentication = "Custom"
+				$WebApp.AppTokenMaximumLifetime = 600 # 10 minutes
+				$WebApp.LoginLimitRate = 8
+				Set-DGatewayConfig -ConfigPath:$ConfigPath -WebApp $WebApp
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.Enabled | Should -Be $true
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.Authentication | Should -Be "Custom"
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.AppTokenMaximumLifetime | Should -Be 600
+				$(Get-DGatewayConfig -ConfigPath:$ConfigPath).WebApp.LoginLimitRate | Should -Be 8
+			}
 		}
 	}
 }


### PR DESCRIPTION
Add basic web app (standalone) configuration in the PowerShell module, excluding the list of users with their hashes. It would actually be a lot easier from PowerShell if we could switch to using a separate users.txt file with <user>:<hash> line entries. We also still need argon2 hashing from PowerShell, which we're hoping we can get from picky.