### PR TITLE
add powershell user management with argon2 password hashing

### DIFF
--- a/powershell/DevolutionsGateway/DevolutionsGateway.psd1
+++ b/powershell/DevolutionsGateway/DevolutionsGateway.psd1
@@ -77,6 +77,7 @@
         'New-DGatewayDelegationKeyPair', 'Import-DGatewayDelegationKey',
         'New-DGatewayToken',
         'New-DGatewayWebAppConfig',
+        'Set-DGatewayUser', 'Remove-DGatewayUser', 'Get-DGatewayUser',
         'Start-DGateway', 'Stop-DGateway', 'Restart-DGateway',
         'Get-DGatewayVersion', 'Get-DGatewayPackage',
         'Install-DGatewayPackage', 'Uninstall-DGatewayPackage')

--- a/powershell/DevolutionsGateway/src/DevolutionsGateway.csproj
+++ b/powershell/DevolutionsGateway/src/DevolutionsGateway.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devolutions.Picky" Version="2023.9.20" />
+    <PackageReference Include="Devolutions.Picky" Version="2024.1.20" />
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />

--- a/powershell/pester/Users.Tests.ps1
+++ b/powershell/pester/Users.Tests.ps1
@@ -1,0 +1,50 @@
+Import-Module "$PSScriptRoot/../DevolutionsGateway"
+
+Describe 'Devolutions Gateway User Management' {
+    InModuleScope DevolutionsGateway {
+        BeforeAll {
+            $ConfigPath = Join-Path $TestDrive 'Gateway'
+            Set-DGatewayConfig -ConfigPath:$ConfigPath -Hostname 'gateway.local'
+            $filePath = Join-Path -Path $ConfigPath -ChildPath "users.txt"
+            Set-Content -Path $filePath -Value ""
+        }
+
+        Context 'User Management' {
+            It 'Can add a new user' {
+                # Set the user's password
+                Set-DGatewayUser -Username "admin" -Password 'password' -ConfigPath $ConfigPath
+            
+                # Retrieve the user and test if a hash exists
+                $user = Get-DGatewayUser -Username "admin" -ConfigPath $ConfigPath
+                $user.Hash | Should -Not -BeNullOrEmpty
+            }            
+
+            It 'Can edit an existing user' {
+                # Get the current hash of the user
+                $originalUser = Get-DGatewayUser -Username "admin" -ConfigPath $ConfigPath
+                $originalHash = $originalUser.Hash
+            
+                # Update the user with a new hash
+                Set-DGatewayUser -Username "admin" -Password 'newpass' -ConfigPath $ConfigPath
+            
+                # Retrieve the updated user and hash
+                $updatedUser = Get-DGatewayUser -Username "admin" -ConfigPath $ConfigPath
+                $updatedHash = $updatedUser.Hash
+            
+                # The test should pass if the original hash and the updated hash are different
+                $updatedHash | Should -Not -Be $originalHash
+            }            
+
+            It 'Can remove a user' {
+                Remove-DGatewayUser -Username "admin" -ConfigPath $ConfigPath
+                $user = Get-DGatewayUser -Username "admin" -ConfigPath $ConfigPath
+                $user | Should -Be $null
+            }
+
+            It 'Handles non-existing user correctly' {
+                $user = Get-DGatewayUser -Username "nonexistent" -ConfigPath $ConfigPath
+                $user | Should -Be $null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add PowerShell user management cmdlets with argon2 password hashing. Here's my set of commands to bootstrap a localhost HTTP configuration with user "admin" and password "yolo123!" for local development:

```
$ConfigPath = Join-Path (Get-Location) 'config'
$Env:DGATEWAY_CONFIG_PATH="$ConfigPath"
$WebAppPath = Join-Path (Get-Location) 'webapp'
$Env:DGATEWAY_WEBAPP_PATH="$ConfigPath"
New-Item $ConfigPath -ItemType Directory -ErrorAction SilentlyContinue

.\powershell\build.ps1
pwsh.exe
Import-Module .\powershell\DevolutionsGateway
$Hostname = "localhost"
$Username = "admin"
$Password = "yolo123!"
$HttpListener = New-DGatewayListener 'http://*:7171' 'http://*:7171'
$WebApp = New-DGatewayWebAppConfig -Enabled $true -Authentication Custom
$ConfigParams = @{
  Hostname = $Hostname
  Listeners = @($HttpListener)
  WebApp = $WebApp
}
Set-DGatewayConfig @ConfigParams
New-DGatewayProvisionerKeyPair -Force
Set-DGatewayUser -Username $Username -Password $Password
exit

cd ./webapp/web && npm install && ng build && cd ../..

cargo run
```