### PR TITLE
feat(dgw): implement none authorization type for webapp login

### DIFF
--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -1,20 +1,17 @@
 # See https://help.github.com/articles/ignoring-files for more about ignoring files.
 
-# web app compiled output
-/client/
-
 # compiled output
-/dist/
+/client/
 /tmp/
 /out-tsc/
 # Only include if you have a build process that generates files here
 # /build/
 
 # dependencies
-/node_modules/
+node_modules/
 
 # IDEs and editors
-/.idea
+.idea
 .project
 .classpath
 .c9/
@@ -32,7 +29,7 @@
 *.code-workspace
 
 # misc
-/.angular/cache
+.angular/cache
 /.sass-cache
 /connect.lock
 /coverage/

--- a/webapp/src/client/app/modules/base/menu/app-menu.component.html
+++ b/webapp/src/client/app/modules/base/menu/app-menu.component.html
@@ -50,15 +50,19 @@
   </gateway-menu-group-list-item>
 
   <hub-divider></hub-divider>
-
   <!-- Logout -->
-  <gateway-menu-group-list-item class="primary-menu-group-list" [accordion]="false">
-    <div class="menu-list-item-container">
+  <gateway-menu-group-list-item
+    *ngIf="!isAutoLoginOn"
+    class="primary-menu-group-list"
+    [accordion]="false">
+
+    <div class="menu-list-item-container menu-list-item-container-footer">
       <div class="menu-list-item"
            (click)="logout()">
         <i class="dvl-icon dvl-icon-logout"></i>
         <span class="menu-list-item-label">Logout</span>
       </div>
     </div>
+
   </gateway-menu-group-list-item>
 </div>

--- a/webapp/src/client/app/modules/base/menu/app-menu.component.scss
+++ b/webapp/src/client/app/modules/base/menu/app-menu.component.scss
@@ -284,6 +284,12 @@ border: 1px solid rgba(58, 163, 255, 0.24)
   }
 }
 
+.menu-list-item-container-footer {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+}
+
 :host-context(.app-menu-container.layout-menu-slim) {
   .menu-list-item-container {
     justify-content: center;

--- a/webapp/src/client/app/modules/base/menu/app-menu.component.ts
+++ b/webapp/src/client/app/modules/base/menu/app-menu.component.ts
@@ -17,6 +17,7 @@ import {AuthService} from "@shared/services/auth.service";
 })
 export class AppMenuComponent extends BaseComponent implements  OnInit {
 
+  isAutoLoginOn = false;
   isMenuSlim: boolean = false;
   mainMenus: Map<string, RouterMenuItem> = new Map<string, RouterMenuItem>();
 
@@ -30,6 +31,7 @@ export class AppMenuComponent extends BaseComponent implements  OnInit {
 
   ngOnInit(): void {
     this.subscribeRouteChange();
+    this.subscribeToIsAutoLoginOn();
   }
 
   onClickGoToNewSessionTab(): void {
@@ -44,6 +46,11 @@ export class AppMenuComponent extends BaseComponent implements  OnInit {
     this.navigationService.getRouteChange().pipe(takeUntil(this.destroyed$)).subscribe((navigationEnd) => {
       this.resetSelectedMenu(navigationEnd.url);
     });
+  }
+
+  private subscribeToIsAutoLoginOn(): void {
+    this.authService.isAutoLoginOn.pipe(takeUntil(this.destroyed$))
+      .subscribe(isAutoLoginOn => this.isAutoLoginOn = isAutoLoginOn);
   }
 
   private initMenu(): void {

--- a/webapp/src/client/app/modules/login/login.component.html
+++ b/webapp/src/client/app/modules/login/login.component.html
@@ -1,4 +1,8 @@
-<div class="login-background">
+<div id="gateway-loading" *ngIf="!autoLoginAttempted">
+  <i class="dvl-icon dvl-icon-logo-gateway"></i>
+</div>
+
+<div *ngIf="autoLoginAttempted" class="login-background">
 
   <div class="login-box">
     <div class="login-box-header">

--- a/webapp/src/client/app/shared/services/navigation.service.ts
+++ b/webapp/src/client/app/shared/services/navigation.service.ts
@@ -5,6 +5,8 @@ import {Observable} from "rxjs";
 
 @Injectable({ providedIn: 'root' })
 export class NavigationService {
+  private static readonly SESSION_KEY: string = 'session';
+  private static readonly LOGIN_KEY: string = 'login';
 
   constructor(
     private readonly router: Router,
@@ -16,12 +18,19 @@ export class NavigationService {
     return this.router.navigateByUrl(anyPath);
   }
 
+  navigateToLogin(): Promise<boolean> {
+    return this.router.navigateByUrl(NavigationService.LOGIN_KEY);
+  }
+
   navigateToRoot(): Promise<boolean> {
     return this.router.navigateByUrl('/');
   }
 
   navigateToNewSession(): Promise<boolean> {
-    return this.router.navigateByUrl('session');
+    if(this.isCurrentRouteUrl(NavigationService.SESSION_KEY)) {
+      return;
+    }
+    return this.router.navigateByUrl(NavigationService.SESSION_KEY);
   }
 
   navigateToRDPSession(connectionTypeRoute: WebClientSection, queryParams?: string) {

--- a/webapp/src/client/app/shared/services/web-session.service.ts
+++ b/webapp/src/client/app/shared/services/web-session.service.ts
@@ -117,7 +117,6 @@ export class WebSessionService {
   }
 
   hasActiveWebSessions(): boolean {
-    console.log('numberOfActiveSessions', this.numberOfActiveSessions)
     return this.numberOfActiveSessions > 0;
   }
 


### PR DESCRIPTION
Implement the none authorization for the web app login.

Also adjusted the token lifespan. I had set it for 10 minutes for testing, but now it's set to the specified 8 hours.

Edited the git ignore to remove some of the 'extra' angular stuff that is not required for source control.

Small adjustments to the UI:
- login page to handle the auto-login smoothly.
- moved the logout button to be positioned at the bottom of the left hand sidebar.
