### PR TITLE
fix(dgw): /jet/network-scan -> /jet/net/scan

### DIFF
--- a/devolutions-gateway/src/api/mod.rs
+++ b/devolutions-gateway/src/api/mod.rs
@@ -27,7 +27,7 @@ pub fn make_router<S>(state: crate::DgwState) -> axum::Router<S> {
         .route("/jet/rdp", axum::routing::get(rdp::handler))
         .nest("/jet/fwd", fwd::make_router(state.clone()))
         .nest("/jet/webapp", webapp::make_router(state.clone()))
-        .route("/jet/network-scan", axum::routing::get(network_scan::handler));
+        .route("/jet/net/scan", axum::routing::get(network_scan::handler));
 
     if state.conf_handle.get_conf().webapp_is_enabled() {
         router = router.route(


### PR DESCRIPTION
As mentioned here: https://github.com/Devolutions/devolutions-gateway/pull/706#discussion_r1493775706

If the intention is to have multiple endpoints related to network exploration, let’s nest everything under `/jet/net/`:

- `GET /jet/net/scan`
- `GET /jet/net/config`
- …

I want to make this change before we cut the release because it’s harder to change later because of our forward compatibility requirements.