### PR TITLE
feat(dgw): generate netscan token for webapp

### DIFF
--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -407,7 +407,7 @@ pub(crate) async fn sign_session_token(
             Some(krb_kdc),
         ),
 
-        SessionTokenContentType::NetScan {} => (
+        SessionTokenContentType::NetScan => (
             NetScanClaims {
                 exp,
                 jti,

--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -248,7 +248,7 @@ pub(crate) enum SessionTokenContentType {
         /// Unique ID for this session
         session_id: Uuid,
     },
-    NetScan {},
+    NetScan,
     Kdc {
         /// Kerberos realm.
         ///


### PR DESCRIPTION
Added the ability to generate netscan tokens for the webapp.
I also removed the "destination" field from the returned truple as with the netscan it's not relevant, hopefully that is ok, it was only used for logging.