### PR TITLE
feat(installer): bug fixes and refinement based on feedback

### DIFF
--- a/package/WindowsManaged/DevolutionsGateway.csproj
+++ b/package/WindowsManaged/DevolutionsGateway.csproj
@@ -24,8 +24,8 @@
   <ItemGroup>
 	<PackageReference Include="System.IO.Compression" Version="4.3.0" />
 	<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="WixSharp" Version="1.25.0" />
-    <PackageReference Include="WixSharp.bin" Version="1.25.0" />
+    <PackageReference Include="WixSharp" Version="1.25.1" />
+    <PackageReference Include="WixSharp.bin" Version="1.25.1" />
     <PackageReference Include="WixSharp.wix.bin" Version="3.14.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/package/WindowsManaged/Dialogs/AccessUriDialog.cs
+++ b/package/WindowsManaged/Dialogs/AccessUriDialog.cs
@@ -24,8 +24,6 @@ namespace WixSharpSetup.Dialogs
 
             this.pictureBox1.Image =
                 StockIcon.GetStockIcon(StockIcon.SIID_WARNING, StockIcon.SHGSI_SMALLICON).ToBitmap();
-
-            this.cmbProtocol.DataSource = Protocols;
         }
 
         public override void FromProperties()
@@ -83,6 +81,8 @@ namespace WixSharpSetup.Dialogs
         public override void OnLoad(object sender, EventArgs e)
         {
             banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
+
+            this.cmbProtocol.DataSource = Protocols;
 
             WinAPI.SendMessage(this.txtHostname.Handle, WinAPI.EM_SETCUEBANNER, 0, "dev.devolutions.net");
 

--- a/package/WindowsManaged/Dialogs/CustomizeDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/CustomizeDialog.Designer.cs
@@ -250,7 +250,7 @@ namespace WixSharpSetup.Dialogs
             this.lblConfigureDescription.Name = "lblConfigureDescription";
             this.lblConfigureDescription.Size = new System.Drawing.Size(464, 37);
             this.lblConfigureDescription.TabIndex = 15;
-            this.lblConfigureDescription.Text = "[RecommendedForStandaloneInstallations]";
+            this.lblConfigureDescription.Text = "[RecommendedForMostInstallations]";
             // 
             // topBorder
             // 

--- a/package/WindowsManaged/Dialogs/CustomizeDialog.cs
+++ b/package/WindowsManaged/Dialogs/CustomizeDialog.cs
@@ -38,10 +38,10 @@ public partial class CustomizeDialog : GatewayDialog
         new GatewayProperties(this.Runtime.Session)
         {
             ConfigureGateway = this.ConfigureNow,
-            ConfigureNgrok = this.chkConfigureNgrok.Checked,
-            ConfigureWebApp = this.chkWebApp.Checked,
-            GenerateCertificate = this.chkGenerateCertificate.Checked && !this.chkConfigureNgrok.Checked,
-            GenerateKeyPair = this.chkGenerateKeyPair.Checked,
+            ConfigureNgrok = this.ConfigureNow && this.chkConfigureNgrok.Checked,
+            ConfigureWebApp = this.ConfigureNow && this.chkWebApp.Checked,
+            GenerateCertificate = this.ConfigureNow && this.chkGenerateCertificate.Checked && !this.chkConfigureNgrok.Checked,
+            GenerateKeyPair = this.ConfigureNow && this.chkGenerateKeyPair.Checked,
             ServiceStart = this.ConfigureNow ? ServiceStartMode.Automatic : ServiceStartMode.Manual,
         };
 
@@ -81,12 +81,12 @@ public partial class CustomizeDialog : GatewayDialog
         if (this.ConfigureNow)
         { 
             this.gbConfigure.Visible = true;
-            this.lblConfigureDescription.Text = I18n(Strings.RecommendedForStandaloneInstallations);
+            this.lblConfigureDescription.Text = I18n(Strings.RecommendedForMostInstallations);
         }
         else
         {
             this.gbConfigure.Visible = false;
-            this.lblConfigureDescription.Text = I18n(Strings.RecommendedForCompanionInstallations);
+            this.lblConfigureDescription.Text = I18n(Strings.RecommendedForManualInstallations);
         }
     }
 

--- a/package/WindowsManaged/Dialogs/GatewayDialog.cs
+++ b/package/WindowsManaged/Dialogs/GatewayDialog.cs
@@ -32,7 +32,7 @@ public class GatewayDialog : ManagedForm
     {
         if (this.ToProperties())
         {
-            Shell.GoPrev();
+            Shell.GoTo(Wizard.GetPrevious(this));
         }
     }
 
@@ -45,7 +45,7 @@ public class GatewayDialog : ManagedForm
 
         if (this.ToProperties())
         {
-            Shell.GoNext();
+            Shell.GoTo(Wizard.GetNext(this));
         }
     }
 

--- a/package/WindowsManaged/Dialogs/ListenersDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/ListenersDialog.Designer.cs
@@ -49,12 +49,12 @@ namespace WixSharpSetup.Dialogs
             this.label7 = new System.Windows.Forms.Label();
             this.label3 = new System.Windows.Forms.Label();
             this.txtHttpPort = new System.Windows.Forms.TextBox();
-            this.cmbHttpProtocol = new System.Windows.Forms.ComboBox();
             this.txtHttpHostname = new System.Windows.Forms.TextBox();
             this.label4 = new System.Windows.Forms.Label();
             this.txtTcpPort = new System.Windows.Forms.TextBox();
             this.txtTcpHostname = new System.Windows.Forms.TextBox();
             this.cmbTcpProtocol = new System.Windows.Forms.ComboBox();
+            this.cmbHttpProtocol = new System.Windows.Forms.ComboBox();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
@@ -227,16 +227,6 @@ namespace WixSharpSetup.Dialogs
             this.txtHttpPort.TabIndex = 2;
             this.txtHttpPort.TextChanged += new System.EventHandler(this.txtHttpPort_TextChanged);
             // 
-            // cmbHttpProtocol
-            // 
-            this.cmbHttpProtocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbHttpProtocol.FormattingEnabled = true;
-            this.cmbHttpProtocol.Location = new System.Drawing.Point(3, 45);
-            this.cmbHttpProtocol.Name = "cmbHttpProtocol";
-            this.cmbHttpProtocol.Size = new System.Drawing.Size(70, 21);
-            this.cmbHttpProtocol.TabIndex = 0;
-            this.cmbHttpProtocol.SelectedIndexChanged += new System.EventHandler(this.cmbHttpProtocol_SelectedIndexChanged);
-            // 
             // txtHttpHostname
             // 
             this.txtHttpHostname.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -284,6 +274,16 @@ namespace WixSharpSetup.Dialogs
             this.cmbTcpProtocol.Name = "cmbTcpProtocol";
             this.cmbTcpProtocol.Size = new System.Drawing.Size(70, 21);
             this.cmbTcpProtocol.TabIndex = 3;
+            // 
+            // cmbHttpProtocol
+            // 
+            this.cmbHttpProtocol.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbHttpProtocol.FormattingEnabled = true;
+            this.cmbHttpProtocol.Location = new System.Drawing.Point(3, 45);
+            this.cmbHttpProtocol.Name = "cmbHttpProtocol";
+            this.cmbHttpProtocol.Size = new System.Drawing.Size(70, 21);
+            this.cmbHttpProtocol.TabIndex = 0;
+            this.cmbHttpProtocol.SelectedIndexChanged += new System.EventHandler(this.cmbHttpProtocol_SelectedIndexChanged);
             // 
             // topBorder
             // 

--- a/package/WindowsManaged/Dialogs/ListenersDialog.cs
+++ b/package/WindowsManaged/Dialogs/ListenersDialog.cs
@@ -31,9 +31,6 @@ public partial class ListenersDialog : GatewayDialog
 
         httpPortDebouncer = new Debouncer(TimeSpan.FromMilliseconds(500), PortCheck, this.txtHttpPort);
         tcpPortDebouncer = new Debouncer(TimeSpan.FromMilliseconds(500), PortCheck, this.txtTcpPort);
-
-        this.cmbHttpProtocol.DataSource = HttpProtocols;
-        this.cmbTcpProtocol.DataSource = TcpProtocols;
     }
 
     public override bool DoValidate()
@@ -98,6 +95,9 @@ public partial class ListenersDialog : GatewayDialog
     {
         banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
 
+        this.cmbHttpProtocol.DataSource = HttpProtocols;
+        this.cmbTcpProtocol.DataSource = TcpProtocols;
+        
         base.OnLoad(sender, e);
     }
 
@@ -154,7 +154,17 @@ public partial class ListenersDialog : GatewayDialog
         
         Action result = () => {};
 
-        string portString = this.Invoke(new Func<string>(() => textBox.Text)).ToString();
+        string portString;
+
+        try
+        {
+            portString = this.Invoke(new Func<string>(() => textBox.Text)).ToString();
+
+        }
+        catch
+        {
+            return;
+        }
 
         if (string.IsNullOrEmpty(portString) || !Validation.IsValidPort(portString, out uint port))
         {

--- a/package/WindowsManaged/Dialogs/NgrokListenersDialog.cs
+++ b/package/WindowsManaged/Dialogs/NgrokListenersDialog.cs
@@ -33,8 +33,8 @@ public partial class NgrokListenersDialog : GatewayDialog
             ShowValidationErrorString(I18n(Strings.DomainIsRequiredAndMustBeValid));
             return false;
         }
-
-        if (this.cmbNativeClient.SelectedIndex == 0)
+        
+        if (this.cmbNativeClient.Selected<Constants.CustomizeMode>() == Constants.CustomizeMode.Now)
         {
             if (string.IsNullOrWhiteSpace(this.txtRemoteAddress.Text.Trim()))
             {

--- a/package/WindowsManaged/Dialogs/VerifyReadyDialog.cs
+++ b/package/WindowsManaged/Dialogs/VerifyReadyDialog.cs
@@ -31,7 +31,10 @@ public partial class VerifyReadyDialog : GatewayDialog
     protected override void Back_Click(object sender, EventArgs e) => base.Back_Click(sender, e);
 
     // ReSharper disable once RedundantOverriddenMember
-    protected override void Next_Click(object sender, EventArgs e) => base.Next_Click(sender, e);
+    protected override void Next_Click(object sender, EventArgs e)
+    {
+        Shell.GoNext();
+    }
 
     // ReSharper disable once RedundantOverriddenMember
     protected override void Cancel_Click(object sender, EventArgs e) => base.Cancel_Click(sender, e);

--- a/package/WindowsManaged/Dialogs/WebClientDialog.cs
+++ b/package/WindowsManaged/Dialogs/WebClientDialog.cs
@@ -1,23 +1,22 @@
 using DevolutionsGateway.Dialogs;
 using DevolutionsGateway.Properties;
 using System;
+using DevolutionsGateway.Helpers;
 using DevolutionsGateway.Resources;
 using WixSharp;
+using static DevolutionsGateway.Properties.Constants;
 
 namespace WixSharpSetup.Dialogs;
 
 public partial class WebClientDialog : GatewayDialog
 {
-    private bool CustomAuth => this.cmbAuthentication.SelectedIndex == (int)Constants.AuthenticationMode.Custom;
+    private bool CustomAuth => this.cmbAuthentication.Selected<AuthenticationMode>() == AuthenticationMode.Custom;
 
     public WebClientDialog()
     {
         InitializeComponent();
         label1.MakeTransparentOn(banner);
         label2.MakeTransparentOn(banner);
-
-        this.cmbAuthentication.DataSource = Enum.GetValues(typeof(Constants.AuthenticationMode));
-        this.cmbAuthentication.SelectedIndex = 0;
     }
 
     public override bool DoValidate()
@@ -81,6 +80,9 @@ public partial class WebClientDialog : GatewayDialog
     {
         banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
 
+        this.cmbAuthentication.Source<AuthenticationMode>(this.MsiRuntime);
+        this.cmbAuthentication.SetSelected(AuthenticationMode.None);
+        
         base.OnLoad(sender, e);
     }
 

--- a/package/WindowsManaged/Dialogs/Wizard.cs
+++ b/package/WindowsManaged/Dialogs/Wizard.cs
@@ -41,9 +41,7 @@ internal static class Wizard
 
         Sequence = dialogs.ToArray();
     }
-
-    private static Type lastDialog;
-
+    
     internal static IEnumerable<Type> Dialogs => Sequence;
 
     private static bool Skip(Session session, Type dialog)
@@ -121,29 +119,23 @@ internal static class Wizard
         return false;
     }
 
-    internal static void DialogChanged(IManagedDialog dialog)
+    internal static int Move(IManagedDialog current, bool forward)
     {
-        Type previousDialog = lastDialog;
-        lastDialog = dialog.GetType();
+        Type t = current.GetType();
+        int index = Dialogs.FindIndex(t);
 
-        Type currentDialog = lastDialog;
-
-        if (!Skip(dialog.Session(), currentDialog))
+        while (true)
         {
-            return;
+            index = forward ? index + 1 : index - 1;
+
+            if (!Skip(current.Session(), Sequence[index]))
+            {
+                return index;
+            }
         }
-
-        int index = Dialogs.FindIndex(currentDialog);
-        int prevIndex = Dialogs.FindIndex(previousDialog);
-
-        bool backward = index < prevIndex;
-
-        while (Skip(dialog.Session(), currentDialog))
-        {
-            index = backward ? index - 1 : index + 1;
-            currentDialog = Sequence[index];
-        }
-
-        dialog.Shell.GoTo(index);
     }
+
+    internal static int GetNext(IManagedDialog current) => Move(current, true);
+
+    internal static int GetPrevious(IManagedDialog current) => Move(current, false);
 }

--- a/package/WindowsManaged/Program.cs
+++ b/package/WindowsManaged/Program.cs
@@ -309,7 +309,8 @@ internal class Program
             .Add<MaintenanceTypeDialog>()
             .Add<ProgressDialog>()
             .Add<ExitDialog>();
-        
+
+        project.UnhandledException += Project_UnhandledException;
         project.UIInitialized += Project_UIInitialized;
         
         if (SourceOnlyBuild)
@@ -343,6 +344,19 @@ internal class Program
             
             msi.SetPackageLanguages(string.Join(",", Languages.Keys).ToLcidList());
         }
+    }
+
+    private static void Project_UnhandledException(ExceptionEventArgs e)
+    {
+        string errorMessage =
+            $"An unhandled error has occurred. If this is recurring, please report the issue to {Includes.EMAIL_SUPPORT} or on {Includes.FORUM_SUPPORT}.";
+        errorMessage += Environment.NewLine;
+        errorMessage += Environment.NewLine;
+        errorMessage += "Error details:";
+        errorMessage += Environment.NewLine;
+        errorMessage += e.Exception;
+
+        MessageBox.Show(errorMessage, Includes.PRODUCT_NAME, MessageBoxButtons.OK, MessageBoxIcon.Error);
     }
 
     private static void Project_UIInitialized(SetupEventArgs e)
@@ -430,7 +444,5 @@ internal class Program
                 Process.Start("https://go.microsoft.com/fwlink/?LinkId=2085155");
             }
         }
-
-        e.ManagedUI.OnCurrentDialogChanged += Wizard.DialogChanged;
     }
 }

--- a/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
@@ -146,8 +146,8 @@ If it appears minimized then active it from the taskbar.</String>
                 <String Id="EnableTheGatewayWebInterface">Enable the Gateway web interface</String>
                 <String Id="GenerateASelfSignedHttpsCertificate">Generate a self-signed HTTPS certificate</String>
                 <String Id="GenerateEncryptionKeys">Generate encryption keys</String>
-                <String Id="RecommendedForCompanionInstallations">Recommended when installing as a companion to another service (e.g. Devolutions Server). The Gateway service will need to be configured and started after installation.</String>
-                <String Id="RecommendedForStandaloneInstallations">Recommended for standalone installations. Generate an initial configuration using this installer and start the Gateway service automatically.</String>
+                <String Id="RecommendedForManualInstallations">The Gateway service will need to be manually configured and started after installation.</String>
+                <String Id="RecommendedForMostInstallations">Recommended for most installations. Generate a basic configuration using this installer and start the Gateway service automatically.</String>
                     <!-- dialogs.accessUri -->
                 <String Id="AccessUriDlgDescription">URL to reach [ProductName].</String>
                 <String Id="AccessUriDlgExplanation">The URI to reach the Gateway externally for HTTP operations. This may differ from the HTTP listener address in certain cases (for example, when using a reverse proxy such as IIS).</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
@@ -156,8 +156,6 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                 <String Id="EnableTheGatewayWebInterface">Activer l'interface Web de Gateway</String>
                 <String Id="GenerateASelfSignedHttpsCertificate">Générer un certificat HTTPS autosigné</String>
                 <String Id="GenerateEncryptionKeys">Générer des clés de chiffrement</String>
-                <String Id="RecommendedForCompanionInstallations">Recommandé pour l'installation du logiciel en tant qu'outil connexe pour un autre service (ex. : Devolutions Server). Le service Gateway devra être configuré et lancé après installation.</String>
-                <String Id="RecommendedForStandaloneInstallations">Recommandé pour les installations autonomes. Générez une configuration initiale à l'aide de cet installateur et lancez le service Gateway automatiquement.</String>
                     <!-- dialogs.accessUri -->
                 <String Id="AccessUriDlgDescription">URL pour rejoindre [ProductName].</String>
                 <String Id="AccessUriDlgExplanation">L'URI permettant de se connecter à la passerelle Gateway en externe pour effectuer des opérations HTTP. Il peut différer de l'adresse de l'écouteur dans certains cas (ex. : lors de l'utilisation d'un proxy inverse tel qu'IIS).</String>
@@ -225,6 +223,9 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                 <String Id="ServiceStartMode_Disabled">Disabled</String>
                 <String Id="ServiceStartMode_Manual">Manual</String>
                 <String Id="ServiceStartMode_System">System</String>
+                    <!-- dialogs.customize.- -->
+                <String Id="RecommendedForManualInstallations">The Gateway service will need to be manually configured and started after installation.</String>
+                <String Id="RecommendedForMostInstallations">Recommended for most installations. Generate a basic configuration using this installer and start the Gateway service automatically.</String>
                     <!-- dialogs.certificate.- -->
                 <String Id="AnX509CertificateInBinaryOrPemEncoded">An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded</String>
                     </WixLocalization>

--- a/package/WindowsManaged/Resources/Includes.cs
+++ b/package/WindowsManaged/Resources/Includes.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-
 namespace DevolutionsGateway.Resources
 {
     internal static class Includes
@@ -17,6 +16,10 @@ namespace DevolutionsGateway.Resources
         internal static string SERVICE_DESCRIPTION = "Devolutions Gateway Service";
 
         internal static string EXECUTABLE_NAME = "DevolutionsGateway.exe";
+
+        internal static string EMAIL_SUPPORT = "support@devolutions.net";
+
+        internal static string FORUM_SUPPORT = "forum.devolutions.net";
 
         internal static Guid UPGRADE_CODE = new("db3903d6-c451-4393-bd80-eb9f45b90214");
 

--- a/package/WindowsManaged/Resources/Strings.g.cs
+++ b/package/WindowsManaged/Resources/Strings.g.cs
@@ -497,13 +497,13 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string CustomInstallDlgInfoLabel = "CustomInstallDlgInfoLabel";		
 		/// <summary>
-		/// Recommended for standalone installations. Generate an initial configuration using this installer and start the Gateway service automatically.
+		/// Recommended for most installations. Generate a basic configuration using this installer and start the Gateway service automatically.
 		/// </summary>
-		public const string RecommendedForStandaloneInstallations = "RecommendedForStandaloneInstallations";		
+		public const string RecommendedForMostInstallations = "RecommendedForMostInstallations";		
 		/// <summary>
-		/// Recommended when installing as a companion to another service (e.g. Devolutions Server). The Gateway service will need to be configured and started after installation.
+		/// The Gateway service will need to be manually configured and started after installation.
 		/// </summary>
-		public const string RecommendedForCompanionInstallations = "RecommendedForCompanionInstallations";		
+		public const string RecommendedForManualInstallations = "RecommendedForManualInstallations";		
 		/// <summary>
 		/// Configure the Gateway installation
 		/// </summary>

--- a/package/WindowsManaged/Resources/Strings_en-US.json
+++ b/package/WindowsManaged/Resources/Strings_en-US.json
@@ -523,12 +523,12 @@
             "text": "The Setup Wizard will generate a configuration which you can update later; or you can provide configuration information now."
           },
           {
-            "id": "RecommendedForStandaloneInstallations",
-            "text": "Recommended for standalone installations. Generate an initial configuration using this installer and start the Gateway service automatically."
+            "id": "RecommendedForMostInstallations",
+            "text": "Recommended for most installations. Generate a basic configuration using this installer and start the Gateway service automatically."
           },
           {
-            "id": "RecommendedForCompanionInstallations",
-            "text": "Recommended when installing as a companion to another service (e.g. Devolutions Server). The Gateway service will need to be configured and started after installation."
+            "id": "RecommendedForManualInstallations",
+            "text": "The Gateway service will need to be manually configured and started after installation."
           },
           {
             "id": "ConfigureTheGatewayInstallation",

--- a/package/WindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/WindowsManaged/Resources/Strings_fr-FR.json
@@ -560,14 +560,6 @@
             "text": "L'assistant d'installation va générer une configuration minimale à finaliser plus tard, ou vous pouvez compléter la configuration maintenant."
           },
           {
-            "id": "RecommendedForStandaloneInstallations",
-            "text": "Recommandé pour les installations autonomes. Générez une configuration initiale à l'aide de cet installateur et lancez le service Gateway automatiquement."
-          },
-          {
-            "id": "RecommendedForCompanionInstallations",
-            "text": "Recommandé pour l'installation du logiciel en tant qu'outil connexe pour un autre service (ex. : Devolutions Server). Le service Gateway devra être configuré et lancé après installation."
-          },
-          {
             "id": "ConfigureTheGatewayInstallation",
             "text": "Configurer l'installation de Gateway"
           },


### PR DESCRIPTION
Bug fixes and refinement to the Windows installer based on feedback:

- Bump wixsharp dependency to 1.25.1 and implement a basic [unhandled exception handler](https://github.com/oleg-shilo/wixsharp/issues/1446)
- Fix display "flicker" when skipping dialogs due to conditions (instead of "fast forwarding" or "rewinding" through the dialog sequence, I realize we can jump to arbitrary indexes 🙌)
- Improve WinForms correctness (UI initialization in `OnLoad` instead of constructors) and fix one possible crash in the listener's dialog
- Tweak the info message on the customization screen to make the options more clear
- Fix a bug where top-level properties (e.g. configure ngrok, configure web app) could hold bad values after going back-and-forth