### PR TITLE
ci: add standalone web ui to CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,10 +283,66 @@ jobs:
           name: jetsocat
           path: .
 
+  devolutions-gateway-web-ui:
+    name: devolutions-gateway-web-ui
+    runs-on: ubuntu-latest
+    needs: preflight
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Check out Devolutions/actions
+        uses: actions/checkout@v3
+        with:
+          repository: Devolutions/actions
+          ref: v1
+          token: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
+          path: ./.github/workflows
+
+      - name: Get npm cache directory
+        id: npm-cache
+        run: |
+          "dir=$(npm config get cache)" >> $Env:GITHUB_OUTPUT
+        shell: pwsh
+        working-directory: webapp/web
+
+      - uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-node-${{ hashFiles('webapp/web/package-lock.json') }}
+          path: ${{ steps.npm-cache.outputs.dir }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Setup .npmrc config file
+        uses: ./.github/workflows/npmrc-setup
+        with:
+          npm_token: ${{ secrets.ARTIFACTORY_NPM_TOKEN }}
+
+      - name: Install NPM dependencies
+        working-directory: webapp/web
+        run: npm ci
+
+      - name: Configure runner
+        shell: pwsh
+        run: npm install -g @angular/cli
+
+      - name: Build
+        shell: pwsh
+        working-directory: webapp/web
+        run: ng build
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: webapp-client
+          path: webapp/client/
+
   devolutions-gateway:
     name: devolutions-gateway [${{ matrix.os }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
-    needs: preflight
+    needs: [preflight, devolutions-gateway-web-ui]
     env:
       CONAN_LOGIN_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
       CONAN_PASSWORD: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
@@ -299,6 +355,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Download webapp-client
+        uses: actions/download-artifact@v3
+        with:
+          name: webapp-client
+          path: webapp/client
 
       - name: Load dynamic variables
         id: load-variables
@@ -372,6 +434,7 @@ jobs:
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}"
             $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
+            $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client"
           }
 
           ./ci/tlk.ps1 package -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -246,6 +246,22 @@ jobs:
             }
           }
 
+      - name: Download web client artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action' && matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
+        uses: actions/download-artifact@v3
+        with:
+          name: webapp-client
+          path: webapp/client
+
+      - name: Download web client artifacts (cli)
+        if: needs.preflight.outputs.dl-strategy == 'cli' && matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $Destination = Join-Path "webapp" "client"
+          gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -D "$Destination"
+
       - name: Add msbuild to PATH
         if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
         uses: microsoft/setup-msbuild@v1.1
@@ -259,6 +275,7 @@ jobs:
           $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_PSMODULE_CLEAN = "1"
+          $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client"
 
           Get-ChildItem -Path (Join-Path $PackageRoot PowerShell "*.zip") -Recurse | % {
             Remove-Item $_.FullName -Force


### PR DESCRIPTION
Add the standalone gateway web UI to CI and package workflows.

There is a lot of room for improvement; this is the bare minimum work to make the files available at packaging time.