### PR TITLE
build(dgw): eliminate openssl link dependency on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,16 +1663,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
- "bytes",
+ "futures-util",
+ "http 0.2.11",
  "hyper 0.14.28",
- "native-tls",
+ "rustls 0.21.10",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3141,15 +3142,15 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-tls",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.10",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -3157,12 +3158,13 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -4502,7 +4504,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -4706,6 +4708,12 @@ dependencies = [
  "ring 0.17.7",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3151,6 +3151,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -3164,7 +3165,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -3341,6 +3341,18 @@ dependencies = [
  "sha2",
  "thiserror",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4151,7 +4163,7 @@ dependencies = [
  "log",
  "native-tls",
  "rustls 0.22.2",
- "rustls-native-certs",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
@@ -4504,7 +4516,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "webpki-roots 0.26.1",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4708,12 +4720,6 @@ dependencies = [
  "ring 0.17.7",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -540,7 +540,7 @@ class TlkRecipe
         $Email = "support@devolutions.net"
         $Website = "https://devolutions.net"
         $PackageVersion = $this.Version
-        $DistroCodeName = "xenial" # Ubuntu 16.04
+        $DistroCodeName = "focal" # Ubuntu 20.04
         $Dependencies = @('liblzma5', 'liblz4-1', '${shlibs:Depends}', '${misc:Depends}')
 
         $Env:DEBFULLNAME = $Packager

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -64,7 +64,7 @@ tracing-appender = "0.2"
 # Async, futures…
 tokio = { version = "1.36", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot", "fs"] }
 tokio-rustls = { version = "0.24", features = ["dangerous_configuration", "tls12"] }
-reqwest = { version = "0.11", features = ["json"] } # TODO: directly use hyper in subscriber module
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] } # TODO: directly use hyper in subscriber module
 futures = "0.3"
 async-trait = "0.1"
 tower = "0.4"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -64,7 +64,7 @@ tracing-appender = "0.2"
 # Async, futures…
 tokio = { version = "1.36", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot", "fs"] }
 tokio-rustls = { version = "0.24", features = ["dangerous_configuration", "tls12"] }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] } # TODO: directly use hyper in subscriber module
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-native-roots", "json"] } # TODO: directly use hyper in subscriber module
 futures = "0.3"
 async-trait = "0.1"
 tower = "0.4"


### PR DESCRIPTION
OpenSSL was still a link dependency brought in by reqwest in Linux. We build for Linux on Ubuntu 20.04 and expect it to be forward-compatible, but this is not possible with OpenSSL, as the library is different and incompatible, especially since OpenSSL 1.1 is now in its EOL and Ubuntu 22.04 has moved on to OpenSSL 3.

Our last .deb package release somehow declares a dependency on libssl, but I'm not sure where it's coming from. Maybe we already removed it from the latest master branch and somehow re-introduced the OpenSSL link dependency by mistake. In any case, I at least updated the declared distro name to "focal" (20.04) since it was still saying "xenial" (16.04).

@CBenoit one last thing I want to make sure is that by switching to rustls for reqwest that we still validate against the system CA bundle. I recall it was now an option for rustls, but can you make sure we've enabled it properly?