### PR TITLE
ci: build managed installer in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,8 +436,15 @@ jobs:
             $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
             $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client"
           }
-
+            
           ./ci/tlk.ps1 package -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+
+          if ($Env:RUNNER_OS -eq "Windows") {
+            $MsiFilename = "${{ steps.load-variables.outputs.dgateway-package }}"
+            $BaseMsiFileName = $MsiFilename.TrimEnd(".msi")
+            $Env:DGATEWAY_PACKAGE = $BaseMsiFileName + "-legacy.msi"
+            ./ci/tlk.ps1 package -PackageOption legacy -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+          }
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -266,22 +266,58 @@ jobs:
         if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
         uses: microsoft/setup-msbuild@v1.1
 
-      - name: Repackage
+      - name: Regenerate MSI
         if: matrix.project == 'devolutions-gateway'
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
           $Env:DGATEWAY_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.exe' | Select -First 1
-          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
-          $Env:DGATEWAY_PSMODULE_CLEAN = "1"
           $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client"
 
           Get-ChildItem -Path (Join-Path $PackageRoot PowerShell "*.zip") -Recurse | % {
             Remove-Item $_.FullName -Force
           }
 
-          ./ci/tlk.ps1 package
+          ./ci/tlk.ps1 package -PackageOption generate
+
+      - name: Sign msi runtime
+        if: matrix.project == 'devolutions-gateway'
+        shell: pwsh
+        working-directory: package/WindowsManaged/Release
+        run: |
+          Get-ChildItem -Path .\* -Include "*.exe" | % {
+            $Params = @('sign',
+              '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+              '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+              '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+              '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+              '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+              '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+              '-v')
+            AzureSignTool @Params $_.FullName
+          }
+
+      - name: Repackage
+        if: matrix.project == 'devolutions-gateway'
+        shell: pwsh
+        run: |
+          $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
+          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.msi' | Where-Object { $_.Name -NotLike "*legacy*"} | Select -First 1
+
+          ./ci/tlk.ps1 package -PackageOption assemble
+
+      - name: Repackage legacy msi
+        if: matrix.project == 'devolutions-gateway'
+        shell: pwsh
+        run: |
+          $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
+          $Env:DGATEWAY_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.exe' | Select -First 1
+          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*-legacy.msi' | Select -First 1
+          $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
+          $Env:DGATEWAY_PSMODULE_CLEAN = "1"
+
+          ./ci/tlk.ps1 package -PackageOption legacy
 
       - name: Sign packages
         if: matrix.project == 'devolutions-gateway'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         description: 'If true, the workflow only indicates which artifacts would be uploaded'
         required: true
         type: boolean
-        default: 'true'
+        default: true
   workflow_call:
     inputs:
       dispatch:
@@ -245,10 +245,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
 
-      ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
         shell: pwsh
-        run: Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+        run: |
+          # workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
+          Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+          # Swap the latest msi for the legacy one
+          $RootPath = Join-Path devolutions-gateway Windows x86_64
+          $NewMsi = Get-ChildItem -Path "$RootPath" -Recurse -Include '*DevolutionsGateway*.msi' | Where-Object { $_.Name -NotLike "*legacy*"} | Select -First 1
+          Remove-Item $NewMsi -Force
+          $OldMsi = Get-ChildItem -Path "$RootPath" -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
+          Rename-Item -Path $OldMsi -NewName $NewMsi.Name
 
       - name: Create GitHub release
         shell: pwsh
@@ -376,6 +383,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh run download ${{ needs.preflight.outputs.run }} -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
+
+      - name: Manage artifacts
+        shell: pwsh
+        run: |
+          # Swap the latest msi for the legacy one
+          $RootPath = Join-Path Windows x86_64
+          $NewMsi = Get-ChildItem -Path "$RootPath" -Recurse -Include '*DevolutionsGateway*.msi' | Where-Object { $_.Name -NotLike "*legacy*"} | Select -First 1
+          Remove-Item $NewMsi -Force
+          $OldMsi = Get-ChildItem -Path "$RootPath" -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
+          Rename-Item -Path $OldMsi -NewName $NewMsi.Name
 
       - name: Prepare upload
         id: prepare

--- a/package/WindowsManaged/DevolutionsGateway.csproj
+++ b/package/WindowsManaged/DevolutionsGateway.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net451</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Integrate the managed wixsharp Windows installer into the build system.

> [!IMPORTANT] 
> The previous WiX installer is still built. In CI and packaging it gets a "-legacy" suffix on the .msi filename. In release, only the legacy installer is currently released - this is a safety hatch in case we need to make a new release between now and 2024.1. Once we are ready to commit; the legacy installer can be removed from the build system.
> These changes add a fair amount of complexity to the build system, which can be removed again once we're committed (2024.1)

In Dev and CI; the managed installer is built using the wixsharp project and msbuild. This is convenient and produces a multi-language MSI in a single build step.

In Packaging, it's necessary to code sign the new runtime components of the installer:

1. tlk.ps1 takes a new "PackageOption" parameter to control what we want to do
2. We use the `generate` option: this builds the installer's managed code, WiX source code, and generates a batch file that invokes standard WiX tooling to build the final MSI.
2(a). This is done twice; for both the en-US and fr-FR localization
3. We call AzureSignTool to code sign the new managed runtime components
4. We use the `assemble` option to build the final MSI
4(a). The en-US MSI is built
4(b). The fr-FR MSI is built
4(c). We create a transform (.mst) between the en-US and fr-FR MSIs
4(d). The transform is embedded in the en-US MSI, and it's language list is updated
6. The MSI itself is code-signed as normal

As regards (3); the managed devolutionsgateway.exe (custom UI and actions) is code signed successfully but the other assemblies (WixSharp DLLs) are not - AzureSignTool claims they are already signed (but they aren't). For now, this appears "good enough" and the new managed MSI no longer triggers SmartScreen on my workstation.