### PR TITLE
fix(dgw): forward protocol advertised by mDNS scanner

### DIFF
--- a/crates/network-scanner/examples/mdns.rs
+++ b/crates/network-scanner/examples/mdns.rs
@@ -12,12 +12,12 @@ pub async fn main() -> anyhow::Result<()> {
     let mut receiver = mdns::mdns_query_scan(
         mdns::MdnsDeamon::new()?,
         TaskManager::new(),
-        Duration::from_secs(20),
-        Duration::from_secs(5),
+        Duration::from_secs(50),
+        Duration::from_secs(10),
     )?;
 
-    while let Some((ip, server, port)) = receiver.recv().await {
-        tracing::info!("ip: {}, server: {:?}, port: {}", ip, server, port);
+    while let Some((ip, server, port, protocol)) = receiver.recv().await {
+        tracing::info!("Found: {}:{:?}:{}:{:?}", ip, server, port, protocol);
     }
 
     Ok(())

--- a/crates/network-scanner/examples/mdns.rs
+++ b/crates/network-scanner/examples/mdns.rs
@@ -12,8 +12,8 @@ pub async fn main() -> anyhow::Result<()> {
     let mut receiver = mdns::mdns_query_scan(
         mdns::MdnsDeamon::new()?,
         TaskManager::new(),
-        Duration::from_secs(50),
-        Duration::from_secs(10),
+        Duration::from_secs(20),
+        Duration::from_secs(5),
     )?;
 
     while let Some((ip, server, port, protocol)) = receiver.recv().await {

--- a/crates/network-scanner/src/mdns.rs
+++ b/crates/network-scanner/src/mdns.rs
@@ -120,8 +120,8 @@ fn parse_fullname(fullname: &str) -> Option<(String, Option<Protocol>)> {
     let mut iter = fullname.split('.');
     let device_name = iter.next()?;
     let mut service_type = String::new();
-    while let Some(part) = iter.next() {
-        if part.starts_with("_") {
+    for part in iter {
+        if part.starts_with('_') {
             service_type.push_str(part);
             service_type.push('.');
         }

--- a/crates/network-scanner/src/mdns.rs
+++ b/crates/network-scanner/src/mdns.rs
@@ -30,7 +30,7 @@ pub fn mdns_query_scan(
     entire_duration: std::time::Duration,
     single_query_duration: std::time::Duration,
 ) -> Result<ScanEntryReceiver, ScannerError> {
-    let service_daemon = service_daemon.service_daemon.clone();
+    let service_daemon = service_daemon.get_service_daemon();
 
     let receiver = service_daemon.browse(META_QUERY)?;
     let service_daemon_clone = service_daemon.clone();

--- a/crates/network-scanner/src/mdns.rs
+++ b/crates/network-scanner/src/mdns.rs
@@ -1,7 +1,8 @@
 use mdns_sd::ServiceEvent;
 
 use crate::{
-    task_utils::{PortReceiver, TaskManager},
+    scanner::Protocol,
+    task_utils::{ScanEntryReceiver, TaskManager},
     ScannerError,
 };
 
@@ -24,7 +25,7 @@ pub fn mdns_query_scan(
     task_manager: TaskManager,
     entire_duration: std::time::Duration,
     single_query_duration: std::time::Duration,
-) -> Result<PortReceiver, ScannerError> {
+) -> Result<ScanEntryReceiver, ScannerError> {
     let service_deamon = service_deamon.service_deamon;
 
     let receiver = service_deamon.browse(META_QUERY)?;
@@ -90,14 +91,18 @@ pub fn mdns_query_scan(
                         'outer: while let Ok(response) = receiver.recv_async().await {
                             tracing::debug!(sub_service_event=?response);
                             if let ServiceEvent::ServiceResolved(info) = response {
-                                let server = info.get_fullname();
+                                let full_name = info.get_fullname();
+                                let (server, protocol) =
+                                    parse_fullname(full_name).unwrap_or((full_name.to_string(), None));
+
                                 let port = info.get_port();
                                 let ip = info.get_addresses();
 
                                 for ip in ip {
                                     let ip = *ip;
                                     let server = server.to_string();
-                                    if let Err(_) = result_sender.send((ip, Some(server), port)).await {
+                                    if let Err(_) = result_sender.send((ip, Some(server), port, protocol.clone())).await
+                                    {
                                         break 'outer;
                                     }
                                 }
@@ -109,4 +114,36 @@ pub fn mdns_query_scan(
             anyhow::Ok(())
         });
     Ok(result_receiver)
+}
+
+fn parse_fullname(fullname: &str) -> Option<(String, Option<Protocol>)> {
+    let mut iter = fullname.split('.');
+    let device_name = iter.next()?;
+    let mut service_type = String::new();
+    while let Some(part) = iter.next() {
+        if part.starts_with("_") {
+            service_type.push_str(part);
+            service_type.push('.');
+        }
+    }
+    // remove the trailing dot
+    service_type.pop()?;
+
+    let protocol = match service_type.as_str() {
+        "_http._tcp" => Some(Protocol::Http),
+        "_https._tcp" => Some(Protocol::Https),
+        "_ssh._tcp" => Some(Protocol::Ssh),
+        "_sftp._tcp" => Some(Protocol::Sftp),
+        "_scp._tcp" => Some(Protocol::Scp),
+        "_telnet._tcp" => Some(Protocol::Telnet),
+        "_ldap._tcp" => Some(Protocol::Ldap),
+        "_ldaps._tcp" => Some(Protocol::Ldaps),
+        // https://jonathanmumm.com/tech-it/mdns-bonjour-bible-common-service-strings-for-various-vendors/
+        // OSX Screen Sharing
+        "_rfb._tcp" => Some(Protocol::Ard),
+        // Note: RDP, VNC, Wayk, and SSH-based PowerShell (SshPwsh), as well as tunneling (Tunnel), are not standardized service types
+        _ => None,
+    };
+
+    Some((device_name.to_string(), protocol))
 }

--- a/crates/network-scanner/src/mdns.rs
+++ b/crates/network-scanner/src/mdns.rs
@@ -141,7 +141,7 @@ fn parse_fullname(fullname: &str) -> Option<(String, Option<Protocol>)> {
         // https://jonathanmumm.com/tech-it/mdns-bonjour-bible-common-service-strings-for-various-vendors/
         // OSX Screen Sharing
         "_rfb._tcp" => Some(Protocol::Ard),
-        // Note: RDP, VNC, Wayk, and SSH-based PowerShell (SshPwsh), as well as tunneling (Tunnel), are not standardized service types
+        // Note: RDP, VNC, Wayk, and SSH-based PowerShell (SshPwsh) are not standardized service types
         _ => None,
     };
 

--- a/crates/network-scanner/src/scanner.rs
+++ b/crates/network-scanner/src/scanner.rs
@@ -4,7 +4,7 @@ use crate::{
     netbios::netbios_query_scan,
     ping::ping_range,
     port_discovery::{scan_ports, PortScanResult},
-    task_utils::TaskManager,
+    task_utils::{ScanEntryReceiver, TaskManager},
 };
 
 use anyhow::Context;
@@ -262,10 +262,14 @@ impl NetworkScanner {
     }
 }
 
+/// ScanEntry is a tuple of (IpAddr, Option<String>, u16, Option<Protocol>)
+/// where IpAddr is the ip address of the device
+/// Option<String> is the hostname of the device
+/// u16 is the port number
+/// Option<Protocol> is the protocol/Service running on the port
 pub type ScanEntry = (IpAddr, Option<String>, u16, Option<Protocol>);
-type ResultReceiver = tokio::sync::mpsc::Receiver<ScanEntry>;
 pub struct NetworkScannerStream {
-    result_receiver: Arc<Mutex<ResultReceiver>>,
+    result_receiver: Arc<Mutex<ScanEntryReceiver>>,
     task_manager: TaskManager,
 }
 

--- a/crates/network-scanner/src/scanner.rs
+++ b/crates/network-scanner/src/scanner.rs
@@ -352,8 +352,6 @@ pub struct NetworkScannerParams {
 
 #[derive(Debug, Clone)]
 pub enum Protocol {
-    /// Wayk Remote Desktop Protocol
-    Wayk,
     /// Remote Desktop Protocol
     Rdp,
     /// Apple Remote Desktop
@@ -362,18 +360,12 @@ pub enum Protocol {
     Vnc,
     /// Secure Shell
     Ssh,
-    /// PowerShell over SSH transport
-    SshPwsh,
     /// SSH File Transfer Protocol
     Sftp,
     /// Secure Copy Protocol
     Scp,
     /// Telnet
     Telnet,
-    /// PowerShell over WinRM via HTTP transport
-    WinrmHttpPwsh,
-    /// PowerShell over WinRM via HTTPS transport
-    WinrmHttpsPwsh,
     /// Hypertext Transfer Protocol
     Http,
     /// Hypertext Transfer Protocol Secure
@@ -382,6 +374,4 @@ pub enum Protocol {
     Ldap,
     /// Secure LDAP Protocol
     Ldaps,
-    /// Devolutions Gateway Tunnel (generic JMUX tunnel)
-    Tunnel,
 }

--- a/crates/network-scanner/src/task_utils.rs
+++ b/crates/network-scanner/src/task_utils.rs
@@ -7,6 +7,7 @@ use std::future::Future;
 use tokio::sync::Mutex;
 
 use crate::mdns::MdnsDeamon;
+use crate::scanner::ScanEntry;
 use crate::{
     ip_utils::{get_subnets, Subnet},
     scanner::NetworkScanner,
@@ -14,16 +15,16 @@ use crate::{
 
 pub(crate) type IpSender = tokio::sync::mpsc::Sender<(IpAddr, Option<String>)>;
 pub(crate) type IpReceiver = tokio::sync::mpsc::Receiver<(IpAddr, Option<String>)>;
-pub(crate) type PortSender = tokio::sync::mpsc::Sender<(IpAddr, Option<String>, u16)>;
-pub(crate) type PortReceiver = tokio::sync::mpsc::Receiver<(IpAddr, Option<String>, u16)>;
+pub(crate) type ScanEntrySender = tokio::sync::mpsc::Sender<ScanEntry>;
+pub(crate) type ScanEntryReceiver = tokio::sync::mpsc::Receiver<ScanEntry>;
 
 #[derive(Clone)]
 pub(crate) struct TaskExecutionContext {
     pub ip_sender: IpSender,
     pub ip_receiver: Arc<Mutex<IpReceiver>>,
 
-    pub port_sender: PortSender,
-    pub port_receiver: Arc<Mutex<PortReceiver>>,
+    pub port_sender: ScanEntrySender,
+    pub port_receiver: Arc<Mutex<ScanEntryReceiver>>,
 
     pub ip_cache: Arc<parking_lot::RwLock<HashMap<IpAddr, Option<String>>>>,
 

--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -140,7 +140,7 @@ impl NetworkScanResponse {
     }
 }
 
-fn network_scanner_protocol_to_gateway_protocol(protocol: Option<scanner::Protocol>) -> ApplicationProtocol {
+fn network_scanner_protocol_to_gateway_protocol(protocol: scanner::Protocol) -> ApplicationProtocol {
     match protocol {
         None => ApplicationProtocol::unknown(),
         Some(scanner::Protocol::Ssh) => ApplicationProtocol::Known(Protocol::Ssh),

--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -119,7 +119,19 @@ impl NetworkScanResponse {
         let hostname = dns;
 
         let protocol = if let Some(protocol) = service {
-            network_scanner_protocol_to_gateway_protocol(protocol)
+            match protocol {
+                scanner::Protocol::Ssh => ApplicationProtocol::Known(Protocol::Ssh),
+                scanner::Protocol::Telnet => ApplicationProtocol::Known(Protocol::Telnet),
+                scanner::Protocol::Http => ApplicationProtocol::Known(Protocol::Http),
+                scanner::Protocol::Https => ApplicationProtocol::Known(Protocol::Https),
+                scanner::Protocol::Ldap => ApplicationProtocol::Known(Protocol::Ldap),
+                scanner::Protocol::Ldaps => ApplicationProtocol::Known(Protocol::Ldaps),
+                scanner::Protocol::Rdp => ApplicationProtocol::Known(Protocol::Rdp),
+                scanner::Protocol::Vnc => ApplicationProtocol::Known(Protocol::Vnc),
+                scanner::Protocol::Ard => ApplicationProtocol::Known(Protocol::Ard),
+                scanner::Protocol::Sftp => ApplicationProtocol::Known(Protocol::Sftp),
+                scanner::Protocol::Scp => ApplicationProtocol::Known(Protocol::Scp),
+            }
         } else {
             match port {
                 22 => ApplicationProtocol::Known(Protocol::Ssh),
@@ -135,23 +147,6 @@ impl NetworkScanResponse {
                 _ => ApplicationProtocol::unknown(),
             }
         };
-
         Self { ip, hostname, protocol }
-    }
-}
-
-fn network_scanner_protocol_to_gateway_protocol(protocol: scanner::Protocol) -> ApplicationProtocol {
-    match protocol {
-        scanner::Protocol::Ssh => ApplicationProtocol::Known(Protocol::Ssh),
-        scanner::Protocol::Telnet => ApplicationProtocol::Known(Protocol::Telnet),
-        scanner::Protocol::Http => ApplicationProtocol::Known(Protocol::Http),
-        scanner::Protocol::Https => ApplicationProtocol::Known(Protocol::Https),
-        scanner::Protocol::Ldap => ApplicationProtocol::Known(Protocol::Ldap),
-        scanner::Protocol::Ldaps => ApplicationProtocol::Known(Protocol::Ldaps),
-        scanner::Protocol::Rdp => ApplicationProtocol::Known(Protocol::Rdp),
-        scanner::Protocol::Vnc => ApplicationProtocol::Known(Protocol::Vnc),
-        scanner::Protocol::Ard => ApplicationProtocol::Known(Protocol::Ard),
-        scanner::Protocol::Sftp => ApplicationProtocol::Known(Protocol::Sftp),
-        scanner::Protocol::Scp => ApplicationProtocol::Known(Protocol::Scp),
     }
 }

--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -118,8 +118,8 @@ impl NetworkScanResponse {
     fn new(ip: IpAddr, port: u16, dns: Option<String>, service: Option<scanner::Protocol>) -> Self {
         let hostname = dns;
 
-        let protocol = if service.is_some() {
-            network_scanner_protocol_to_gateway_protocol(service)
+        let protocol = if let Some(protocol) = service {
+            network_scanner_protocol_to_gateway_protocol(protocol)
         } else {
             match port {
                 22 => ApplicationProtocol::Known(Protocol::Ssh),

--- a/devolutions-gateway/src/api/network_scan.rs
+++ b/devolutions-gateway/src/api/network_scan.rs
@@ -142,22 +142,16 @@ impl NetworkScanResponse {
 
 fn network_scanner_protocol_to_gateway_protocol(protocol: scanner::Protocol) -> ApplicationProtocol {
     match protocol {
-        None => ApplicationProtocol::unknown(),
-        Some(scanner::Protocol::Ssh) => ApplicationProtocol::Known(Protocol::Ssh),
-        Some(scanner::Protocol::Telnet) => ApplicationProtocol::Known(Protocol::Telnet),
-        Some(scanner::Protocol::Http) => ApplicationProtocol::Known(Protocol::Http),
-        Some(scanner::Protocol::Https) => ApplicationProtocol::Known(Protocol::Https),
-        Some(scanner::Protocol::Ldap) => ApplicationProtocol::Known(Protocol::Ldap),
-        Some(scanner::Protocol::Ldaps) => ApplicationProtocol::Known(Protocol::Ldaps),
-        Some(scanner::Protocol::Rdp) => ApplicationProtocol::Known(Protocol::Rdp),
-        Some(scanner::Protocol::Vnc) => ApplicationProtocol::Known(Protocol::Vnc),
-        Some(scanner::Protocol::WinrmHttpPwsh) => ApplicationProtocol::Known(Protocol::WinrmHttpPwsh),
-        Some(scanner::Protocol::WinrmHttpsPwsh) => ApplicationProtocol::Known(Protocol::WinrmHttpsPwsh),
-        Some(scanner::Protocol::Ard) => ApplicationProtocol::Known(Protocol::Ard),
-        Some(scanner::Protocol::Sftp) => ApplicationProtocol::Known(Protocol::Sftp),
-        Some(scanner::Protocol::Scp) => ApplicationProtocol::Known(Protocol::Scp),
-        Some(scanner::Protocol::Wayk) => ApplicationProtocol::Known(Protocol::Wayk),
-        Some(scanner::Protocol::SshPwsh) => ApplicationProtocol::Known(Protocol::SshPwsh),
-        Some(scanner::Protocol::Tunnel) => ApplicationProtocol::Known(Protocol::Tunnel),
+        scanner::Protocol::Ssh => ApplicationProtocol::Known(Protocol::Ssh),
+        scanner::Protocol::Telnet => ApplicationProtocol::Known(Protocol::Telnet),
+        scanner::Protocol::Http => ApplicationProtocol::Known(Protocol::Http),
+        scanner::Protocol::Https => ApplicationProtocol::Known(Protocol::Https),
+        scanner::Protocol::Ldap => ApplicationProtocol::Known(Protocol::Ldap),
+        scanner::Protocol::Ldaps => ApplicationProtocol::Known(Protocol::Ldaps),
+        scanner::Protocol::Rdp => ApplicationProtocol::Known(Protocol::Rdp),
+        scanner::Protocol::Vnc => ApplicationProtocol::Known(Protocol::Vnc),
+        scanner::Protocol::Ard => ApplicationProtocol::Known(Protocol::Ard),
+        scanner::Protocol::Sftp => ApplicationProtocol::Known(Protocol::Sftp),
+        scanner::Protocol::Scp => ApplicationProtocol::Known(Protocol::Scp),
     }
 }


### PR DESCRIPTION
Current implementation only guesses what service type it is by using port, mdns allows more than just port guessing, enable passing kown protocol types to caller, for unknwon protocols, the caller can keep guess what it is using port.