### PR TITLE
fix(dgw): validate maximum lifetime for webapp token

### DIFF
--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -189,6 +189,13 @@ pub(crate) async fn sign_app_token(
         let lifetime = req
             .lifetime
             .map(Duration::from_secs)
+            .map(|lifetime| {
+                if lifetime < conf.app_token_maximum_lifetime {
+                    lifetime
+                } else {
+                    conf.app_token_maximum_lifetime
+                }
+            })
             .unwrap_or(conf.app_token_maximum_lifetime);
 
         let jti = Uuid::new_v4();


### PR DESCRIPTION
An oversight in the endpoint for signing webapp token was discovered. The configured maximum lifetime wasn’t properly enforced. Fortunately, this bug was discovered by our security team before the feature was released and delivered.
As such, there is no need to create a security advisory.

cc @pdugre 