### PR TITLE
feat(dgw): store users list in a users.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,16 +203,18 @@ Stable options are:
     * **LoginLimitRate** (_Integer_): The maximum number of login requests for a given username/IP pair
         over a minute (default is `10`).
 
-    * **Users** (_Array_): A list of users authorized to access the web application when using the
-        `Custom` authentication method.
+    * **UsersPath** (_FilePath_): Path to the users file which holds the list of users authorized to access
+        the web application when using the `Custom` authentication method.
 
-        Each element has the following schema: 
+        For each line such as `<user>:<hash>`:
 
-        * **Name** (_String_): The name of the user.
+        * `<user>`: The name of the user.
 
-        * **Password** (_String_): Hash of the password in the [PHC string format][phc-string].
+        * `<hash>`: Hash of the password in the [PHC string format][phc-string].
             Currently, the only supported hash algorithm is [Argon2][argon2-wikipedia].
             It’s possible to use the online tool [argon2.online][argon2-online] to generate a hash.
+
+        Blank lines and lines starting by `#` are ignored.
 
 - **VerbosityProfile** (_String_): Logging verbosity profile (pre-defined tracing directives).
 

--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -14,8 +14,7 @@ use tap::prelude::*;
 use tower_http::services::ServeFile;
 use uuid::Uuid;
 
-use crate::config::dto::WebAppUser;
-use crate::config::{WebAppAuth, WebAppConf};
+use crate::config::{WebAppAuth, WebAppConf, WebAppUser};
 use crate::extract::WebAppToken;
 use crate::http::HttpError;
 use crate::target_addr::TargetAddr;

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -86,7 +86,7 @@ pub struct Conf {
     pub debug: dto::DebugConf,
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone)]
 pub struct WebAppConf {
     pub enabled: bool,
     pub authentication: WebAppAuth,
@@ -94,10 +94,17 @@ pub struct WebAppConf {
     pub login_limit_rate: u8,
 }
 
-#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum WebAppAuth {
-    Custom(HashMap<String, dto::WebAppUser>),
+    Custom(HashMap<String, WebAppUser>),
     None,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub struct WebAppUser {
+    pub name: String,
+    /// Hash of the password, in the PHC string format
+    pub password_hash: dto::Password,
 }
 
 impl Conf {
@@ -282,7 +289,12 @@ impl Conf {
             jrl_file,
             ngrok: conf_file.ngrok.clone(),
             verbosity_profile: conf_file.verbosity_profile.unwrap_or_default(),
-            web_app: conf_file.web_app.clone().map(WebAppConf::from),
+            web_app: conf_file
+                .web_app
+                .as_ref()
+                .map(WebAppConf::from_dto)
+                .transpose()
+                .context("webapp config")?,
             debug: conf_file.debug.clone().unwrap_or_default(),
         })
     }
@@ -296,6 +308,56 @@ impl Conf {
 
     pub fn webapp_is_enabled(&self) -> bool {
         self.webapp_conf_if_enabled().is_some()
+    }
+}
+
+impl WebAppConf {
+    fn from_dto(value: &dto::WebAppConf) -> anyhow::Result<Self> {
+        let conf = Self {
+            enabled: value.enabled,
+            authentication: match value.authentication {
+                dto::WebAppAuth::Custom => {
+                    let users_path = value
+                        .users_path
+                        .clone()
+                        .unwrap_or_else(|| Utf8PathBuf::from("users.txt"))
+                        .pipe_ref(|path| normalize_data_path(path, &get_data_dir()));
+
+                    let users_contents = std::fs::read_to_string(&users_path)
+                        .with_context(|| format!("failed to read file at {users_path}"))?;
+
+                    let mut users = HashMap::new();
+
+                    for line in users_contents.lines() {
+                        // Skip blank lines and commented lines.
+                        if line.trim().is_empty() || line.starts_with('#') {
+                            continue;
+                        }
+
+                        let (user, hash) = line.split_once(':').context("missing separator in users file")?;
+
+                        users.insert(
+                            user.to_owned(),
+                            WebAppUser {
+                                name: user.to_owned(),
+                                password_hash: hash.to_owned().into(),
+                            },
+                        );
+                    }
+
+                    WebAppAuth::Custom(users)
+                }
+                dto::WebAppAuth::None => WebAppAuth::None,
+            },
+            app_token_maximum_lifetime: std::time::Duration::from_secs(
+                value
+                    .app_token_maximum_lifetime
+                    .unwrap_or(WEB_APP_TOKEN_DEFAULT_LIFETIME_SECS),
+            ),
+            login_limit_rate: value.login_limit_rate.unwrap_or(WEB_APP_DEFAULT_LOGIN_LIMIT_RATE),
+        };
+
+        Ok(conf)
     }
 }
 
@@ -757,27 +819,6 @@ fn to_listener_urls(conf: &dto::ListenerConf, hostname: &str, auto_ipv6: bool) -
     });
 
     Ok(out)
-}
-
-impl From<dto::WebAppConf> for WebAppConf {
-    fn from(value: dto::WebAppConf) -> Self {
-        Self {
-            enabled: value.enabled,
-            authentication: match value.authentication {
-                dto::WebAppAuth::Custom => {
-                    let users = value.users.into_iter().map(|user| (user.name.clone(), user)).collect();
-                    WebAppAuth::Custom(users)
-                }
-                dto::WebAppAuth::None => WebAppAuth::None,
-            },
-            app_token_maximum_lifetime: std::time::Duration::from_secs(
-                value
-                    .app_token_maximum_lifetime
-                    .unwrap_or(WEB_APP_TOKEN_DEFAULT_LIFETIME_SECS),
-            ),
-            login_limit_rate: value.login_limit_rate.unwrap_or(WEB_APP_DEFAULT_LOGIN_LIMIT_RATE),
-        }
-    }
 }
 
 pub mod dto {
@@ -1291,24 +1332,16 @@ pub mod dto {
         pub authentication: WebAppAuth,
         /// Maximum lifetime granted for application tokens, in seconds
         pub app_token_maximum_lifetime: Option<u64>,
-        /// The maximum number of login requests for a given username over a minute.
+        /// The maximum number of login requests for a given username over a minute
         pub login_limit_rate: Option<u8>,
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub users: Vec<WebAppUser>,
+        /// Path to the users file with <user>:<hash> lines
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub users_path: Option<Utf8PathBuf>,
     }
 
     #[derive(PartialEq, Eq, Debug, Clone, Copy, Serialize, Deserialize)]
     pub enum WebAppAuth {
         Custom,
         None,
-    }
-
-    #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
-    #[serde(rename_all = "PascalCase")]
-    pub struct WebAppUser {
-        pub name: String,
-        /// Hash of the password, in the PHC string format
-        #[serde(rename = "Password")]
-        pub password_hash: Password,
     }
 }

--- a/devolutions-gateway/tests/config.rs
+++ b/devolutions-gateway/tests/config.rs
@@ -195,17 +195,7 @@ fn standalone_custom_auth_sample() -> Sample {
                 "Enabled": true,
                 "Authentication": "Custom",
                 "AppTokenMaximumLifetime": 28800,
-                "LoginLimitRate": 10,
-                "Users": [
-                    {
-                        "Name": "David",
-                        "Password": "$argon2id$v=19$m=16,t=2,p=1$U0tDR3NSSjlBaVJMRmV0Tg$4KRKy3UsOganH/qTYVvOQg"
-                    },
-                    {
-                        "Name": "Maurice",
-                        "Password": "$argon2id$v=19$m=16,t=2,p=1$ZmdQWTkwQUNWcWh4T1YzQw$B6qWmJXHODN/bxZGIe/lyg"
-                    }
-                ]
+                "LoginLimitRate": 10
             }
         }"#,
         file_conf: ConfFile {
@@ -248,20 +238,7 @@ fn standalone_custom_auth_sample() -> Sample {
                 authentication: WebAppAuth::Custom,
                 app_token_maximum_lifetime: Some(28800),
                 login_limit_rate: Some(10),
-                users: vec![
-                    WebAppUser {
-                        name: "David".to_owned(),
-                        password_hash: Password::from(
-                            "$argon2id$v=19$m=16,t=2,p=1$U0tDR3NSSjlBaVJMRmV0Tg$4KRKy3UsOganH/qTYVvOQg",
-                        ),
-                    },
-                    WebAppUser {
-                        name: "Maurice".to_owned(),
-                        password_hash: Password::from(
-                            "$argon2id$v=19$m=16,t=2,p=1$ZmdQWTkwQUNWcWh4T1YzQw$B6qWmJXHODN/bxZGIe/lyg",
-                        ),
-                    },
-                ],
+                users_path: None,
             }),
             debug: None,
             rest: Default::default(),
@@ -289,12 +266,7 @@ fn standalone_no_auth_sample() -> Sample {
             "WebApp": {
                 "Enabled": true,
                 "Authentication": "None",
-                "Users": [
-                    {
-                        "Name": "LeftoverUnusedUser",
-                        "Password": "$argon2id$v=19$m=16,t=2,p=1$U0tDR3NSSjlBaVJMRmV0Tg$4KRKy3UsOganH/qTYVvOQg"
-                    }
-                ]
+                "UsersPath": "/path/to/users.txt"
             }
         }"#,
         file_conf: ConfFile {
@@ -337,12 +309,7 @@ fn standalone_no_auth_sample() -> Sample {
                 authentication: WebAppAuth::None,
                 app_token_maximum_lifetime: None,
                 login_limit_rate: None,
-                users: vec![WebAppUser {
-                    name: "LeftoverUnusedUser".to_owned(),
-                    password_hash: Password::from(
-                        "$argon2id$v=19$m=16,t=2,p=1$U0tDR3NSSjlBaVJMRmV0Tg$4KRKy3UsOganH/qTYVvOQg",
-                    ),
-                }],
+                users_path: Some("/path/to/users.txt".into()),
             }),
             debug: None,
             rest: Default::default(),

--- a/docs/COOKBOOK.md
+++ b/docs/COOKBOOK.md
@@ -130,19 +130,19 @@ Try entering text and see it printed on the other side.
 This section demonstrates how to use `curl` to test the `/jet/webapp/app-token` and `/jet/webapp/session-token` endpoints.
 
 The standalone web application must be enabled and configured to use the custom authentication mode.
-For instance, with a user named `David` protected by the password `abc`:
 
 ```json
 "WebApp": {
   "Enabled": true,
-  "Authentication": "Custom",
-  "Users": [
-    {
-      "Name": "David",
-      "Password": "$argon2id$v=19$m=16,t=2,p=1$U0tDR3NSSjlBaVJMRmV0Tg$4KRKy3UsOganH/qTYVvOQg"
-    }
-  ]
+  "Authentication": "Custom"
 }
+```
+
+A `users.txt` file is expected as well.
+For instance, with a user named `David` protected by the password `abc`:
+
+```
+David:$argon2id$v=19$m=16,t=2,p=1$U0tDR3NSSjlBaVJMRmV0Tg$4KRKy3UsOganH/qTYVvOQg
 ```
 
 It’s possible to retrieve a web application token using the `POST /jet/webapp/app-token` endpoint.


### PR DESCRIPTION
This changes the `Users` option into `UsersPath` for specifying a path to a users.txt file.
By default, the path is `%ProgrameData%/Devolutions/Gateway/users.txt`.

For each line such as `<user>:<hash>`:

* `<user>`: The name of the user.
* `<hash>`: Hash of the password in the PHC string format.

Blank lines and lines starting by `#` are ignored.

Issue: DGW-127