### PR TITLE
refactor(dgw): fix clippy warning

### DIFF
--- a/devolutions-gateway/src/tls.rs
+++ b/devolutions-gateway/src/tls.rs
@@ -142,7 +142,7 @@ pub mod windows {
                 .server_name()
                 .context("server name missing from ClientHello")?;
 
-            if !crate::utils::wildcard_host_match(&self.subject_name, &request_server_name) {
+            if !crate::utils::wildcard_host_match(&self.subject_name, request_server_name) {
                 warn!(
                     request_server_name,
                     expected_server_name = self.subject_name,


### PR DESCRIPTION
fix made by clippy with version 0.1.14
```
PS C:\Users\jou\code\devolutions-gateway> cargo clippy --version
clippy 0.1.74 (a28077b2 2023-12-04)
PS C:\Users\jou\code\devolutions-gateway> cargo --version
cargo 1.74.1 (ecb9851af 2023-10-18)
PS C:\Users\jou\code\devolutions-gateway> rustup --version      
rustup 1.26.0 (5af9b9484 2023-04-05)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.74.1 (a28077b28 2023-12-04)`
```