### PR TITLE
feat(installer): initial webapp integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,7 @@ jobs:
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}"
             $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
-            $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client"
+            $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client" | Resolve-Path
           }
             
           ./ci/tlk.ps1 package -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}

--- a/package/WindowsManaged/DevolutionsGateway.csproj
+++ b/package/WindowsManaged/DevolutionsGateway.csproj
@@ -34,6 +34,9 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="Dialogs\WebClientDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="Dialogs\SummaryDialog.cs" />
     <Compile Update="Dialogs\ServiceDialog.cs" />
     <Compile Update="Dialogs\PublicKeyDialog.cs" />

--- a/package/WindowsManaged/Dialogs/AccessUriDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/AccessUriDialog.Designer.cs
@@ -36,6 +36,7 @@ namespace WixSharpSetup.Dialogs
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.middlePanel = new System.Windows.Forms.Panel();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.lblPublicKeyDescription = new System.Windows.Forms.Label();
             this.txtPort = new System.Windows.Forms.TextBox();
             this.txtHostname = new System.Windows.Forms.TextBox();
             this.cmbProtocol = new System.Windows.Forms.ComboBox();
@@ -79,9 +80,9 @@ namespace WixSharpSetup.Dialogs
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.middlePanel.Controls.Add(this.tableLayoutPanel2);
-            this.middlePanel.Location = new System.Drawing.Point(22, 75);
+            this.middlePanel.Location = new System.Drawing.Point(0, 58);
             this.middlePanel.Name = "middlePanel";
-            this.middlePanel.Size = new System.Drawing.Size(449, 59);
+            this.middlePanel.Size = new System.Drawing.Size(493, 261);
             this.middlePanel.TabIndex = 16;
             // 
             // tableLayoutPanel2
@@ -90,28 +91,42 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.txtPort, 2, 0);
-            this.tableLayoutPanel2.Controls.Add(this.txtHostname, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.cmbProtocol, 0, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.lblPublicKeyDescription, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.txtPort, 2, 1);
+            this.tableLayoutPanel2.Controls.Add(this.txtHostname, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.cmbProtocol, 0, 1);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(22, 17);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 1;
+            this.tableLayoutPanel2.RowCount = 2;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 59);
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 130);
             this.tableLayoutPanel2.TabIndex = 0;
+            // 
+            // lblPublicKeyDescription
+            // 
+            this.lblPublicKeyDescription.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.lblPublicKeyDescription, 3);
+            this.lblPublicKeyDescription.Location = new System.Drawing.Point(3, 0);
+            this.lblPublicKeyDescription.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPublicKeyDescription.Name = "lblPublicKeyDescription";
+            this.lblPublicKeyDescription.Size = new System.Drawing.Size(262, 13);
+            this.lblPublicKeyDescription.TabIndex = 3;
+            this.lblPublicKeyDescription.Text = "The external access URI for the Devolutions Gateway";
             // 
             // txtPort
             // 
             this.txtPort.CausesValidation = false;
-            this.txtPort.Location = new System.Drawing.Point(362, 3);
+            this.txtPort.Location = new System.Drawing.Point(362, 21);
             this.txtPort.Name = "txtPort";
             this.txtPort.Size = new System.Drawing.Size(40, 20);
             this.txtPort.TabIndex = 2;
             // 
             // txtHostname
             // 
-            this.txtHostname.Location = new System.Drawing.Point(79, 3);
+            this.txtHostname.Location = new System.Drawing.Point(79, 21);
             this.txtHostname.Name = "txtHostname";
             this.txtHostname.Size = new System.Drawing.Size(277, 20);
             this.txtHostname.TabIndex = 1;
@@ -120,7 +135,7 @@ namespace WixSharpSetup.Dialogs
             // 
             this.cmbProtocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cmbProtocol.FormattingEnabled = true;
-            this.cmbProtocol.Location = new System.Drawing.Point(3, 3);
+            this.cmbProtocol.Location = new System.Drawing.Point(3, 21);
             this.cmbProtocol.Name = "cmbProtocol";
             this.cmbProtocol.Size = new System.Drawing.Size(70, 21);
             this.cmbProtocol.TabIndex = 0;
@@ -306,5 +321,6 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.TextBox txtHostname;
         private System.Windows.Forms.ComboBox cmbProtocol;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Label lblPublicKeyDescription;
     }
 }

--- a/package/WindowsManaged/Dialogs/AccessUriDialog.cs
+++ b/package/WindowsManaged/Dialogs/AccessUriDialog.cs
@@ -28,6 +28,12 @@ namespace WixSharpSetup.Dialogs
             this.cmbProtocol.SelectedIndex = Protocols.FindIndex(properties.AccessUriScheme);
             this.txtHostname.Text = properties.AccessUriHost;
             this.txtPort.Text = properties.AccessUriPort.ToString();
+
+            if (properties.ConfigureWebApp && properties.GenerateCertificate &&
+                string.IsNullOrEmpty(properties.AccessUriHost))
+            {
+                this.txtHostname.Text = Environment.MachineName;
+            }
         }
 
         public override bool ToProperties()

--- a/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
@@ -45,7 +45,7 @@ namespace WixSharpSetup.Dialogs
             this.txtCertificatePassword = new System.Windows.Forms.TextBox();
             this.lblPrivateKeyFile = new System.Windows.Forms.Label();
             this.lblCertificatePassword = new System.Windows.Forms.Label();
-            this.label3 = new System.Windows.Forms.Label();
+            this.lblCertificateFile = new System.Windows.Forms.Label();
             this.txtCertificateFile = new System.Windows.Forms.TextBox();
             this.butBrowseCertificateFile = new System.Windows.Forms.Button();
             this.lblHint = new System.Windows.Forms.Label();
@@ -136,14 +136,15 @@ namespace WixSharpSetup.Dialogs
             this.pnlExternal.Controls.Add(this.txtCertificatePassword, 1, 3);
             this.pnlExternal.Controls.Add(this.lblPrivateKeyFile, 0, 5);
             this.pnlExternal.Controls.Add(this.lblCertificatePassword, 0, 3);
-            this.pnlExternal.Controls.Add(this.label3, 0, 1);
+            this.pnlExternal.Controls.Add(this.lblCertificateFile, 0, 1);
             this.pnlExternal.Controls.Add(this.txtCertificateFile, 1, 1);
             this.pnlExternal.Controls.Add(this.butBrowseCertificateFile, 2, 1);
             this.pnlExternal.Controls.Add(this.lblHint, 1, 6);
             this.pnlExternal.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pnlExternal.Location = new System.Drawing.Point(3, 16);
             this.pnlExternal.Name = "pnlExternal";
-            this.pnlExternal.RowCount = 7;
+            this.pnlExternal.RowCount = 6;
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -151,7 +152,6 @@ namespace WixSharpSetup.Dialogs
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.pnlExternal.Size = new System.Drawing.Size(464, 205);
             this.pnlExternal.TabIndex = 8;
             // 
@@ -212,17 +212,17 @@ namespace WixSharpSetup.Dialogs
             this.lblCertificatePassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.lblCertificatePassword.Visible = false;
             // 
-            // label3
+            // lblCertificateFile
             // 
-            this.label3.AutoSize = true;
-            this.label3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label3.Location = new System.Drawing.Point(3, 3);
-            this.label3.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(144, 20);
-            this.label3.TabIndex = 1;
-            this.label3.Text = "[CertificateDlgCertFileLabel]";
-            this.label3.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.lblCertificateFile.AutoSize = true;
+            this.lblCertificateFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblCertificateFile.Location = new System.Drawing.Point(3, 3);
+            this.lblCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblCertificateFile.Name = "lblCertificateFile";
+            this.lblCertificateFile.Size = new System.Drawing.Size(144, 20);
+            this.lblCertificateFile.TabIndex = 1;
+            this.lblCertificateFile.Text = "[CertificateDlgCertFileLabel]";
+            this.lblCertificateFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // txtCertificateFile
             // 
@@ -248,12 +248,13 @@ namespace WixSharpSetup.Dialogs
             // lblHint
             // 
             this.lblHint.AutoSize = true;
+            this.pnlExternal.SetColumnSpan(this.lblHint, 2);
             this.lblHint.Dock = System.Windows.Forms.DockStyle.Top;
             this.lblHint.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblHint.ForeColor = System.Drawing.Color.Blue;
             this.lblHint.Location = new System.Drawing.Point(153, 96);
             this.lblHint.Name = "lblHint";
-            this.lblHint.Size = new System.Drawing.Size(275, 13);
+            this.lblHint.Size = new System.Drawing.Size(308, 13);
             this.lblHint.TabIndex = 8;
             // 
             // gbSystem
@@ -643,13 +644,8 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.Panel topBorder;
         private System.Windows.Forms.Panel middlePanel;
         private System.Windows.Forms.Button butBrowseCertificateFile;
-        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label lblCertificateFile;
         private System.Windows.Forms.TextBox txtCertificateFile;
-        private System.Windows.Forms.TextBox txtCertificatePassword;
-        private System.Windows.Forms.Label lblCertificatePassword;
-        private System.Windows.Forms.TextBox txtPrivateKeyFile;
-        private System.Windows.Forms.Label lblPrivateKeyFile;
-        private System.Windows.Forms.Button butBrowsePrivateKeyFile;
         private System.Windows.Forms.TableLayoutPanel pnlExternal;
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.ComboBox cmbCertificateSource;
@@ -669,5 +665,10 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.GroupBox gbSystem;
         private System.Windows.Forms.GroupBox gbExternal;
         private System.Windows.Forms.Label lblHint;
+        private System.Windows.Forms.Button butBrowsePrivateKeyFile;
+        private System.Windows.Forms.TextBox txtPrivateKeyFile;
+        private System.Windows.Forms.TextBox txtCertificatePassword;
+        private System.Windows.Forms.Label lblPrivateKeyFile;
+        private System.Windows.Forms.Label lblCertificatePassword;
     }
 }

--- a/package/WindowsManaged/Dialogs/CertificateDialog.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.cs
@@ -131,21 +131,24 @@ public partial class CertificateDialog : GatewayDialog
             CertificateFindTypes.IndexOf(CertificateFindTypes.First(x => x.Key == properties.CertificateFindType));
         this.txtSearch.Text = properties.CertificateSearchText;
 
-        try
+        if (this.UseSystemCertificate)
         {
-            X509Certificate2Collection certificates = this.SearchCertificate(
-                (StoreLocation) this.cmbStoreLocation.SelectedIndex + 1,
-                Stores[this.cmbStore.SelectedIndex].Key,
-                CertificateFindType.Thumbprint,
-                properties.CertificateThumbprint);
-
-            if (certificates?.Count == 1)
+            try
             {
-                this.SetSelectedCertificate(certificates[0]);
+                X509Certificate2Collection certificates = this.SearchCertificate(
+                    (StoreLocation) this.cmbStoreLocation.SelectedIndex + 1,
+                    Stores[this.cmbStore.SelectedIndex].Key,
+                    CertificateFindType.Thumbprint,
+                    properties.CertificateThumbprint);
+
+                if (certificates?.Count == 1)
+                {
+                    this.SetSelectedCertificate(certificates[0]);
+                }
             }
-        }
-        catch // Failed to restore state, don't crash
-        {
+            catch // Failed to restore state, don't crash
+            {
+            }
         }
 
         this.SetControlStates();
@@ -155,7 +158,7 @@ public partial class CertificateDialog : GatewayDialog
     {
         GatewayProperties properties = new(this.Runtime.Session)
         {
-            CertificateMode = (Constants.CertificateMode)this.cmbCertificateSource.SelectedIndex
+            CertificateMode = (Constants.CertificateMode)this.cmbCertificateSource.SelectedIndex,
         };
 
         if (this.UseExternalCertificate)
@@ -279,7 +282,7 @@ public partial class CertificateDialog : GatewayDialog
         {
             this.gbExternal.Visible = false;
             this.gbSystem.Visible = true;
-
+            
             this.butSearchCertificate.Enabled = !string.IsNullOrWhiteSpace(this.txtSearch.Text);
         }
     }

--- a/package/WindowsManaged/Dialogs/CustomizeDialog.cs
+++ b/package/WindowsManaged/Dialogs/CustomizeDialog.cs
@@ -1,20 +1,29 @@
 using DevolutionsGateway.Actions;
 using DevolutionsGateway.Dialogs;
+using DevolutionsGateway.Helpers;
 using DevolutionsGateway.Properties;
 
 using System;
-
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.ServiceProcess;
 using WixSharp;
 
 namespace WixSharpSetup.Dialogs;
 
 public partial class CustomizeDialog : GatewayDialog
 {
+    private static Icon warningIcon;
+
+    public static Icon WarningSmall => warningIcon ??= StockIcon.GetStockIcon(StockIcon.SIID_INFO, StockIcon.SHGSI_SMALLICON);
+    
     public CustomizeDialog()
     {
         InitializeComponent();
         label1.MakeTransparentOn(banner);
         label2.MakeTransparentOn(banner);
+
+        pictureBox1.Image = WarningSmall.ToBitmap();
     }
 
     public override void FromProperties()
@@ -22,13 +31,20 @@ public partial class CustomizeDialog : GatewayDialog
         GatewayProperties properties = new(this.Runtime.Session);
         this.rbConfigLater.Checked = !properties.ConfigureGateway;
         this.rbConfigNow.Checked = properties.ConfigureGateway;
+        this.chkWebApp.Checked = properties.ConfigureWebApp;
+        this.chkGenerateCertificate.Checked = properties.GenerateCertificate;
+        this.chkGenerateKeyPair.Checked = properties.GenerateKeyPair;
     }
 
     public override bool ToProperties()
     {
         new GatewayProperties(this.Runtime.Session)
         {
-            ConfigureGateway = this.rbConfigNow.Checked
+            ConfigureGateway = this.rbConfigNow.Checked,
+            ConfigureWebApp = this.chkWebApp.Checked,
+            GenerateCertificate = this.chkGenerateCertificate.Checked,
+            GenerateKeyPair = this.chkGenerateKeyPair.Checked,
+            ServiceStart = this.rbConfigNow.Checked ? (int)ServiceStartMode.Automatic : (int)ServiceStartMode.Manual,
         };
 
         return true;
@@ -56,4 +72,27 @@ public partial class CustomizeDialog : GatewayDialog
 
     // ReSharper disable once RedundantOverriddenMember
     protected override void Cancel_Click(object sender, EventArgs e) => base.Cancel_Click(sender, e);
+
+    private void SetControlStates()
+    {
+        this.chkWebApp.Enabled = this.rbConfigNow.Checked;
+
+        this.chkGenerateCertificate.Enabled = this.chkWebApp.Checked && this.chkWebApp.Enabled;
+        this.chkGenerateKeyPair.Enabled = this.chkWebApp.Checked && this.chkWebApp.Enabled;
+    }
+
+    private void rbConfigLater_CheckedChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+
+    private void rbConfigNow_CheckedChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+
+    private void chkWebApp_CheckedChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
 }

--- a/package/WindowsManaged/Dialogs/ListenersDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/ListenersDialog.Designer.cs
@@ -36,14 +36,14 @@ namespace WixSharpSetup.Dialogs
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.middlePanel = new System.Windows.Forms.Panel();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.cmbTcpProtocol = new System.Windows.Forms.ComboBox();
-            this.txtTcpPort = new System.Windows.Forms.TextBox();
-            this.txtTcpHostname = new System.Windows.Forms.TextBox();
             this.label3 = new System.Windows.Forms.Label();
             this.txtHttpPort = new System.Windows.Forms.TextBox();
             this.cmbHttpProtocol = new System.Windows.Forms.ComboBox();
             this.txtHttpHostname = new System.Windows.Forms.TextBox();
             this.label4 = new System.Windows.Forms.Label();
+            this.txtTcpPort = new System.Windows.Forms.TextBox();
+            this.txtTcpHostname = new System.Windows.Forms.TextBox();
+            this.cmbTcpProtocol = new System.Windows.Forms.ComboBox();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
@@ -95,53 +95,30 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.Controls.Add(this.cmbTcpProtocol, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.txtTcpPort, 2, 3);
-            this.tableLayoutPanel2.Controls.Add(this.txtTcpHostname, 1, 3);
             this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.txtHttpPort, 2, 1);
             this.tableLayoutPanel2.Controls.Add(this.cmbHttpProtocol, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.txtHttpHostname, 1, 1);
-            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.label4, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.txtTcpPort, 2, 4);
+            this.tableLayoutPanel2.Controls.Add(this.txtTcpHostname, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.cmbTcpProtocol, 0, 4);
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 4;
+            this.tableLayoutPanel2.RowCount = 5;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 139);
             this.tableLayoutPanel2.TabIndex = 17;
-            // 
-            // cmbTcpProtocol
-            // 
-            this.cmbTcpProtocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbTcpProtocol.Enabled = false;
-            this.cmbTcpProtocol.FormattingEnabled = true;
-            this.cmbTcpProtocol.Location = new System.Drawing.Point(3, 68);
-            this.cmbTcpProtocol.Name = "cmbTcpProtocol";
-            this.cmbTcpProtocol.Size = new System.Drawing.Size(70, 21);
-            this.cmbTcpProtocol.TabIndex = 3;
-            // 
-            // txtTcpPort
-            // 
-            this.txtTcpPort.Location = new System.Drawing.Point(418, 68);
-            this.txtTcpPort.Name = "txtTcpPort";
-            this.txtTcpPort.Size = new System.Drawing.Size(40, 20);
-            this.txtTcpPort.TabIndex = 5;
-            // 
-            // txtTcpHostname
-            // 
-            this.txtTcpHostname.Enabled = false;
-            this.txtTcpHostname.Location = new System.Drawing.Point(135, 68);
-            this.txtTcpHostname.Name = "txtTcpHostname";
-            this.txtTcpHostname.Size = new System.Drawing.Size(277, 20);
-            this.txtTcpHostname.TabIndex = 4;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.label3, 3);
             this.label3.Location = new System.Drawing.Point(3, 3);
             this.label3.Margin = new System.Windows.Forms.Padding(3);
             this.label3.Name = "label3";
@@ -151,7 +128,7 @@ namespace WixSharpSetup.Dialogs
             // 
             // txtHttpPort
             // 
-            this.txtHttpPort.Location = new System.Drawing.Point(418, 22);
+            this.txtHttpPort.Location = new System.Drawing.Point(362, 22);
             this.txtHttpPort.Name = "txtHttpPort";
             this.txtHttpPort.Size = new System.Drawing.Size(40, 20);
             this.txtHttpPort.TabIndex = 2;
@@ -168,7 +145,7 @@ namespace WixSharpSetup.Dialogs
             // txtHttpHostname
             // 
             this.txtHttpHostname.Enabled = false;
-            this.txtHttpHostname.Location = new System.Drawing.Point(135, 22);
+            this.txtHttpHostname.Location = new System.Drawing.Point(79, 22);
             this.txtHttpHostname.Name = "txtHttpHostname";
             this.txtHttpHostname.Size = new System.Drawing.Size(277, 20);
             this.txtHttpHostname.TabIndex = 1;
@@ -176,12 +153,38 @@ namespace WixSharpSetup.Dialogs
             // label4
             // 
             this.label4.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.label4, 3);
             this.label4.Location = new System.Drawing.Point(3, 49);
             this.label4.Margin = new System.Windows.Forms.Padding(3);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(118, 13);
             this.label4.TabIndex = 7;
             this.label4.Text = "[ListenersDlgTCPLabel]";
+            // 
+            // txtTcpPort
+            // 
+            this.txtTcpPort.Location = new System.Drawing.Point(362, 68);
+            this.txtTcpPort.Name = "txtTcpPort";
+            this.txtTcpPort.Size = new System.Drawing.Size(40, 20);
+            this.txtTcpPort.TabIndex = 5;
+            // 
+            // txtTcpHostname
+            // 
+            this.txtTcpHostname.Enabled = false;
+            this.txtTcpHostname.Location = new System.Drawing.Point(79, 68);
+            this.txtTcpHostname.Name = "txtTcpHostname";
+            this.txtTcpHostname.Size = new System.Drawing.Size(277, 20);
+            this.txtTcpHostname.TabIndex = 4;
+            // 
+            // cmbTcpProtocol
+            // 
+            this.cmbTcpProtocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbTcpProtocol.Enabled = false;
+            this.cmbTcpProtocol.FormattingEnabled = true;
+            this.cmbTcpProtocol.Location = new System.Drawing.Point(3, 68);
+            this.cmbTcpProtocol.Name = "cmbTcpProtocol";
+            this.cmbTcpProtocol.Size = new System.Drawing.Size(70, 21);
+            this.cmbTcpProtocol.TabIndex = 3;
             // 
             // topBorder
             // 

--- a/package/WindowsManaged/Dialogs/ProgressDialog.cs
+++ b/package/WindowsManaged/Dialogs/ProgressDialog.cs
@@ -4,6 +4,7 @@ using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using DevolutionsGateway.Helpers;
 using WixSharp;
 using WixSharp.CommonTasks;
 
@@ -13,42 +14,7 @@ public partial class ProgressDialog : GatewayDialog, IProgressDialog
 {
     private static Icon shieldIcon;
 
-    public static Icon ShieldLarge => shieldIcon ?? (shieldIcon = GetStockIcon(SIID_SHIELD, SHGSI_LARGEICON));
-
-    private static Icon GetStockIcon(uint type, uint size)
-    {
-        var info = new SHSTOCKICONINFO();
-        info.cbSize = (uint)Marshal.SizeOf(info);
-
-        SHGetStockIconInfo(type, SHGSI_ICON | size, ref info);
-
-        var icon = (Icon)Icon.FromHandle(info.hIcon).Clone(); // Get a copy that doesn't use the original handle
-        DestroyIcon(info.hIcon); // Clean up native icon to prevent resource leak
-
-        return icon;
-    }
-
-    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-    public struct SHSTOCKICONINFO
-    {
-        public uint cbSize;
-        public IntPtr hIcon;
-        public int iSysIconIndex;
-        public int iIcon;
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
-        public string szPath;
-    }
-
-    [DllImport("shell32.dll")]
-    public static extern int SHGetStockIconInfo(uint siid, uint uFlags, ref SHSTOCKICONINFO psii);
-
-    [DllImport("user32.dll")]
-    public static extern bool DestroyIcon(IntPtr handle);
-
-    private const uint SIID_SHIELD = 77;
-    private const uint SHGSI_ICON = 0x100;
-    private const uint SHGSI_LARGEICON = 0x0;
-    private const uint SHGSI_SMALLICON = 0x1;
+    public static Icon ShieldLarge => shieldIcon ??= StockIcon.GetStockIcon(StockIcon.SIID_SHIELD, StockIcon.SHGSI_LARGEICON);
 
     public ProgressDialog()
     {

--- a/package/WindowsManaged/Dialogs/PublicKeyDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/PublicKeyDialog.Designer.cs
@@ -36,7 +36,13 @@ namespace WixSharpSetup.Dialogs
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.middlePanel = new System.Windows.Forms.Panel();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            this.butBrowsePrivateKeyFile = new System.Windows.Forms.Button();
+            this.txtPrivateKeyFile = new System.Windows.Forms.TextBox();
+            this.lblPrivateKeyFile = new System.Windows.Forms.Label();
+            this.lblPrivateKeyDescription = new System.Windows.Forms.Label();
+            this.lblPublicKeyDescription = new System.Windows.Forms.Label();
             this.butBrowsePublicKeyFile = new System.Windows.Forms.Button();
+            this.lblPublicKeyFile = new System.Windows.Forms.Label();
             this.txtPublicKeyFile = new System.Windows.Forms.TextBox();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
@@ -73,34 +79,94 @@ namespace WixSharpSetup.Dialogs
             // 
             // middlePanel
             // 
-            this.middlePanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.middlePanel.Controls.Add(this.tableLayoutPanel2);
-            this.middlePanel.Location = new System.Drawing.Point(22, 75);
+            this.middlePanel.Location = new System.Drawing.Point(0, 58);
             this.middlePanel.Name = "middlePanel";
-            this.middlePanel.Size = new System.Drawing.Size(449, 139);
+            this.middlePanel.Size = new System.Drawing.Size(494, 261);
             this.middlePanel.TabIndex = 16;
             // 
             // tableLayoutPanel2
             // 
-            this.tableLayoutPanel2.ColumnCount = 2;
+            this.tableLayoutPanel2.ColumnCount = 3;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.Controls.Add(this.butBrowsePublicKeyFile, 1, 0);
-            this.tableLayoutPanel2.Controls.Add(this.txtPublicKeyFile, 0, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.butBrowsePrivateKeyFile, 2, 3);
+            this.tableLayoutPanel2.Controls.Add(this.txtPrivateKeyFile, 1, 3);
+            this.tableLayoutPanel2.Controls.Add(this.lblPrivateKeyFile, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.lblPrivateKeyDescription, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.lblPublicKeyDescription, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.butBrowsePublicKeyFile, 2, 1);
+            this.tableLayoutPanel2.Controls.Add(this.lblPublicKeyFile, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.txtPublicKeyFile, 1, 1);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(22, 17);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 1;
+            this.tableLayoutPanel2.RowCount = 5;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 139);
-            this.tableLayoutPanel2.TabIndex = 3;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 130);
+            this.tableLayoutPanel2.TabIndex = 2;
+            // 
+            // butBrowsePrivateKeyFile
+            // 
+            this.butBrowsePrivateKeyFile.Location = new System.Drawing.Point(419, 77);
+            this.butBrowsePrivateKeyFile.Name = "butBrowsePrivateKeyFile";
+            this.butBrowsePrivateKeyFile.Size = new System.Drawing.Size(27, 20);
+            this.butBrowsePrivateKeyFile.TabIndex = 5;
+            this.butBrowsePrivateKeyFile.Text = "...";
+            this.butBrowsePrivateKeyFile.UseVisualStyleBackColor = true;
+            this.butBrowsePrivateKeyFile.Click += new System.EventHandler(this.butBrowsePrivateKeyFile_Click);
+            // 
+            // txtPrivateKeyFile
+            // 
+            this.txtPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtPrivateKeyFile.Location = new System.Drawing.Point(153, 77);
+            this.txtPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtPrivateKeyFile.Name = "txtPrivateKeyFile";
+            this.txtPrivateKeyFile.Size = new System.Drawing.Size(260, 20);
+            this.txtPrivateKeyFile.TabIndex = 4;
+            // 
+            // lblPrivateKeyFile
+            // 
+            this.lblPrivateKeyFile.AutoSize = true;
+            this.lblPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblPrivateKeyFile.Location = new System.Drawing.Point(3, 74);
+            this.lblPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPrivateKeyFile.Name = "lblPrivateKeyFile";
+            this.lblPrivateKeyFile.Size = new System.Drawing.Size(144, 23);
+            this.lblPrivateKeyFile.TabIndex = 3;
+            this.lblPrivateKeyFile.Text = "Private Key File";
+            this.lblPrivateKeyFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // lblPrivateKeyDescription
+            // 
+            this.lblPrivateKeyDescription.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.lblPrivateKeyDescription, 3);
+            this.lblPrivateKeyDescription.Location = new System.Drawing.Point(3, 56);
+            this.lblPrivateKeyDescription.Margin = new System.Windows.Forms.Padding(3, 10, 3, 5);
+            this.lblPrivateKeyDescription.Name = "lblPrivateKeyDescription";
+            this.lblPrivateKeyDescription.Size = new System.Drawing.Size(412, 13);
+            this.lblPrivateKeyDescription.TabIndex = 2;
+            this.lblPrivateKeyDescription.Text = "The private key is used to generate session tokens for the standalone web applica" +
+    "tion";
+            // 
+            // lblPublicKeyDescription
+            // 
+            this.lblPublicKeyDescription.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.lblPublicKeyDescription, 3);
+            this.lblPublicKeyDescription.Location = new System.Drawing.Point(3, 0);
+            this.lblPublicKeyDescription.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPublicKeyDescription.Name = "lblPublicKeyDescription";
+            this.lblPublicKeyDescription.Size = new System.Drawing.Size(317, 13);
+            this.lblPublicKeyDescription.TabIndex = 0;
+            this.lblPublicKeyDescription.Text = "The public key is used to verify tokens without specific restrictions";
             // 
             // butBrowsePublicKeyFile
             // 
-            this.butBrowsePublicKeyFile.Location = new System.Drawing.Point(368, 3);
+            this.butBrowsePublicKeyFile.Location = new System.Drawing.Point(419, 21);
             this.butBrowsePublicKeyFile.Name = "butBrowsePublicKeyFile";
             this.butBrowsePublicKeyFile.Size = new System.Drawing.Size(27, 20);
             this.butBrowsePublicKeyFile.TabIndex = 1;
@@ -108,12 +174,25 @@ namespace WixSharpSetup.Dialogs
             this.butBrowsePublicKeyFile.UseVisualStyleBackColor = true;
             this.butBrowsePublicKeyFile.Click += new System.EventHandler(this.butBrowsePublicKeyFile_Click);
             // 
+            // lblPublicKeyFile
+            // 
+            this.lblPublicKeyFile.AutoSize = true;
+            this.lblPublicKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblPublicKeyFile.Location = new System.Drawing.Point(3, 18);
+            this.lblPublicKeyFile.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPublicKeyFile.Name = "lblPublicKeyFile";
+            this.lblPublicKeyFile.Size = new System.Drawing.Size(144, 23);
+            this.lblPublicKeyFile.TabIndex = 1;
+            this.lblPublicKeyFile.Text = "Public Key File";
+            this.lblPublicKeyFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // txtPublicKeyFile
             // 
             this.txtPublicKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtPublicKeyFile.Location = new System.Drawing.Point(3, 3);
+            this.txtPublicKeyFile.Location = new System.Drawing.Point(153, 21);
+            this.txtPublicKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.txtPublicKeyFile.Name = "txtPublicKeyFile";
-            this.txtPublicKeyFile.Size = new System.Drawing.Size(359, 20);
+            this.txtPublicKeyFile.Size = new System.Drawing.Size(260, 20);
             this.txtPublicKeyFile.TabIndex = 0;
             // 
             // topBorder
@@ -146,9 +225,9 @@ namespace WixSharpSetup.Dialogs
             this.label2.ForeColor = System.Drawing.SystemColors.HighlightText;
             this.label2.Location = new System.Drawing.Point(18, 31);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(129, 13);
+            this.label2.Size = new System.Drawing.Size(194, 13);
             this.label2.TabIndex = 1;
-            this.label2.Text = "[PublicKeyDlgDescription]";
+            this.label2.Text = "Keys for token creation and verification.";
             // 
             // label1
             // 
@@ -295,5 +374,11 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.TextBox txtPublicKeyFile;
         private System.Windows.Forms.Button butBrowsePublicKeyFile;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.Button butBrowsePrivateKeyFile;
+        private System.Windows.Forms.TextBox txtPrivateKeyFile;
+        private System.Windows.Forms.Label lblPrivateKeyFile;
+        private System.Windows.Forms.Label lblPrivateKeyDescription;
+        private System.Windows.Forms.Label lblPublicKeyDescription;
+        private System.Windows.Forms.Label lblPublicKeyFile;
     }
 }

--- a/package/WindowsManaged/Dialogs/PublicKeyDialog.cs
+++ b/package/WindowsManaged/Dialogs/PublicKeyDialog.cs
@@ -24,6 +24,15 @@ public partial class PublicKeyDialog : GatewayDialog
             return false;
         }
 
+        if (new GatewayProperties(this.Session()).ConfigureWebApp)
+        {
+            if (string.IsNullOrWhiteSpace(this.txtPrivateKeyFile.Text) || !File.Exists(this.txtPrivateKeyFile.Text.Trim()))
+            {
+                ShowValidationError("Error29996");
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -31,14 +40,34 @@ public partial class PublicKeyDialog : GatewayDialog
     {
         GatewayProperties properties = new(this.Runtime.Session);
         this.txtPublicKeyFile.Text = properties.PublicKeyFile;
+        this.txtPrivateKeyFile.Text = properties.PrivateKeyFile;
+
+        this.lblPrivateKeyDescription.Visible =
+            this.lblPrivateKeyFile.Visible =
+                this.txtPrivateKeyFile.Visible =
+                    this.butBrowsePrivateKeyFile.Visible = properties.ConfigureWebApp;
+
+        this.SetControlStates();
     }
 
     public override bool ToProperties()
     {
-        GatewayProperties _ = new(this.Runtime.Session)
+        GatewayProperties properties = new(this.Runtime.Session)
         {
-            PublicKeyFile = this.txtPublicKeyFile.Text.Trim()
+            PublicKeyFile = this.txtPublicKeyFile.Text.Trim(),
+            PrivateKeyFile = this.txtPrivateKeyFile.Text.Trim(),
         };
+
+        if (properties.GenerateKeyPair)
+        {
+            properties.PublicKeyFile = string.Empty;
+            properties.PrivateKeyFile = string.Empty;
+        }
+
+        if (properties.ConfigureWebApp)
+        {
+            properties.PrivateKeyFile = string.Empty;
+        }
 
         return true;
     }
@@ -59,6 +88,11 @@ public partial class PublicKeyDialog : GatewayDialog
     // ReSharper disable once RedundantOverriddenMember
     protected override void Cancel_Click(object sender, EventArgs e) => base.Cancel_Click(sender, e);
 
+    private void SetControlStates()
+    {
+
+    }
+
     private void butBrowsePublicKeyFile_Click(object sender, EventArgs e)
     {
         // TODO: (rmarkiewicz) localization
@@ -68,6 +102,18 @@ public partial class PublicKeyDialog : GatewayDialog
         if (!string.IsNullOrEmpty(file))
         {
             this.txtPublicKeyFile.Text = file;
+        }
+    }
+
+    private void butBrowsePrivateKeyFile_Click(object sender, EventArgs e)
+    {
+        // TODO: (rmarkiewicz) localization
+        const string filter = "Public Key Files (*.pem)|*.pem|Private Key Files (*.key)|*.key|All Files|*.*";
+        string file = this.BrowseForFile(filter);
+
+        if (!string.IsNullOrEmpty(file))
+        {
+            this.txtPrivateKeyFile.Text = file;
         }
     }
 

--- a/package/WindowsManaged/Dialogs/WebClientDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/WebClientDialog.Designer.cs
@@ -3,7 +3,7 @@ using WixSharp.UI.Forms;
 
 namespace WixSharpSetup.Dialogs
 {
-    partial class CustomizeDialog
+    partial class WebClientDialog
     {
         /// <summary>
         /// Required designer variable.
@@ -36,16 +36,16 @@ namespace WixSharpSetup.Dialogs
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.middlePanel = new System.Windows.Forms.Panel();
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.label3 = new System.Windows.Forms.Label();
-            this.rbConfigNow = new System.Windows.Forms.RadioButton();
-            this.rbConfigLater = new System.Windows.Forms.RadioButton();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
-            this.chkWebApp = new System.Windows.Forms.CheckBox();
-            this.chkGenerateCertificate = new System.Windows.Forms.CheckBox();
-            this.chkGenerateKeyPair = new System.Windows.Forms.CheckBox();
-            this.chkConfigureNgrok = new System.Windows.Forms.CheckBox();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.lblPassword2 = new System.Windows.Forms.Label();
+            this.lblPassword = new System.Windows.Forms.Label();
+            this.txtUsername = new System.Windows.Forms.TextBox();
+            this.lblUsername = new System.Windows.Forms.Label();
+            this.lblDefaultUserDescription = new System.Windows.Forms.Label();
+            this.lblPublicKeyDescription = new System.Windows.Forms.Label();
+            this.lblAuthentication = new System.Windows.Forms.Label();
+            this.cmbAuthentication = new System.Windows.Forms.ComboBox();
+            this.txtPassword = new System.Windows.Forms.TextBox();
+            this.txtPassword2 = new System.Windows.Forms.TextBox();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
@@ -57,13 +57,9 @@ namespace WixSharpSetup.Dialogs
             this.next = new System.Windows.Forms.Button();
             this.cancel = new System.Windows.Forms.Button();
             this.border1 = new System.Windows.Forms.Panel();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.contextMenuStrip1.SuspendLayout();
             this.middlePanel.SuspendLayout();
             this.tableLayoutPanel2.SuspendLayout();
-            this.groupBox1.SuspendLayout();
-            this.tableLayoutPanel3.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.topPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).BeginInit();
             this.bottomPanel.SuspendLayout();
@@ -72,7 +68,6 @@ namespace WixSharpSetup.Dialogs
             // 
             // contextMenuStrip1
             // 
-            this.contextMenuStrip1.ImageScalingSize = new System.Drawing.Size(32, 32);
             this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
@@ -86,165 +81,154 @@ namespace WixSharpSetup.Dialogs
             // 
             // middlePanel
             // 
-            this.middlePanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.middlePanel.Controls.Add(this.tableLayoutPanel2);
             this.middlePanel.Location = new System.Drawing.Point(0, 58);
             this.middlePanel.Name = "middlePanel";
-            this.middlePanel.Size = new System.Drawing.Size(494, 254);
+            this.middlePanel.Size = new System.Drawing.Size(494, 261);
             this.middlePanel.TabIndex = 16;
             // 
             // tableLayoutPanel2
             // 
-            this.tableLayoutPanel2.ColumnCount = 1;
+            this.tableLayoutPanel2.ColumnCount = 3;
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Controls.Add(this.label3, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.rbConfigNow, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.rbConfigLater, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.groupBox1, 0, 3);
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(12, 7);
+            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel2.Controls.Add(this.lblPassword2, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this.lblPassword, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.txtUsername, 1, 3);
+            this.tableLayoutPanel2.Controls.Add(this.lblUsername, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.lblDefaultUserDescription, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.lblPublicKeyDescription, 0, 0);
+            this.tableLayoutPanel2.Controls.Add(this.lblAuthentication, 0, 1);
+            this.tableLayoutPanel2.Controls.Add(this.cmbAuthentication, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.txtPassword, 1, 4);
+            this.tableLayoutPanel2.Controls.Add(this.txtPassword2, 1, 5);
+            this.tableLayoutPanel2.Location = new System.Drawing.Point(22, 17);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 4;
+            this.tableLayoutPanel2.RowCount = 7;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(470, 241);
-            this.tableLayoutPanel2.TabIndex = 14;
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 216);
+            this.tableLayoutPanel2.TabIndex = 2;
             // 
-            // label3
+            // lblPassword2
             // 
-            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.label3.BackColor = System.Drawing.Color.Transparent;
-            this.label3.Location = new System.Drawing.Point(3, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(464, 43);
-            this.label3.TabIndex = 11;
-            this.label3.Text = "[CustomInstallDlgInfoLabel]";
+            this.lblPassword2.AutoSize = true;
+            this.lblPassword2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblPassword2.Location = new System.Drawing.Point(3, 131);
+            this.lblPassword2.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPassword2.Name = "lblPassword2";
+            this.lblPassword2.Size = new System.Drawing.Size(144, 23);
+            this.lblPassword2.TabIndex = 8;
+            this.lblPassword2.Text = "Confirm Password";
+            this.lblPassword2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // rbConfigNow
+            // lblPassword
             // 
-            this.rbConfigNow.AutoSize = true;
-            this.rbConfigNow.Location = new System.Drawing.Point(3, 69);
-            this.rbConfigNow.Name = "rbConfigNow";
-            this.rbConfigNow.Size = new System.Drawing.Size(202, 17);
-            this.rbConfigNow.TabIndex = 1;
-            this.rbConfigNow.Text = "[CustomInstallDlgConfigureNowLabel]";
-            this.rbConfigNow.UseVisualStyleBackColor = true;
-            this.rbConfigNow.CheckedChanged += new System.EventHandler(this.rbConfigNow_CheckedChanged);
+            this.lblPassword.AutoSize = true;
+            this.lblPassword.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblPassword.Location = new System.Drawing.Point(3, 103);
+            this.lblPassword.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPassword.Name = "lblPassword";
+            this.lblPassword.Size = new System.Drawing.Size(144, 23);
+            this.lblPassword.TabIndex = 6;
+            this.lblPassword.Text = "Password";
+            this.lblPassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // rbConfigLater
+            // txtUsername
             // 
-            this.rbConfigLater.AutoSize = true;
-            this.rbConfigLater.Checked = true;
-            this.rbConfigLater.Location = new System.Drawing.Point(3, 46);
-            this.rbConfigLater.Name = "rbConfigLater";
-            this.rbConfigLater.Size = new System.Drawing.Size(204, 17);
-            this.rbConfigLater.TabIndex = 0;
-            this.rbConfigLater.TabStop = true;
-            this.rbConfigLater.Text = "[CustomInstallDlgConfigureLaterLabel]";
-            this.rbConfigLater.UseVisualStyleBackColor = true;
-            this.rbConfigLater.CheckedChanged += new System.EventHandler(this.rbConfigLater_CheckedChanged);
+            this.txtUsername.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtUsername.Location = new System.Drawing.Point(153, 78);
+            this.txtUsername.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtUsername.MaxLength = 256;
+            this.txtUsername.Name = "txtUsername";
+            this.txtUsername.Size = new System.Drawing.Size(293, 20);
+            this.txtUsername.TabIndex = 4;
             // 
-            // groupBox1
+            // lblUsername
             // 
-            this.groupBox1.Controls.Add(this.tableLayoutPanel3);
-            this.groupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.groupBox1.Location = new System.Drawing.Point(3, 99);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(3, 10, 3, 3);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(464, 139);
-            this.groupBox1.TabIndex = 12;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Configuration Options";
+            this.lblUsername.AutoSize = true;
+            this.lblUsername.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblUsername.Location = new System.Drawing.Point(3, 75);
+            this.lblUsername.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblUsername.Name = "lblUsername";
+            this.lblUsername.Size = new System.Drawing.Size(144, 23);
+            this.lblUsername.TabIndex = 3;
+            this.lblUsername.Text = "Username";
+            this.lblUsername.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // tableLayoutPanel3
+            // lblDefaultUserDescription
             // 
-            this.tableLayoutPanel3.ColumnCount = 2;
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Controls.Add(this.chkWebApp, 0, 0);
-            this.tableLayoutPanel3.Controls.Add(this.chkGenerateCertificate, 0, 1);
-            this.tableLayoutPanel3.Controls.Add(this.chkGenerateKeyPair, 0, 2);
-            this.tableLayoutPanel3.Controls.Add(this.chkConfigureNgrok, 0, 3);
-            this.tableLayoutPanel3.Controls.Add(this.pictureBox1, 1, 1);
-            this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
-            this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 5;
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Size = new System.Drawing.Size(458, 120);
-            this.tableLayoutPanel3.TabIndex = 0;
+            this.lblDefaultUserDescription.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.lblDefaultUserDescription, 3);
+            this.lblDefaultUserDescription.Location = new System.Drawing.Point(3, 57);
+            this.lblDefaultUserDescription.Margin = new System.Windows.Forms.Padding(3, 10, 3, 5);
+            this.lblDefaultUserDescription.Name = "lblDefaultUserDescription";
+            this.lblDefaultUserDescription.Size = new System.Drawing.Size(249, 13);
+            this.lblDefaultUserDescription.TabIndex = 2;
+            this.lblDefaultUserDescription.Text = "Create a default user to access the web application";
             // 
-            // chkWebApp
+            // lblPublicKeyDescription
             // 
-            this.chkWebApp.AutoSize = true;
-            this.chkWebApp.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkWebApp.Enabled = false;
-            this.chkWebApp.Location = new System.Drawing.Point(10, 3);
-            this.chkWebApp.Margin = new System.Windows.Forms.Padding(10, 3, 3, 3);
-            this.chkWebApp.Name = "chkWebApp";
-            this.chkWebApp.Size = new System.Drawing.Size(203, 17);
-            this.chkWebApp.TabIndex = 12;
-            this.chkWebApp.Text = "Configure standalone web application";
-            this.chkWebApp.UseVisualStyleBackColor = true;
-            this.chkWebApp.CheckedChanged += new System.EventHandler(this.chkWebApp_CheckedChanged);
+            this.lblPublicKeyDescription.AutoSize = true;
+            this.tableLayoutPanel2.SetColumnSpan(this.lblPublicKeyDescription, 3);
+            this.lblPublicKeyDescription.Location = new System.Drawing.Point(3, 0);
+            this.lblPublicKeyDescription.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblPublicKeyDescription.Name = "lblPublicKeyDescription";
+            this.lblPublicKeyDescription.Size = new System.Drawing.Size(370, 13);
+            this.lblPublicKeyDescription.TabIndex = 0;
+            this.lblPublicKeyDescription.Text = "Choose the authentication method used when accessing the web application";
             // 
-            // chkGenerateCertificate
+            // lblAuthentication
             // 
-            this.chkGenerateCertificate.AutoSize = true;
-            this.chkGenerateCertificate.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkGenerateCertificate.Enabled = false;
-            this.chkGenerateCertificate.Location = new System.Drawing.Point(30, 26);
-            this.chkGenerateCertificate.Margin = new System.Windows.Forms.Padding(30, 3, 3, 3);
-            this.chkGenerateCertificate.Name = "chkGenerateCertificate";
-            this.chkGenerateCertificate.Size = new System.Drawing.Size(183, 17);
-            this.chkGenerateCertificate.TabIndex = 13;
-            this.chkGenerateCertificate.Text = "Generate a self-signed certificate";
-            this.chkGenerateCertificate.UseVisualStyleBackColor = true;
+            this.lblAuthentication.AutoSize = true;
+            this.lblAuthentication.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblAuthentication.Location = new System.Drawing.Point(3, 18);
+            this.lblAuthentication.Margin = new System.Windows.Forms.Padding(3, 0, 3, 5);
+            this.lblAuthentication.Name = "lblAuthentication";
+            this.lblAuthentication.Size = new System.Drawing.Size(144, 24);
+            this.lblAuthentication.TabIndex = 1;
+            this.lblAuthentication.Text = "Authentication";
+            this.lblAuthentication.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // chkGenerateKeyPair
+            // cmbAuthentication
             // 
-            this.chkGenerateKeyPair.AutoSize = true;
-            this.chkGenerateKeyPair.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkGenerateKeyPair.Enabled = false;
-            this.chkGenerateKeyPair.Location = new System.Drawing.Point(30, 49);
-            this.chkGenerateKeyPair.Margin = new System.Windows.Forms.Padding(30, 3, 3, 3);
-            this.chkGenerateKeyPair.Name = "chkGenerateKeyPair";
-            this.chkGenerateKeyPair.Size = new System.Drawing.Size(183, 17);
-            this.chkGenerateKeyPair.TabIndex = 14;
-            this.chkGenerateKeyPair.Text = "Generate the provisioner key pair";
-            this.chkGenerateKeyPair.UseVisualStyleBackColor = true;
+            this.cmbAuthentication.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.cmbAuthentication.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbAuthentication.FormattingEnabled = true;
+            this.cmbAuthentication.Location = new System.Drawing.Point(153, 21);
+            this.cmbAuthentication.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.cmbAuthentication.Name = "cmbAuthentication";
+            this.cmbAuthentication.Size = new System.Drawing.Size(293, 21);
+            this.cmbAuthentication.TabIndex = 5;
+            this.cmbAuthentication.SelectedIndexChanged += new System.EventHandler(this.cmbAuthentication_SelectedIndexChanged);
             // 
-            // chkConfigureNgrok
+            // txtPassword
             // 
-            this.chkConfigureNgrok.AutoSize = true;
-            this.chkConfigureNgrok.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.chkConfigureNgrok.Enabled = false;
-            this.chkConfigureNgrok.Location = new System.Drawing.Point(10, 72);
-            this.chkConfigureNgrok.Margin = new System.Windows.Forms.Padding(10, 3, 3, 3);
-            this.chkConfigureNgrok.Name = "chkConfigureNgrok";
-            this.chkConfigureNgrok.Size = new System.Drawing.Size(203, 17);
-            this.chkConfigureNgrok.TabIndex = 15;
-            this.chkConfigureNgrok.Text = "Configure ngrok";
-            this.chkConfigureNgrok.UseVisualStyleBackColor = true;
-            this.chkConfigureNgrok.Visible = false;
+            this.txtPassword.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtPassword.Location = new System.Drawing.Point(153, 106);
+            this.txtPassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtPassword.MaxLength = 256;
+            this.txtPassword.Name = "txtPassword";
+            this.txtPassword.Size = new System.Drawing.Size(293, 20);
+            this.txtPassword.TabIndex = 7;
+            this.txtPassword.UseSystemPasswordChar = true;
             // 
-            // pictureBox1
+            // txtPassword2
             // 
-            this.pictureBox1.Location = new System.Drawing.Point(219, 26);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(16, 16);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
-            this.pictureBox1.TabIndex = 16;
-            this.pictureBox1.TabStop = false;
-            this.toolTip1.SetToolTip(this.pictureBox1, "Self-signed certificates are not trusted by default");
+            this.txtPassword2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtPassword2.Location = new System.Drawing.Point(153, 134);
+            this.txtPassword2.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtPassword2.MaxLength = 256;
+            this.txtPassword2.Name = "txtPassword2";
+            this.txtPassword2.Size = new System.Drawing.Size(293, 20);
+            this.txtPassword2.TabIndex = 9;
+            this.txtPassword2.UseSystemPasswordChar = true;
             // 
             // topBorder
             // 
@@ -276,9 +260,9 @@ namespace WixSharpSetup.Dialogs
             this.label2.ForeColor = System.Drawing.SystemColors.HighlightText;
             this.label2.Location = new System.Drawing.Point(18, 31);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(130, 13);
+            this.label2.Size = new System.Drawing.Size(205, 13);
             this.label2.TabIndex = 1;
-            this.label2.Text = "[CustomizeDlgDescription]";
+            this.label2.Text = "Configure the standalone web application.";
             // 
             // label1
             // 
@@ -288,9 +272,9 @@ namespace WixSharpSetup.Dialogs
             this.label1.ForeColor = System.Drawing.SystemColors.HighlightText;
             this.label1.Location = new System.Drawing.Point(11, 8);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(116, 13);
+            this.label1.Size = new System.Drawing.Size(107, 13);
             this.label1.TabIndex = 1;
-            this.label1.Text = "[CustomizeDlgTitle]";
+            this.label1.Text = "[WebAppDlgTitle]";
             // 
             // banner
             // 
@@ -381,13 +365,7 @@ namespace WixSharpSetup.Dialogs
             this.border1.Size = new System.Drawing.Size(494, 1);
             this.border1.TabIndex = 14;
             // 
-            // toolTip1
-            // 
-            this.toolTip1.IsBalloon = true;
-            this.toolTip1.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
-            this.toolTip1.ToolTipTitle = "Self-Signed Certificate";
-            // 
-            // CustomizeDialog
+            // WebClientDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.ClientSize = new System.Drawing.Size(494, 361);
@@ -395,17 +373,13 @@ namespace WixSharpSetup.Dialogs
             this.Controls.Add(this.topBorder);
             this.Controls.Add(this.topPanel);
             this.Controls.Add(this.bottomPanel);
-            this.Name = "CustomizeDialog";
-            this.Text = "[CustomizeDlg_Title]";
+            this.Name = "WebClientDialog";
+            this.Text = "[WebAppDlg_Title]";
             this.Load += new System.EventHandler(this.OnLoad);
             this.contextMenuStrip1.ResumeLayout(false);
             this.middlePanel.ResumeLayout(false);
             this.tableLayoutPanel2.ResumeLayout(false);
             this.tableLayoutPanel2.PerformLayout();
-            this.groupBox1.ResumeLayout(false);
-            this.tableLayoutPanel3.ResumeLayout(false);
-            this.tableLayoutPanel3.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.topPanel.ResumeLayout(false);
             this.topPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).EndInit();
@@ -425,7 +399,6 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Panel bottomPanel;
-        private System.Windows.Forms.Label label3;
         private System.Windows.Forms.Panel border1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Button back;
@@ -433,16 +406,16 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.Button cancel;
         private System.Windows.Forms.Panel topBorder;
         private System.Windows.Forms.Panel middlePanel;
-        private System.Windows.Forms.RadioButton rbConfigNow;
-        private System.Windows.Forms.RadioButton rbConfigLater;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
-        private System.Windows.Forms.CheckBox chkWebApp;
-        private System.Windows.Forms.GroupBox groupBox1;
-        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;
-        private System.Windows.Forms.CheckBox chkGenerateCertificate;
-        private System.Windows.Forms.CheckBox chkGenerateKeyPair;
-        private System.Windows.Forms.CheckBox chkConfigureNgrok;
-        private System.Windows.Forms.PictureBox pictureBox1;
-        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.TextBox txtUsername;
+        private System.Windows.Forms.Label lblUsername;
+        private System.Windows.Forms.Label lblDefaultUserDescription;
+        private System.Windows.Forms.Label lblPublicKeyDescription;
+        private System.Windows.Forms.Label lblAuthentication;
+        private System.Windows.Forms.ComboBox cmbAuthentication;
+        private System.Windows.Forms.Label lblPassword;
+        private System.Windows.Forms.TextBox txtPassword;
+        private System.Windows.Forms.Label lblPassword2;
+        private System.Windows.Forms.TextBox txtPassword2;
     }
 }

--- a/package/WindowsManaged/Dialogs/WebClientDialog.cs
+++ b/package/WindowsManaged/Dialogs/WebClientDialog.cs
@@ -1,0 +1,105 @@
+using DevolutionsGateway.Dialogs;
+using DevolutionsGateway.Properties;
+using System;
+using WixSharp;
+
+namespace WixSharpSetup.Dialogs;
+
+public partial class WebClientDialog : GatewayDialog
+{
+    private bool CustomAuth => this.cmbAuthentication.SelectedIndex == (int)Constants.AuthenticationMode.Custom;
+
+    public WebClientDialog()
+    {
+        InitializeComponent();
+        label1.MakeTransparentOn(banner);
+        label2.MakeTransparentOn(banner);
+
+        this.cmbAuthentication.DataSource = Enum.GetValues(typeof(Constants.AuthenticationMode));
+        this.cmbAuthentication.SelectedIndex = 0;
+    }
+
+    public override bool DoValidate()
+    {
+        if (!this.CustomAuth)
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(this.txtUsername.Text))
+        {
+            ShowValidationError("Error29996");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(this.txtPassword.Text))
+        {
+            ShowValidationError("Error29996");
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(this.txtPassword2.Text))
+        {
+            ShowValidationError("Error29996");
+            return false;
+        }
+
+        if (!string.Equals(this.txtPassword.Text, this.txtPassword2.Text))
+        {
+            ShowValidationError("Error29996");
+            return false;
+        }
+
+        return true;
+    }
+
+    public override void FromProperties()
+    {
+        GatewayProperties properties = new(this.Runtime.Session);
+        this.cmbAuthentication.SelectedIndex = (int) properties.AuthenticationMode;
+        this.txtUsername.Text = properties.WebUsername;
+        this.txtPassword.Text = properties.WebPassword;
+
+        this.SetControlStates();
+    }
+
+    public override bool ToProperties()
+    {
+        GatewayProperties _ = new(this.Runtime.Session)
+        {
+            AuthenticationMode = (Constants.AuthenticationMode)this.cmbAuthentication.SelectedIndex,
+            WebUsername = this.txtUsername.Text,
+            WebPassword = this.txtPassword.Text
+        };
+
+        return true;
+    }
+
+    public override void OnLoad(object sender, EventArgs e)
+    {
+        banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
+
+        base.OnLoad(sender, e);
+    }
+
+    // ReSharper disable once RedundantOverriddenMember
+    protected override void Back_Click(object sender, EventArgs e) => base.Back_Click(sender, e);
+
+    // ReSharper disable once RedundantOverriddenMember
+    protected override void Next_Click(object sender, EventArgs e) => base.Next_Click(sender, e);
+
+    // ReSharper disable once RedundantOverriddenMember
+    protected override void Cancel_Click(object sender, EventArgs e) => base.Cancel_Click(sender, e);
+
+    private void SetControlStates()
+    {
+        this.lblUsername.Enabled = this.txtUsername.Enabled = 
+            this.lblPassword.Enabled = this.txtPassword.Enabled =
+                this.lblPassword2.Enabled = this.txtPassword2.Enabled = this.CustomAuth;
+    }
+
+    private void cmbAuthentication_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+}

--- a/package/WindowsManaged/Dialogs/WebClientDialog.resx
+++ b/package/WindowsManaged/Dialogs/WebClientDialog.resx
@@ -120,7 +120,4 @@
   <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>172, 17</value>
-  </metadata>
 </root>

--- a/package/WindowsManaged/Dialogs/Wizard.cs
+++ b/package/WindowsManaged/Dialogs/Wizard.cs
@@ -1,8 +1,10 @@
 ﻿using DevolutionsGateway.Properties;
 using Microsoft.Deployment.WindowsInstaller;
 using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq;
+using System.Windows.Forms.VisualStyles;
 using DevolutionsGateway.Helpers;
 using WixSharp;
 using WixSharpSetup.Dialogs;
@@ -17,6 +19,7 @@ internal static class Wizard
         typeof(ListenersDialog),
         typeof(CertificateDialog),
         typeof(PublicKeyDialog),
+        typeof(WebClientDialog),
         typeof(ServiceDialog),
         typeof(SummaryDialog),
     };
@@ -65,6 +68,32 @@ internal static class Wizard
             {
                 return true;
             }
+
+            if (properties.ConfigureWebApp && properties.GenerateCertificate)
+            {
+                return true;
+            }
+        }
+
+        if (dialog == typeof(PublicKeyDialog))
+        {
+            if (properties.ConfigureWebApp && properties.GenerateKeyPair)
+            {
+                return true;
+            }
+        }
+
+        if (dialog == typeof(WebClientDialog))
+        {
+            if (!properties.ConfigureWebApp)
+            {
+                return true;
+            }
+        }
+
+        if (dialog == typeof(ServiceDialog))
+        {
+            return true;
         }
 
         if (CustomizeSequence.Contains(dialog))

--- a/package/WindowsManaged/Helpers/StockIcon.cs
+++ b/package/WindowsManaged/Helpers/StockIcon.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace DevolutionsGateway.Helpers
+{
+    internal class StockIcon
+    {
+        internal static Icon GetStockIcon(uint type, uint size)
+        {
+            var info = new SHSTOCKICONINFO();
+            info.cbSize = (uint)Marshal.SizeOf(info);
+
+            SHGetStockIconInfo(type, SHGSI_ICON | size, ref info);
+
+            var icon = (Icon)Icon.FromHandle(info.hIcon).Clone(); // Get a copy that doesn't use the original handle
+            DestroyIcon(info.hIcon); // Clean up native icon to prevent resource leak
+
+            return icon;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct SHSTOCKICONINFO
+        {
+            public uint cbSize;
+            public IntPtr hIcon;
+            public int iSysIconIndex;
+            public int iIcon;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+            public string szPath;
+        }
+
+        [DllImport("shell32.dll")]
+        private static extern int SHGetStockIconInfo(uint siid, uint uFlags, ref SHSTOCKICONINFO psii);
+
+        [DllImport("user32.dll")]
+        private static extern bool DestroyIcon(IntPtr handle);
+
+        internal const uint SIID_SHIELD = 77;
+        internal const uint SIID_WARNING = 78;
+        internal const uint SIID_INFO = 79;
+        internal const uint SHGSI_ICON = 0x100;
+        internal const uint SHGSI_LARGEICON = 0x0;
+        internal const uint SHGSI_SMALLICON = 0x1;
+    }
+}

--- a/package/WindowsManaged/Properties/Constants.cs
+++ b/package/WindowsManaged/Properties/Constants.cs
@@ -20,6 +20,12 @@ namespace DevolutionsGateway.Properties
             SubjectName
         }
 
+        internal enum AuthenticationMode
+        {
+            None,
+            Custom,
+        }
+
         internal const string HttpProtocol = "http";
 
         internal const string HttpsProtocol = "https";
@@ -32,10 +38,16 @@ namespace DevolutionsGateway.Properties
 
         internal const string ImportDGatewayCertificateWithPasswordCommandFormat = "Import-DGatewayCertificate -CertificateFile '{0}' -Password '{1}'";
 
-        internal const string ImportDGatewayCertificateWithPrivateKeyCommandFormat = "Import-DGatewayCertificate -CertificateFile '{0} -PrivateKeyFile '{1}'";
+        internal const string ImportDGatewayCertificateWithPrivateKeyCommandFormat = "Import-DGatewayCertificate -CertificateFile '{0}' -PrivateKeyFile '{1}'";
 
         internal const string ImportDGatewayCertificateFromSystemFormat = "Set-DGatewayConfig -TlsCertificateSource {0} -TlsCertificateSubjectName {1} -TlsCertificateStoreName {2} -TlsCertificateStoreLocation {3}";
 
+        internal const string ImportDGatewayProvisionerKeyCommand = "Import-DGatewayProvisionerKey";
+
         internal const string ImportDGatewayProvisionerKeyCommandFormat = "Import-DGatewayProvisionerKey -PublicKeyFile '{0}'";
+
+        internal const string NewDGatewayCertificateCommand = "New-DGatewayCertificate";
+
+        internal const string NewDGatewayProvisionerKeyPairCommand = "New-DGatewayProvisionerKeyPair -Force";
     }
 }

--- a/package/WindowsManaged/Properties/GatewayProperties.g.cs
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.cs
@@ -247,6 +247,30 @@ namespace DevolutionsGateway.Properties
             }
         }
  
+        internal static readonly WixProperty<bool> _GenerateCertificate = new()
+        {
+            Id = "P.GENERATECERTIFICATE",
+            Default = false,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public bool GenerateCertificate
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_GenerateCertificate.Id);
+                return WixProperties.GetPropertyValue<bool>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_GenerateCertificate, value); 
+                }
+            }
+        }
+ 
         internal static readonly WixProperty<Constants.CertificateFindType> _CertificateFindType = new()
         {
             Id = "P.CERTIFICATEFINDTYPE",
@@ -327,7 +351,7 @@ namespace DevolutionsGateway.Properties
             Hidden = false,
         };
 
-        /// `true` to configure the Gateway interactively
+        /// <summary>`true` to configure the Gateway interactively</summary>
         public bool ConfigureGateway
         {
             get
@@ -460,6 +484,54 @@ namespace DevolutionsGateway.Properties
                 if (this.runtimeSession is not null)
                 {
                     this.runtimeSession.Set(_PublicKeyFile, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<string> _PrivateKeyFile = new()
+        {
+            Id = "P.PRIVATEKEYFILE",
+            Default = string.Empty,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public string PrivateKeyFile
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_PrivateKeyFile.Id);
+                return WixProperties.GetPropertyValue<string>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_PrivateKeyFile, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<bool> _GenerateKeyPair = new()
+        {
+            Id = "P.GENERATEKEYPAIR",
+            Default = false,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public bool GenerateKeyPair
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_GenerateKeyPair.Id);
+                return WixProperties.GetPropertyValue<bool>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_GenerateKeyPair, value); 
                 }
             }
         }
@@ -608,6 +680,127 @@ namespace DevolutionsGateway.Properties
             }
         }
  
+        internal static readonly WixProperty<bool> _ConfigureWebApp = new()
+        {
+            Id = "P.CONFIGUREWEBAPP",
+            Default = false,
+            Secure = true,
+            Hidden = false,
+        };
+
+        /// <summary>`true` to configure the standalone web application interactively</summary>
+        public bool ConfigureWebApp
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_ConfigureWebApp.Id);
+                return WixProperties.GetPropertyValue<bool>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_ConfigureWebApp, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<Constants.AuthenticationMode> _AuthenticationMode = new()
+        {
+            Id = "P.AUTHENTICATIONMODE",
+            Default = Constants.AuthenticationMode.None,
+            Secure = true,
+            Hidden = true,
+        };
+
+        public Constants.AuthenticationMode AuthenticationMode
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_AuthenticationMode.Id);
+                return WixProperties.GetPropertyValue<Constants.AuthenticationMode>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_AuthenticationMode, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<string> _WebUsername = new()
+        {
+            Id = "P.WEBUSERNAME",
+            Default = string.Empty,
+            Secure = true,
+            Hidden = false,
+        };
+
+        public string WebUsername
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_WebUsername.Id);
+                return WixProperties.GetPropertyValue<string>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_WebUsername, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<string> _WebPassword = new()
+        {
+            Id = "P.WEBPASSWORD",
+            Default = string.Empty,
+            Secure = true,
+            Hidden = true,
+        };
+
+        public string WebPassword
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_WebPassword.Id);
+                return WixProperties.GetPropertyValue<string>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_WebPassword, value); 
+                }
+            }
+        }
+ 
+        internal static readonly WixProperty<uint> _NetFx45Version = new()
+        {
+            Id = "P.NETFX45VERSION",
+            Default = 0,
+            Secure = false,
+            Hidden = false,
+        };
+
+        public uint NetFx45Version
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(_NetFx45Version.Id);
+                return WixProperties.GetPropertyValue<uint>(stringValue);
+            }
+            set 
+            { 
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(_NetFx45Version, value); 
+                }
+            }
+        }
+ 
         internal static readonly WixProperty<bool> _FirstInstall = new()
         {
             Id = "P.FIRSTINSTALL",
@@ -752,6 +945,8 @@ namespace DevolutionsGateway.Properties
  
             _CertificateName,
  
+            _GenerateCertificate,
+ 
             _CertificateFindType,
  
             _CertificateSearchText,
@@ -770,6 +965,10 @@ namespace DevolutionsGateway.Properties
  
             _PublicKeyFile,
  
+            _PrivateKeyFile,
+ 
+            _GenerateKeyPair,
+ 
             _PowerShellPath,
  
             _NoStartService,
@@ -781,6 +980,16 @@ namespace DevolutionsGateway.Properties
             _TcpListenerPort,
  
             _TcpListenerScheme,
+ 
+            _ConfigureWebApp,
+ 
+            _AuthenticationMode,
+ 
+            _WebUsername,
+ 
+            _WebPassword,
+ 
+            _NetFx45Version,
  
             _FirstInstall,
  

--- a/package/WindowsManaged/Properties/GatewayProperties.g.tt
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.tt
@@ -26,7 +26,7 @@ namespace DevolutionsGateway.Properties
         };
 
 <# if (this.properties[idx,6] != "") { #>
-        /// <#= this.properties[idx,6] #>
+        /// <summary><#= this.properties[idx,6] #></summary>
 <# } #>
         public <#= this.properties[idx,0] #> <#= this.properties[idx,1] #>
         {
@@ -71,6 +71,7 @@ namespace DevolutionsGateway.Properties
     {"StoreLocation", "CertificateLocation", "StoreLocation.CurrentUser", "true", "false", "", ""},
     {"StoreName", "CertificateStore", "StoreName.My", "true", "true", "", ""},
     {"string", "CertificateName", "string.Empty", "true", "false", "", ""},
+    {"bool", "GenerateCertificate", "false", "true", "false", "", ""},
     // UI Helpers
     {"Constants.CertificateFindType", "CertificateFindType", "Constants.CertificateFindType.Thumbprint", "false", "false", "", ""},
     {"string", "CertificateSearchText", "string.Empty", "true", "false", "", ""},
@@ -84,6 +85,8 @@ namespace DevolutionsGateway.Properties
     {"string", "HttpListenerScheme", "Constants.HttpsProtocol", "true", "false", "", ""},
 
     {"string", "PublicKeyFile", "string.Empty", "true", "false", "", ""},
+    {"string", "PrivateKeyFile", "string.Empty", "true", "false", "", ""},
+    {"bool", "GenerateKeyPair", "false", "true", "false", "", ""},
 
     {"string", "PowerShellPath", "string.Empty", "true", "false", "", ""},
     {"string", "NoStartService", "string.Empty", "true", "false", "dgw.no_start_service", ""},
@@ -93,11 +96,16 @@ namespace DevolutionsGateway.Properties
     {"uint", "TcpListenerPort", "8181", "true", "false", "", ""},
     {"string", "TcpListenerScheme", "Constants.TcpProtocol", "true", "false", "", ""},
 
+    {"bool", "ConfigureWebApp", "false", "true", "false", "", "`true` to configure the standalone web application interactively"},
+    {"Constants.AuthenticationMode", "AuthenticationMode", "Constants.AuthenticationMode.None", "true", "true", "", ""},
+    {"string", "WebUsername", "string.Empty", "true", "false", "", ""},
+    {"string", "WebPassword", "string.Empty", "true", "true", "", ""},
+
+    {"uint", "NetFx45Version", "0", "false", "false", "", ""},
     {"bool", "FirstInstall", "false", "true", "false", "", ""},
     {"bool", "Upgrading", "false", "true", "false", "", ""},
     {"bool", "RemovingForUpgrade", "false", "true", "false", "", ""},
     {"bool", "Uninstalling", "false", "true", "false", "", ""},
-
     {"bool", "Maintenance", "false", "true", "false", "", ""},
   };               
 #>

--- a/package/WindowsManaged/README.md
+++ b/package/WindowsManaged/README.md
@@ -83,7 +83,7 @@ System.IO.File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(Assembly.GetExec
 The custom UI targets .NET Framework 4.5.1; which is available out-of-the-box on Windows. The provides compatiblity with Windows 8.1 and Windows Server 2012 R2, but it's an additional download on Windows 8 / Windows Server 2012.
 
 > [!IMPORTANT]  
-> The managed installer UI and actions are currently run as x86, meaning x64-only references cannot be used. Additionally, when querying the registry, it's important to ensure you don't check the WoW64 view.
+> The managed installer UI and actions are currently run as x86, meaning x64-only references cannot be used. Additionally, when querying the registry, it's important to ensure you don't check the WoW64 view. There is a [path](https://github.com/oleg-shilo/wixsharp/issues/1427) to work around this for custom actions only, if it becomes important to do so.
 
 The MSI project only targets the x64 architecture and the install won't execute on an x86 operating system. Behaviour on arm64 is currently undefined.
 

--- a/package/WindowsManaged/Resources/Includes.cs
+++ b/package/WindowsManaged/Resources/Includes.cs
@@ -28,5 +28,10 @@ namespace DevolutionsGateway.Resources
         /// SYSTEM/BuiltInAdministrators = Full Control, LocalService = Read / Write / Execute, BuiltInUsers - Read/Execute
         /// </summary>
         internal static string PROGRAM_DATA_SDDL = "D:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)";
+
+        /// <summary>
+        /// NT AUTHORITY\SYSTEM Allow  FullControl, NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize, BUILTIN\Administrators Allow  FullControl
+        /// </summary>
+        internal static string USERS_FILE_SDDL = "O:SYG:SYD:PAI(A;;FA;;;SY)(A;;0x1201bf;;;LS)(A;;FA;;;BA)";
     }
 }

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -9,6 +9,7 @@
 
 # dependencies
 node_modules/
+web/node_modules/
 
 # IDEs and editors
 .idea
@@ -30,6 +31,7 @@ node_modules/
 
 # misc
 .angular/cache
+web/.angular/cache
 /.sass-cache
 /connect.lock
 /coverage/


### PR DESCRIPTION
When customizing the install, the user is now prompted to setup the standalone web application (and, optionally, generate a certificate and/or provisioner key pair - in this case, the relevant dialogs are skipped in the wizard).

An additional dialog allows configuring the authentication mode and (if relevant) a default user.

If the file "users.txt" exists in the %programdata% directory, the installer will enforce it's permissions with the following ACL:

>NT AUTHORITY\SYSTEM Allow FullControl, NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize, BUILTIN\Administrators Allow FullControl

Finally, I added a prerequisite check for the installed .NET Framework version.

> [!NOTE] 
> This is an intermediate PR and final polish (for example, but not limited to: finishing localization, finalizing validation and error messages, and setting tab orders) remains WIP.

