### PR TITLE
fix(dgw): add ARD to common ports to scan

### DIFF
--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -88,7 +88,7 @@ pub struct NetworkScanQueryParams {
     pub max_wait: Option<u64>,
 }
 
-const COMMON_PORTS: [u16; 10] = [22, 23, 80, 443, 389, 636, 3389, 5900, 5985, 5986];
+const COMMON_PORTS: [u16; 11] = [22, 23, 80, 443, 389, 636, 3283, 3389, 5900, 5985, 5986];
 
 impl From<NetworkScanQueryParams> for NetworkScannerParams {
     fn from(val: NetworkScanQueryParams) -> Self {
@@ -129,6 +129,7 @@ impl NetworkScanResponse {
             5900 => ApplicationProtocol::Known(Protocol::Vnc),
             5985 => ApplicationProtocol::Known(Protocol::WinrmHttpPwsh),
             5986 => ApplicationProtocol::Known(Protocol::WinrmHttpsPwsh),
+            3283 => ApplicationProtocol::Known(Protocol::Ard),
             _ => ApplicationProtocol::unknown(),
         };
 


### PR DESCRIPTION
Need to fix the fact that the service indentification is currently based on port. For mdns, the service type is given, so no need to do port to service mapping anymore. but that is a TODO in the future. 
For this PR, we just add the port 3283 to common ports.

edit: #702 allows service type obtained by mdns to be passed to the caller 