### PR TITLE
feat(installer): installer revision based on feedback

### DIFF
--- a/package/WindowsManaged/Dialogs/AccessUriDialog.cs
+++ b/package/WindowsManaged/Dialogs/AccessUriDialog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using DevolutionsGateway.Actions;
 using DevolutionsGateway.Dialogs;
 using DevolutionsGateway.Helpers;
@@ -10,7 +11,7 @@ namespace WixSharpSetup.Dialogs
 {
     public partial class AccessUriDialog : GatewayDialog
     {
-        private static readonly string MachineName = Environment.MachineName;
+        private static readonly string MachineName = Dns.GetHostEntry(Environment.MachineName).HostName;
 
         private static readonly string[] Protocols = { Constants.HttpProtocol, Constants.HttpsProtocol };
 
@@ -38,7 +39,7 @@ namespace WixSharpSetup.Dialogs
             {
                 this.txtHostname.Text = 
                     this.cmbProtocol.SelectedValue.ToString() == Constants.HttpsProtocol ? 
-                    Environment.MachineName : "localhost";
+                    MachineName : "localhost";
             }
         }
 

--- a/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
@@ -38,6 +38,18 @@ namespace WixSharpSetup.Dialogs
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.middlePanel = new System.Windows.Forms.Panel();
+            this.gbExternal = new System.Windows.Forms.GroupBox();
+            this.pnlExternal = new System.Windows.Forms.TableLayoutPanel();
+            this.butBrowsePrivateKeyFile = new System.Windows.Forms.Button();
+            this.txtPrivateKeyFile = new System.Windows.Forms.TextBox();
+            this.txtCertificatePassword = new System.Windows.Forms.TextBox();
+            this.lblPrivateKeyFile = new System.Windows.Forms.Label();
+            this.lblCertificatePassword = new System.Windows.Forms.Label();
+            this.lblCertificateFile = new System.Windows.Forms.Label();
+            this.txtCertificateFile = new System.Windows.Forms.TextBox();
+            this.butBrowseCertificateFile = new System.Windows.Forms.Button();
+            this.lblHint = new System.Windows.Forms.Label();
+            this.lblCertificateFormats = new System.Windows.Forms.Label();
             this.gbSystem = new System.Windows.Forms.GroupBox();
             this.pnlSystem = new System.Windows.Forms.TableLayoutPanel();
             this.lblCertificateDescription = new System.Windows.Forms.Label();
@@ -52,17 +64,6 @@ namespace WixSharpSetup.Dialogs
             this.txtSearch = new System.Windows.Forms.TextBox();
             this.butSearchCertificate = new System.Windows.Forms.Button();
             this.butViewCertificate = new System.Windows.Forms.Button();
-            this.gbExternal = new System.Windows.Forms.GroupBox();
-            this.pnlExternal = new System.Windows.Forms.TableLayoutPanel();
-            this.butBrowsePrivateKeyFile = new System.Windows.Forms.Button();
-            this.txtPrivateKeyFile = new System.Windows.Forms.TextBox();
-            this.txtCertificatePassword = new System.Windows.Forms.TextBox();
-            this.lblPrivateKeyFile = new System.Windows.Forms.Label();
-            this.lblCertificatePassword = new System.Windows.Forms.Label();
-            this.lblCertificateFile = new System.Windows.Forms.Label();
-            this.txtCertificateFile = new System.Windows.Forms.TextBox();
-            this.butBrowseCertificateFile = new System.Windows.Forms.Button();
-            this.lblHint = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.cmbCertificateSource = new System.Windows.Forms.ComboBox();
             this.topBorder = new System.Windows.Forms.Panel();
@@ -78,10 +79,10 @@ namespace WixSharpSetup.Dialogs
             this.border1 = new System.Windows.Forms.Panel();
             this.contextMenuStrip1.SuspendLayout();
             this.middlePanel.SuspendLayout();
-            this.gbSystem.SuspendLayout();
-            this.pnlSystem.SuspendLayout();
             this.gbExternal.SuspendLayout();
             this.pnlExternal.SuspendLayout();
+            this.gbSystem.SuspendLayout();
+            this.pnlSystem.SuspendLayout();
             this.topPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).BeginInit();
             this.bottomPanel.SuspendLayout();
@@ -114,6 +115,160 @@ namespace WixSharpSetup.Dialogs
             this.middlePanel.Name = "middlePanel";
             this.middlePanel.Size = new System.Drawing.Size(494, 261);
             this.middlePanel.TabIndex = 0;
+            // 
+            // gbExternal
+            // 
+            this.gbExternal.Controls.Add(this.pnlExternal);
+            this.gbExternal.Location = new System.Drawing.Point(12, 34);
+            this.gbExternal.Name = "gbExternal";
+            this.gbExternal.Size = new System.Drawing.Size(470, 164);
+            this.gbExternal.TabIndex = 1;
+            this.gbExternal.TabStop = false;
+            this.gbExternal.Text = "[BrowseForACertificateToUse]";
+            // 
+            // pnlExternal
+            // 
+            this.pnlExternal.ColumnCount = 3;
+            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
+            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.pnlExternal.Controls.Add(this.butBrowsePrivateKeyFile, 2, 5);
+            this.pnlExternal.Controls.Add(this.txtPrivateKeyFile, 1, 5);
+            this.pnlExternal.Controls.Add(this.txtCertificatePassword, 1, 3);
+            this.pnlExternal.Controls.Add(this.lblPrivateKeyFile, 0, 5);
+            this.pnlExternal.Controls.Add(this.lblCertificatePassword, 0, 3);
+            this.pnlExternal.Controls.Add(this.lblCertificateFile, 0, 1);
+            this.pnlExternal.Controls.Add(this.txtCertificateFile, 1, 1);
+            this.pnlExternal.Controls.Add(this.butBrowseCertificateFile, 2, 1);
+            this.pnlExternal.Controls.Add(this.lblHint, 1, 6);
+            this.pnlExternal.Controls.Add(this.lblCertificateFormats, 1, 2);
+            this.pnlExternal.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.pnlExternal.Location = new System.Drawing.Point(3, 16);
+            this.pnlExternal.Name = "pnlExternal";
+            this.pnlExternal.RowCount = 7;
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.pnlExternal.Size = new System.Drawing.Size(464, 145);
+            this.pnlExternal.TabIndex = 8;
+            // 
+            // butBrowsePrivateKeyFile
+            // 
+            this.butBrowsePrivateKeyFile.Location = new System.Drawing.Point(434, 105);
+            this.butBrowsePrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.butBrowsePrivateKeyFile.Name = "butBrowsePrivateKeyFile";
+            this.butBrowsePrivateKeyFile.Size = new System.Drawing.Size(27, 20);
+            this.butBrowsePrivateKeyFile.TabIndex = 4;
+            this.butBrowsePrivateKeyFile.Text = "...";
+            this.butBrowsePrivateKeyFile.UseVisualStyleBackColor = true;
+            this.butBrowsePrivateKeyFile.Click += new System.EventHandler(this.butBrowsePrivateKeyFile_Click);
+            // 
+            // txtPrivateKeyFile
+            // 
+            this.txtPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtPrivateKeyFile.Location = new System.Drawing.Point(153, 105);
+            this.txtPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtPrivateKeyFile.Name = "txtPrivateKeyFile";
+            this.txtPrivateKeyFile.Size = new System.Drawing.Size(275, 20);
+            this.txtPrivateKeyFile.TabIndex = 3;
+            // 
+            // txtCertificatePassword
+            // 
+            this.pnlExternal.SetColumnSpan(this.txtCertificatePassword, 2);
+            this.txtCertificatePassword.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtCertificatePassword.Location = new System.Drawing.Point(153, 71);
+            this.txtCertificatePassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtCertificatePassword.Name = "txtCertificatePassword";
+            this.txtCertificatePassword.Size = new System.Drawing.Size(308, 20);
+            this.txtCertificatePassword.TabIndex = 2;
+            this.txtCertificatePassword.UseSystemPasswordChar = true;
+            this.txtCertificatePassword.Visible = false;
+            // 
+            // lblPrivateKeyFile
+            // 
+            this.lblPrivateKeyFile.AutoSize = true;
+            this.lblPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblPrivateKeyFile.Location = new System.Drawing.Point(3, 105);
+            this.lblPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblPrivateKeyFile.Name = "lblPrivateKeyFile";
+            this.lblPrivateKeyFile.Size = new System.Drawing.Size(144, 26);
+            this.lblPrivateKeyFile.TabIndex = 4;
+            this.lblPrivateKeyFile.Text = "[CertificateDlgCertKeyFileLabel]";
+            this.lblPrivateKeyFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // lblCertificatePassword
+            // 
+            this.lblCertificatePassword.AutoSize = true;
+            this.lblCertificatePassword.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblCertificatePassword.Location = new System.Drawing.Point(3, 71);
+            this.lblCertificatePassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblCertificatePassword.Name = "lblCertificatePassword";
+            this.lblCertificatePassword.Size = new System.Drawing.Size(144, 26);
+            this.lblCertificatePassword.TabIndex = 7;
+            this.lblCertificatePassword.Text = "[CertificateDlgCertPasswordLabel]";
+            this.lblCertificatePassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.lblCertificatePassword.Visible = false;
+            // 
+            // lblCertificateFile
+            // 
+            this.lblCertificateFile.AutoSize = true;
+            this.lblCertificateFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblCertificateFile.Location = new System.Drawing.Point(3, 3);
+            this.lblCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblCertificateFile.Name = "lblCertificateFile";
+            this.lblCertificateFile.Size = new System.Drawing.Size(144, 20);
+            this.lblCertificateFile.TabIndex = 1;
+            this.lblCertificateFile.Text = "[CertificateDlgCertFileLabel]";
+            this.lblCertificateFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // txtCertificateFile
+            // 
+            this.txtCertificateFile.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtCertificateFile.Location = new System.Drawing.Point(153, 3);
+            this.txtCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.txtCertificateFile.Name = "txtCertificateFile";
+            this.txtCertificateFile.Size = new System.Drawing.Size(275, 20);
+            this.txtCertificateFile.TabIndex = 0;
+            this.txtCertificateFile.TextChanged += new System.EventHandler(this.txtCertificateFile_TextChanged);
+            // 
+            // butBrowseCertificateFile
+            // 
+            this.butBrowseCertificateFile.Location = new System.Drawing.Point(434, 3);
+            this.butBrowseCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.butBrowseCertificateFile.Name = "butBrowseCertificateFile";
+            this.butBrowseCertificateFile.Size = new System.Drawing.Size(27, 20);
+            this.butBrowseCertificateFile.TabIndex = 1;
+            this.butBrowseCertificateFile.Text = "...";
+            this.butBrowseCertificateFile.UseVisualStyleBackColor = true;
+            this.butBrowseCertificateFile.Click += new System.EventHandler(this.butBrowseCertificateFile_Click);
+            // 
+            // lblHint
+            // 
+            this.lblHint.AutoSize = true;
+            this.pnlExternal.SetColumnSpan(this.lblHint, 2);
+            this.lblHint.Dock = System.Windows.Forms.DockStyle.Top;
+            this.lblHint.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblHint.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblHint.Location = new System.Drawing.Point(153, 136);
+            this.lblHint.Name = "lblHint";
+            this.lblHint.Size = new System.Drawing.Size(308, 13);
+            this.lblHint.TabIndex = 8;
+            // 
+            // lblCertificateFormats
+            // 
+            this.pnlExternal.SetColumnSpan(this.lblCertificateFormats, 2);
+            this.lblCertificateFormats.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblCertificateFormats.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblCertificateFormats.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.lblCertificateFormats.Location = new System.Drawing.Point(153, 28);
+            this.lblCertificateFormats.Name = "lblCertificateFormats";
+            this.lblCertificateFormats.Size = new System.Drawing.Size(308, 40);
+            this.lblCertificateFormats.TabIndex = 9;
+            this.lblCertificateFormats.Text = "[AnX509CertificateInBinaryOrPemEncoded]";
             // 
             // gbSystem
             // 
@@ -302,148 +457,6 @@ namespace WixSharpSetup.Dialogs
             this.butViewCertificate.Visible = false;
             this.butViewCertificate.Click += new System.EventHandler(this.butViewCertificate_Click);
             // 
-            // gbExternal
-            // 
-            this.gbExternal.Controls.Add(this.pnlExternal);
-            this.gbExternal.Location = new System.Drawing.Point(12, 34);
-            this.gbExternal.Name = "gbExternal";
-            this.gbExternal.Size = new System.Drawing.Size(470, 128);
-            this.gbExternal.TabIndex = 1;
-            this.gbExternal.TabStop = false;
-            this.gbExternal.Text = "[BrowseForACertificateToUse]";
-            // 
-            // pnlExternal
-            // 
-            this.pnlExternal.ColumnCount = 3;
-            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 150F));
-            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.pnlExternal.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.pnlExternal.Controls.Add(this.butBrowsePrivateKeyFile, 2, 5);
-            this.pnlExternal.Controls.Add(this.txtPrivateKeyFile, 1, 5);
-            this.pnlExternal.Controls.Add(this.txtCertificatePassword, 1, 3);
-            this.pnlExternal.Controls.Add(this.lblPrivateKeyFile, 0, 5);
-            this.pnlExternal.Controls.Add(this.lblCertificatePassword, 0, 3);
-            this.pnlExternal.Controls.Add(this.lblCertificateFile, 0, 1);
-            this.pnlExternal.Controls.Add(this.txtCertificateFile, 1, 1);
-            this.pnlExternal.Controls.Add(this.butBrowseCertificateFile, 2, 1);
-            this.pnlExternal.Controls.Add(this.lblHint, 1, 6);
-            this.pnlExternal.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pnlExternal.Location = new System.Drawing.Point(3, 16);
-            this.pnlExternal.Name = "pnlExternal";
-            this.pnlExternal.RowCount = 6;
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.pnlExternal.Size = new System.Drawing.Size(464, 109);
-            this.pnlExternal.TabIndex = 8;
-            // 
-            // butBrowsePrivateKeyFile
-            // 
-            this.butBrowsePrivateKeyFile.Location = new System.Drawing.Point(434, 65);
-            this.butBrowsePrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.butBrowsePrivateKeyFile.Name = "butBrowsePrivateKeyFile";
-            this.butBrowsePrivateKeyFile.Size = new System.Drawing.Size(27, 20);
-            this.butBrowsePrivateKeyFile.TabIndex = 4;
-            this.butBrowsePrivateKeyFile.Text = "...";
-            this.butBrowsePrivateKeyFile.UseVisualStyleBackColor = true;
-            this.butBrowsePrivateKeyFile.Click += new System.EventHandler(this.butBrowsePrivateKeyFile_Click);
-            // 
-            // txtPrivateKeyFile
-            // 
-            this.txtPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtPrivateKeyFile.Location = new System.Drawing.Point(153, 65);
-            this.txtPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.txtPrivateKeyFile.Name = "txtPrivateKeyFile";
-            this.txtPrivateKeyFile.Size = new System.Drawing.Size(275, 20);
-            this.txtPrivateKeyFile.TabIndex = 3;
-            // 
-            // txtCertificatePassword
-            // 
-            this.pnlExternal.SetColumnSpan(this.txtCertificatePassword, 2);
-            this.txtCertificatePassword.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtCertificatePassword.Location = new System.Drawing.Point(153, 31);
-            this.txtCertificatePassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.txtCertificatePassword.Name = "txtCertificatePassword";
-            this.txtCertificatePassword.Size = new System.Drawing.Size(308, 20);
-            this.txtCertificatePassword.TabIndex = 2;
-            this.txtCertificatePassword.UseSystemPasswordChar = true;
-            this.txtCertificatePassword.Visible = false;
-            // 
-            // lblPrivateKeyFile
-            // 
-            this.lblPrivateKeyFile.AutoSize = true;
-            this.lblPrivateKeyFile.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblPrivateKeyFile.Location = new System.Drawing.Point(3, 65);
-            this.lblPrivateKeyFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.lblPrivateKeyFile.Name = "lblPrivateKeyFile";
-            this.lblPrivateKeyFile.Size = new System.Drawing.Size(144, 26);
-            this.lblPrivateKeyFile.TabIndex = 4;
-            this.lblPrivateKeyFile.Text = "[CertificateDlgCertKeyFileLabel]";
-            this.lblPrivateKeyFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // lblCertificatePassword
-            // 
-            this.lblCertificatePassword.AutoSize = true;
-            this.lblCertificatePassword.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblCertificatePassword.Location = new System.Drawing.Point(3, 31);
-            this.lblCertificatePassword.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.lblCertificatePassword.Name = "lblCertificatePassword";
-            this.lblCertificatePassword.Size = new System.Drawing.Size(144, 26);
-            this.lblCertificatePassword.TabIndex = 7;
-            this.lblCertificatePassword.Text = "[CertificateDlgCertPasswordLabel]";
-            this.lblCertificatePassword.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.lblCertificatePassword.Visible = false;
-            // 
-            // lblCertificateFile
-            // 
-            this.lblCertificateFile.AutoSize = true;
-            this.lblCertificateFile.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.lblCertificateFile.Location = new System.Drawing.Point(3, 3);
-            this.lblCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.lblCertificateFile.Name = "lblCertificateFile";
-            this.lblCertificateFile.Size = new System.Drawing.Size(144, 20);
-            this.lblCertificateFile.TabIndex = 1;
-            this.lblCertificateFile.Text = "[CertificateDlgCertFileLabel]";
-            this.lblCertificateFile.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // txtCertificateFile
-            // 
-            this.txtCertificateFile.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtCertificateFile.Location = new System.Drawing.Point(153, 3);
-            this.txtCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.txtCertificateFile.Name = "txtCertificateFile";
-            this.txtCertificateFile.Size = new System.Drawing.Size(275, 20);
-            this.txtCertificateFile.TabIndex = 0;
-            this.txtCertificateFile.TextChanged += new System.EventHandler(this.txtCertificateFile_TextChanged);
-            // 
-            // butBrowseCertificateFile
-            // 
-            this.butBrowseCertificateFile.Location = new System.Drawing.Point(434, 3);
-            this.butBrowseCertificateFile.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.butBrowseCertificateFile.Name = "butBrowseCertificateFile";
-            this.butBrowseCertificateFile.Size = new System.Drawing.Size(27, 20);
-            this.butBrowseCertificateFile.TabIndex = 1;
-            this.butBrowseCertificateFile.Text = "...";
-            this.butBrowseCertificateFile.UseVisualStyleBackColor = true;
-            this.butBrowseCertificateFile.Click += new System.EventHandler(this.butBrowseCertificateFile_Click);
-            // 
-            // lblHint
-            // 
-            this.lblHint.AutoSize = true;
-            this.pnlExternal.SetColumnSpan(this.lblHint, 2);
-            this.lblHint.Dock = System.Windows.Forms.DockStyle.Top;
-            this.lblHint.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblHint.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblHint.Location = new System.Drawing.Point(153, 96);
-            this.lblHint.Name = "lblHint";
-            this.lblHint.Size = new System.Drawing.Size(308, 13);
-            this.lblHint.TabIndex = 8;
-            // 
             // label5
             // 
             this.label5.AutoSize = true;
@@ -611,12 +624,12 @@ namespace WixSharpSetup.Dialogs
             this.contextMenuStrip1.ResumeLayout(false);
             this.middlePanel.ResumeLayout(false);
             this.middlePanel.PerformLayout();
-            this.gbSystem.ResumeLayout(false);
-            this.pnlSystem.ResumeLayout(false);
-            this.pnlSystem.PerformLayout();
             this.gbExternal.ResumeLayout(false);
             this.pnlExternal.ResumeLayout(false);
             this.pnlExternal.PerformLayout();
+            this.gbSystem.ResumeLayout(false);
+            this.pnlSystem.ResumeLayout(false);
+            this.pnlSystem.PerformLayout();
             this.topPanel.ResumeLayout(false);
             this.topPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).EndInit();
@@ -670,5 +683,6 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.TextBox txtCertificatePassword;
         private System.Windows.Forms.Label lblPrivateKeyFile;
         private System.Windows.Forms.Label lblCertificatePassword;
+        private System.Windows.Forms.Label lblCertificateFormats;
     }
 }

--- a/package/WindowsManaged/Dialogs/CertificateDialog.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.cs
@@ -13,6 +13,7 @@ using static DevolutionsGateway.Properties.Constants;
 using File = System.IO.File;
 using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
 using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
+using DevolutionsGateway.Actions;
 
 namespace WixSharpSetup.Dialogs;
 
@@ -153,7 +154,9 @@ public partial class CertificateDialog : GatewayDialog
     public override void OnLoad(object sender, EventArgs e)
     {
         banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
-        
+
+        WinAPI.SendMessage(this.txtSearch.Handle, WinAPI.EM_SETCUEBANNER, 0, I18n(Strings.EnterTextToSearch));
+
         this.cmbCertificateSource.Source<CertificateMode>(this.MsiRuntime);
         this.cmbCertificateSource.SetSelected(CertificateMode.External);
 

--- a/package/WindowsManaged/Dialogs/ListenersDialog.cs
+++ b/package/WindowsManaged/Dialogs/ListenersDialog.cs
@@ -80,10 +80,16 @@ public partial class ListenersDialog : GatewayDialog
             TcpListenerPort = Convert.ToUInt32(this.txtTcpPort.Text.Trim())
         };
 
+        // If the user hasn't customized the Access URI port, let's make it match
+        // the HTTP listener
         if (properties.AccessUriPort == GatewayProperties.accessUriPort.Default)
         {
             properties.AccessUriPort = properties.HttpListenerPort;
         }
+
+        // Generally they should match, so let's change that for the user
+        // They can adjust this on the Access URI page if needed
+        properties.AccessUriScheme = properties.HttpListenerScheme;
 
         return true;
     }

--- a/package/WindowsManaged/Dialogs/PublicKeyDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/PublicKeyDialog.Designer.cs
@@ -45,6 +45,7 @@ namespace WixSharpSetup.Dialogs
             this.butBrowsePublicKeyFile = new System.Windows.Forms.Button();
             this.lblPublicKeyFile = new System.Windows.Forms.Label();
             this.txtPublicKeyFile = new System.Windows.Forms.TextBox();
+            this.lnkKeyHint = new System.Windows.Forms.LinkLabel();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
@@ -101,6 +102,7 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2.Controls.Add(this.butBrowsePublicKeyFile, 2, 1);
             this.tableLayoutPanel2.Controls.Add(this.lblPublicKeyFile, 0, 1);
             this.tableLayoutPanel2.Controls.Add(this.txtPublicKeyFile, 1, 1);
+            this.tableLayoutPanel2.Controls.Add(this.lnkKeyHint, 0, 5);
             this.tableLayoutPanel2.Location = new System.Drawing.Point(22, 17);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
             this.tableLayoutPanel2.RowCount = 6;
@@ -110,7 +112,7 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 40F));
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 192);
+            this.tableLayoutPanel2.Size = new System.Drawing.Size(449, 219);
             this.tableLayoutPanel2.TabIndex = 2;
             // 
             // lblKeysDescription
@@ -210,6 +212,20 @@ namespace WixSharpSetup.Dialogs
             this.txtPublicKeyFile.Name = "txtPublicKeyFile";
             this.txtPublicKeyFile.Size = new System.Drawing.Size(260, 20);
             this.txtPublicKeyFile.TabIndex = 0;
+            // 
+            // lnkKeyHint
+            // 
+            this.tableLayoutPanel2.SetColumnSpan(this.lnkKeyHint, 3);
+            this.lnkKeyHint.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lnkKeyHint.Location = new System.Drawing.Point(3, 176);
+            this.lnkKeyHint.Name = "lnkKeyHint";
+            this.lnkKeyHint.Size = new System.Drawing.Size(443, 43);
+            this.lnkKeyHint.TabIndex = 16;
+            this.lnkKeyHint.TabStop = true;
+            this.lnkKeyHint.Text = "Find the public key file for Devolutions Server or Devolutions Hub";
+            this.lnkKeyHint.TextAlign = System.Drawing.ContentAlignment.BottomRight;
+            this.lnkKeyHint.Visible = false;
+            this.lnkKeyHint.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.lnkKeyHint_LinkClicked);
             // 
             // topBorder
             // 
@@ -396,5 +412,6 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.Label lblPublicKeyDescription;
         private System.Windows.Forms.Label lblPublicKeyFile;
         private System.Windows.Forms.Label lblKeysDescription;
+        private System.Windows.Forms.LinkLabel lnkKeyHint;
     }
 }

--- a/package/WindowsManaged/Dialogs/PublicKeyDialog.cs
+++ b/package/WindowsManaged/Dialogs/PublicKeyDialog.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Diagnostics;
 using System.Windows.Forms;
 using DevolutionsGateway.Dialogs;
+using DevolutionsGateway.Helpers;
 using DevolutionsGateway.Properties;
 using DevolutionsGateway.Resources;
 using WixSharp;
@@ -51,10 +53,12 @@ public partial class PublicKeyDialog : GatewayDialog
         if (properties.ConfigureWebApp)
         {
             this.lblKeysDescription.Text = I18n(Strings.ProvideAnEncryptionKeyPairForTokenCreationVerification);
+            this.lnkKeyHint.Visible = false;
         }
         else
         {
             this.lblKeysDescription.Text = I18n(Strings.ProvideAPublicKeyForTokenVerification);
+            this.lnkKeyHint.Visible = true;
         }
 
         this.SetControlStates();
@@ -85,6 +89,8 @@ public partial class PublicKeyDialog : GatewayDialog
     public override void OnLoad(object sender, EventArgs e)
     {
         banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
+
+        this.lnkKeyHint.SetLink(this.MsiRuntime, Strings.FindYourPublicKeyForXorX, Strings.FindYourPublicKeyDevolutionsServerLink, Strings.FindYourPublicKeyDevolutionsHubLink);
 
         base.OnLoad(sender, e);
     }
@@ -134,5 +140,24 @@ public partial class PublicKeyDialog : GatewayDialog
         ofd.Filter = filter;
 
         return ofd.ShowDialog(this) == DialogResult.OK ? ofd.FileName : null;
+    }
+
+    private void lnkKeyHint_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+    {
+        string address = null;
+
+        if (e.Link.Tag.ToString() == Strings.FindYourPublicKeyDevolutionsServerLink)
+        {
+            address = Constants.DevolutionsServerHelpLink;
+        }
+        else if (e.Link.Tag.ToString() == Strings.FindYourPublicKeyDevolutionsHubLink)
+        {
+            address = Constants.DevolutionsHubHelpLink;
+        }
+
+        if (address is not null)
+        {
+            Process.Start(address);
+        }
     }
 }

--- a/package/WindowsManaged/Helpers/Localization.cs
+++ b/package/WindowsManaged/Helpers/Localization.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Windows.Forms;
 using WixSharp;
+using static System.Windows.Forms.LinkLabel;
 
 namespace DevolutionsGateway.Helpers
 {
@@ -18,14 +19,27 @@ namespace DevolutionsGateway.Helpers
 
         internal static void SetSelected<T>(this ComboBox comboBox, T value) where T : Enum => comboBox.SelectedValue = value;
 
-        internal static void SetLink(this LinkLabel label, MsiRuntime runtime, string labelFormat, string linkText)
+        internal static void SetLink(this LinkLabel label, MsiRuntime runtime, string labelFormat, params string[] linkText)
         {
             string linkFormat = $"[{labelFormat}]".LocalizeWith(runtime.Localize);
-            string link = $"[{linkText}]".LocalizeWith(runtime.Localize);
 
-            label.Text = string.Format(linkFormat, link);
-            label.LinkArea = new LinkArea(label.Text.IndexOf(link, StringComparison.CurrentCulture), link.Length);
+            object[] localizedLinkText = new object[linkText.Length];
 
+            for (int i = 0; i < linkText.Length; i++)
+            {
+                localizedLinkText[i] = $"[{linkText[i]}]".LocalizeWith(runtime.Localize);
+            }
+            
+            label.Text = string.Format(linkFormat, localizedLinkText);
+
+            for (int i = 0; i < localizedLinkText.Length; i++)
+            {
+                string localizedLink = localizedLinkText[i].ToString();
+                Link link = new Link(label.Text.IndexOf(localizedLink, StringComparison.CurrentCulture),
+                    localizedLink.Length);
+                link.Tag = linkText[i];
+                label.Links.Add(link);
+            }
         }
     }
 }

--- a/package/WindowsManaged/Program.cs
+++ b/package/WindowsManaged/Program.cs
@@ -389,6 +389,11 @@ internal class Program
         Version thisVersion = e.Session.QueryProductVersion();
         Version installedVersion = Helpers.AppSearch.InstalledVersion;
 
+        if (installedVersion is null)
+        {
+            e.Session.Set(GatewayProperties.configureGateway, true);
+        }
+
         if (thisVersion < installedVersion)
         {
             MessageBox.Show($"{I18n(Strings.NewerInstalled)} ({installedVersion})");
@@ -425,8 +430,6 @@ internal class Program
                 Process.Start("https://go.microsoft.com/fwlink/?LinkId=2085155");
             }
         }
-
-        e.Session.Set(GatewayProperties.configureGateway, true);
 
         e.ManagedUI.OnCurrentDialogChanged += Wizard.DialogChanged;
     }

--- a/package/WindowsManaged/Properties/Constants.cs
+++ b/package/WindowsManaged/Properties/Constants.cs
@@ -27,5 +27,9 @@
         internal const string NgrokDomainsUrl = "https://dashboard.ngrok.com/cloud-edge/domains";
 
         internal const string NgrokTcpAddressesUrl = "https://dashboard.ngrok.com/cloud-edge/tcp-addresses";
+
+        internal const string DevolutionsServerHelpLink = "https://docs.devolutions.net/server/dgw/server-configuration/";
+
+        internal const string DevolutionsHubHelpLink = "https://docs.devolutions.net/hub/dgw/hub-business-configuration/install-manually/";
     }
 }

--- a/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
@@ -30,6 +30,9 @@
                 <String Id="YouMustProvideAValidHostname">You must provide a valid hostname</String>
                 <String Id="YouMustSelectACertificateFromTheSystemCertificateStore">You must select a certificate from the system certificate store</String>
                     <!-- links -->
+                <String Id="FindYourPublicKeyDevolutionsHubLink">Devolutions Hub</String>
+                <String Id="FindYourPublicKeyDevolutionsServerLink">Devolutions Server</String>
+                <String Id="FindYourPublicKeyForXorX">Find your public key for {0} or {1}</String>
                 <String Id="NgrokAuthTokenLink">authentication token</String>
                 <String Id="NgrokDomainLink">domain</String>
                 <String Id="NgrokProvideYourX">Provide your {0}</String>
@@ -146,6 +149,7 @@ If it appears minimized then active it from the taskbar.</String>
                 <String Id="AccessUriDlgHttpWarn">An insecure external URI is not recommended for production environments</String>
                 <String Id="AccessUriDlgTitle">External URL</String>
                     <!-- dialogs.certificate -->
+                <String Id="AnX509CertificateInBinaryOrPemEncoded">An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded</String>
                 <String Id="BrowseForACertificateToUse">Browse for a certificate to use</String>
                 <String Id="CertificateDlgCertConfigLabel">Certificate Configuration</String>
                 <String Id="CertificateDlgCertFileLabel">Certificate File</String>
@@ -156,6 +160,7 @@ If it appears minimized then active it from the taskbar.</String>
                 <String Id="CertificateSource">Certificate Source</String>
                 <String Id="CertificateStore">Certificate Store</String>
                 <String Id="EncryptedPrivateKeysAreNotSupported">Encrypted private keys are not supported</String>
+                <String Id="EnterTextToSearch">Enter text to search</String>
                 <String Id="Search">Search</String>
                 <String Id="SearchBy">Search By</String>
                 <String Id="SearchForACertificateToUse">Search for a certificate to use</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
@@ -58,6 +58,7 @@
                 <String Id="CertificateDlgCertPasswordLabel">Mot de passe du certificat</String>
                 <String Id="CertificateDlgDescription">Un certificat est nécessaire pour utiliser HTTPS.</String>
                 <String Id="CertificateDlgTitle">Certificat</String>
+                <String Id="EnterTextToSearch">Saisir le texte à rechercher</String>
                     <!-- dialogs.listeners -->
                 <String Id="ListenersDlgDescription">Écouteurs HTTP(S) et TCP.</String>
                 <String Id="ListenersDlgHTTPLabel">Écouteur HTTP</String>
@@ -78,6 +79,9 @@
                 <String Id="WixSchedFirewallExceptionsInstall">Configuration du Pare-feu Windows</String>
                 <String Id="WixSchedFirewallExceptionsUninstall">Configuration du Pare-feu Windows</String>
                     <!-- links.- -->
+                <String Id="FindYourPublicKeyDevolutionsHubLink">Devolutions Hub</String>
+                <String Id="FindYourPublicKeyDevolutionsServerLink">Devolutions Server</String>
+                <String Id="FindYourPublicKeyForXorX">Find your public key for {0} or {1}</String>
                 <String Id="NgrokAuthTokenLink">authentication token</String>
                 <String Id="NgrokDomainLink">domain</String>
                 <String Id="NgrokProvideYourX">Provide your {0}</String>
@@ -194,6 +198,7 @@ If it appears minimized then active it from the taskbar.</String>
                 <String Id="AccessUriDlgExplanation">The URI to reach the Gateway externally for HTTP operations. This may differ from the HTTP listener address in certain cases (for example, when using a reverse proxy such as IIS).</String>
                 <String Id="AccessUriDlgHttpWarn">An insecure external URI is not recommended for production environments</String>
                     <!-- dialogs.certificate.- -->
+                <String Id="AnX509CertificateInBinaryOrPemEncoded">An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded</String>
                 <String Id="BrowseForACertificateToUse">Browse for a certificate to use</String>
                 <String Id="CertificateSource">Certificate Source</String>
                 <String Id="CertificateStore">Certificate Store</String>

--- a/package/WindowsManaged/Resources/Strings.g.cs
+++ b/package/WindowsManaged/Resources/Strings.g.cs
@@ -117,6 +117,18 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string WindowsPowerShell51IsRequired = "WindowsPowerShell51IsRequired";		
 		/// <summary>
+		/// Find your public key for {0} or {1}
+		/// </summary>
+		public const string FindYourPublicKeyForXorX = "FindYourPublicKeyForXorX";		
+		/// <summary>
+		/// Devolutions Server
+		/// </summary>
+		public const string FindYourPublicKeyDevolutionsServerLink = "FindYourPublicKeyDevolutionsServerLink";		
+		/// <summary>
+		/// Devolutions Hub
+		/// </summary>
+		public const string FindYourPublicKeyDevolutionsHubLink = "FindYourPublicKeyDevolutionsHubLink";		
+		/// <summary>
 		/// Read more at {0}
 		/// </summary>
 		public const string NgrokReadMoreAtX = "NgrokReadMoreAtX";		
@@ -541,6 +553,10 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string CertificateSource = "CertificateSource";		
 		/// <summary>
+		/// Enter text to search
+		/// </summary>
+		public const string EnterTextToSearch = "EnterTextToSearch";		
+		/// <summary>
 		/// Search for a certificate to use
 		/// </summary>
 		public const string SearchForACertificateToUse = "SearchForACertificateToUse";		
@@ -576,6 +592,10 @@ namespace DevolutionsGateway.Resources
 		/// Select the certificate to use
 		/// </summary>
 		public const string SelectTheCertificateToUse = "SelectTheCertificateToUse";		
+		/// <summary>
+		/// An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded
+		/// </summary>
+		public const string AnX509CertificateInBinaryOrPemEncoded = "AnX509CertificateInBinaryOrPemEncoded";		
 		/// <summary>
 		/// Listeners
 		/// </summary>

--- a/package/WindowsManaged/Resources/Strings_en-US.json
+++ b/package/WindowsManaged/Resources/Strings_en-US.json
@@ -115,6 +115,18 @@
       ],
       "links": [
         {
+          "id": "FindYourPublicKeyForXorX",
+          "text": "Find your public key for {0} or {1}"
+        },
+        {
+          "id": "FindYourPublicKeyDevolutionsServerLink",
+          "text": "Devolutions Server"
+        },
+        {
+          "id": "FindYourPublicKeyDevolutionsHubLink",
+          "text": "Devolutions Hub"
+        },
+        {
           "id": "NgrokReadMoreAtX",
           "text": "Read more at {0}"
         },
@@ -571,6 +583,10 @@
             "text": "Certificate Source"
           },
           {
+            "id": "EnterTextToSearch",
+            "text": "Enter text to search"
+          },
+          {
             "id": "SearchForACertificateToUse",
             "text": "Search for a certificate to use"
           },
@@ -605,6 +621,10 @@
           {
             "id": "SelectTheCertificateToUse",
             "text": "Select the certificate to use"
+          },
+          {
+            "id": "AnX509CertificateInBinaryOrPemEncoded",
+            "text": "An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded"
           }
         ],
         "listeners": [

--- a/package/WindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/WindowsManaged/Resources/Strings_fr-FR.json
@@ -210,6 +210,10 @@
           {
             "id": "CertificateDlgCertKeyFileLabel",
             "text": "Fichier de clé privée"
+          },
+          {
+            "id": "EnterTextToSearch",
+            "text": "Saisir le texte à rechercher"
           }
         ],
         "listeners": [


### PR DESCRIPTION
Fixes an important installer bug (the customization UI should only be shown on a first install, not on upgrades).

Additionally, incorporated feedback items:

- The Access URI hostname will default to the FQDN of the machine if it's domain-joined (rather than just the NetBIOS name)
- Added an "Enter search text here" cue banner on the system certificate selection page
- Default the Access URI protocol to whatever was chosen for the HTTP listener. The user can still customize.
- If configuring as a "companion" install (i.e. no ngrok, no standalone web application) provide a hint linking to the Devolutions Server/Hub documentation on the encryption keys page ("Find your public key for [Devolutions Server](https://docs.devolutions.net/server/dgw/server-configuration/) or [Devolutions Hub](https://docs.devolutions.net/hub/dgw/hub-business-configuration/install-manually/)")
- Provide a help callout when configuring an external certificate, explaining the supported file formats
