### PR TITLE
fix(dgw): debug option to set the webapp path

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ Stable options are:
 
         Blank lines and lines starting by `#` are ignored.
 
+    * **StaticRootPath** (_FilePath_): Path to the static files for the standalone web application.
+        This is an advanced option which should typically not be changed.
+
 - **VerbosityProfile** (_String_): Logging verbosity profile (pre-defined tracing directives).
 
     Possible values:

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -1012,6 +1012,7 @@ pub mod dto {
         pub dump_tokens: bool,
 
         /// Ignore token signature and accept as-is (any signer is accepted), expired tokens and token
+        ///
         /// reuse is allowed, etc. Only restriction is to provide claims in the right format.
         #[serde(default)]
         pub disable_token_validation: bool,
@@ -1023,8 +1024,12 @@ pub mod dto {
         pub log_directives: Option<String>,
 
         /// Folder where pcap recordings should be stored
-        /// Providing this option will cause the PCAP interceptor to be attached to each stream
+        ///
+        /// Providing this option will cause the PCAP interceptor to be attached to each stream.
         pub capture_path: Option<Utf8PathBuf>,
+
+        /// Override the path to the standalone web application
+        pub webapp_path: Option<Utf8PathBuf>,
     }
 
     /// Manual Default trait implementation just to make sure default values are deliberates
@@ -1037,6 +1042,7 @@ pub mod dto {
                 override_kdc: None,
                 log_directives: None,
                 capture_path: None,
+                webapp_path: None,
             }
         }
     }

--- a/devolutions-gateway/tests/config.rs
+++ b/devolutions-gateway/tests/config.rs
@@ -239,6 +239,7 @@ fn standalone_custom_auth_sample() -> Sample {
                 app_token_maximum_lifetime: Some(28800),
                 login_limit_rate: Some(10),
                 users_file: None,
+                static_root_path: None,
             }),
             debug: None,
             rest: Default::default(),
@@ -266,7 +267,8 @@ fn standalone_no_auth_sample() -> Sample {
             "WebApp": {
                 "Enabled": true,
                 "Authentication": "None",
-                "UsersFile": "/path/to/users.txt"
+                "UsersFile": "/path/to/users.txt",
+                "StaticRootPath": "/path/to/webapp/static/root"
             }
         }"#,
         file_conf: ConfFile {
@@ -310,6 +312,7 @@ fn standalone_no_auth_sample() -> Sample {
                 app_token_maximum_lifetime: None,
                 login_limit_rate: None,
                 users_file: Some("/path/to/users.txt".into()),
+                static_root_path: Some("/path/to/webapp/static/root".into()),
             }),
             debug: None,
             rest: Default::default(),


### PR DESCRIPTION
~~This also removes the `DGATEWAY_WEBAPP_PATH` env variable.~~
The `DGATEWAY_WEBAPP_PATH` env variable is conserved.

For example:
```json
{
  "WebApp": {
    "Enabled": true,
    "Authentication": "Custom",
    "StaticRootPath": "./webapp"
  },
}
```

This will reproduce the behavior of the initial implementation, finding the webapp folder in the current working directly.

cc @kristahouse 