### PR TITLE
test: initial tracing-cov-mark crate implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
+ "tracing-cov-mark",
  "tracing-subscriber",
  "transport",
  "tungstenite",
@@ -2108,6 +2109,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-cov-mark",
  "tracing-subscriber",
 ]
 
@@ -4177,6 +4179,13 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-cov-mark"
+version = "0.0.0"
+dependencies = [
+ "tracing",
 ]
 
 [[package]]

--- a/crates/network-scanner-net/Cargo.toml
+++ b/crates/network-scanner-net/Cargo.toml
@@ -17,6 +17,7 @@ tokio-stream = "0.1.14"
 tracing = "0.1.40"
 
 [dev-dependencies]
+tracing-cov-mark = { path = "../tracing-cov-mark" }
 tracing-subscriber = "0.3.18"
 tokio = { version = "1.36.0", features = [
     "rt",

--- a/crates/network-scanner-net/src/lib.rs
+++ b/crates/network-scanner-net/src/lib.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 pub mod runtime;
 pub mod socket;
 #[cfg(test)]
-mod test;
+mod tests;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ScannnerNetError {

--- a/crates/network-scanner-net/src/runtime.rs
+++ b/crates/network-scanner-net/src/runtime.rs
@@ -29,14 +29,17 @@ pub struct Socket2Runtime {
 
 impl Drop for Socket2Runtime {
     fn drop(&mut self) {
-        tracing::debug!("dropping runtime");
+        tracing::trace!(covmark = "socket2_runtime_drop");
+
         self.is_terminated.store(true, Ordering::SeqCst);
+
         let _ = self // ignore errors, cannot handle it here
             .poller
             .notify()
             .map_err(|e| tracing::error!("failed to notify poller: {:?}", e));
-        // event loop will terminate after this
-        // register loop will terminate because of sender is dropped after this.
+
+        // Event loop will terminate after this.
+        // The register loop will also terminate because of sender is dropped.
     }
 }
 

--- a/crates/tracing-cov-mark/Cargo.toml
+++ b/crates/tracing-cov-mark/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "tracing-cov-mark"
+version = "0.0.0"
+authors = ["Devolutions Inc. <infos@devolutions.net>"]
+edition = "2021"
+publish = false
+
+[dependencies]
+tracing = "0.1"

--- a/crates/tracing-cov-mark/src/lib.rs
+++ b/crates/tracing-cov-mark/src/lib.rs
@@ -1,0 +1,93 @@
+use std::sync::{Arc, Mutex};
+
+use tracing::span;
+
+#[derive(Clone, Debug)]
+pub struct CovMarkSubscriber {
+    records: Arc<Mutex<Vec<String>>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CovMarkHandle {
+    records: Arc<Mutex<Vec<String>>>,
+}
+
+#[derive(Clone, Debug)]
+struct CovMarkVisitor {
+    records: Arc<Mutex<Vec<String>>>,
+}
+
+pub fn init_cov_mark() -> (CovMarkHandle, tracing::subscriber::DefaultGuard) {
+    let subscriber = CovMarkSubscriber::new();
+    let cov_handle = subscriber.handle();
+    let default_guard = tracing::subscriber::set_default(subscriber);
+    (cov_handle, default_guard)
+}
+
+impl CovMarkSubscriber {
+    pub fn new() -> Self {
+        Self {
+            records: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn handle(&self) -> CovMarkHandle {
+        CovMarkHandle {
+            records: self.records.clone(),
+        }
+    }
+}
+
+impl Default for CovMarkSubscriber {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl tracing::Subscriber for CovMarkSubscriber {
+    fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+
+    fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut visitor = CovMarkVisitor {
+            records: self.records.clone(),
+        };
+        event.record(&mut visitor);
+    }
+
+    fn enter(&self, _span: &span::Id) {}
+
+    fn exit(&self, _span: &span::Id) {}
+}
+
+impl CovMarkHandle {
+    #[track_caller]
+    pub fn assert_mark(&self, covmark: &str) {
+        let mut guard = self.records.lock().unwrap();
+        let idx = guard
+            .iter()
+            .enumerate()
+            .find_map(|(idx, mark)| (mark.as_str() == covmark).then_some(idx))
+            .expect("coverage marker not emitted");
+        guard.remove(idx);
+    }
+}
+
+impl tracing::field::Visit for CovMarkVisitor {
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "covmark" {
+            self.records.lock().unwrap().push(value.to_owned());
+        }
+    }
+}

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -107,3 +107,4 @@ proptest = "1.3"
 rstest = "0.18"
 devolutions-gateway-generators = { path = "../crates/devolutions-gateway-generators" }
 http-body-util = "0.1"
+tracing-cov-mark = { path = "../crates/tracing-cov-mark" }


### PR DESCRIPTION
@irvingoujAtDevolution this is what I mentioned you earlier this week.
We can assert that some code path has been exercised using this tracing subscriber and helper.