### PR TITLE
fix(dgw): rename type for network scan to ap(application protocol)

### DIFF
--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -105,14 +105,14 @@ impl From<NetworkScanQueryParams> for NetworkScannerParams {
 pub struct NetworkScanResponse {
     pub ip: IpAddr,
     pub hostname: Option<String>,
-    pub ap: ApplicationProtocol,
+    pub protocol: ApplicationProtocol,
 }
 
 impl NetworkScanResponse {
     fn new(ip: IpAddr, port: u16, dns: Option<String>) -> Self {
         let hostname = dns;
 
-        let ap = match port {
+        let protocol = match port {
             22 => ApplicationProtocol::Known(Protocol::Ssh),
             23 => ApplicationProtocol::Known(Protocol::Telnet),
             80 => ApplicationProtocol::Known(Protocol::Http),
@@ -126,6 +126,6 @@ impl NetworkScanResponse {
             _ => ApplicationProtocol::unknown(),
         };
 
-        Self { ip, hostname, ap }
+        Self { ip, hostname, protocol }
     }
 }

--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -105,15 +105,14 @@ impl From<NetworkScanQueryParams> for NetworkScannerParams {
 pub struct NetworkScanResponse {
     pub ip: IpAddr,
     pub hostname: Option<String>,
-    #[serde(rename = "type")]
-    pub ty: ApplicationProtocol,
+    pub ap: ApplicationProtocol,
 }
 
 impl NetworkScanResponse {
     fn new(ip: IpAddr, port: u16, dns: Option<String>) -> Self {
         let hostname = dns;
 
-        let ty = match port {
+        let ap = match port {
             22 => ApplicationProtocol::Known(Protocol::Ssh),
             23 => ApplicationProtocol::Known(Protocol::Telnet),
             80 => ApplicationProtocol::Known(Protocol::Http),
@@ -127,6 +126,6 @@ impl NetworkScanResponse {
             _ => ApplicationProtocol::unknown(),
         };
 
-        Self { ip, hostname, ty }
+        Self { ip, hostname, ap }
     }
 }


### PR DESCRIPTION
rename type ty to ap, stay consistent with rest of the gateway