### PR TITLE
feat(dgw): hide unstable API behind a debug flag

### DIFF
--- a/devolutions-gateway/src/api/net.rs
+++ b/devolutions-gateway/src/api/net.rs
@@ -11,10 +11,16 @@ use serde::Serialize;
 use std::net::IpAddr;
 
 pub fn make_router<S>(state: DgwState) -> Router<S> {
-    Router::new()
-        .route("/scan", axum::routing::get(handle_network_scan))
-        .route("/config", axum::routing::get(get_net_config))
-        .with_state(state)
+    let router = Router::new().route("/scan", axum::routing::get(handle_network_scan));
+
+    let router = if state.conf_handle.get_conf().debug.enable_unstable {
+        // This route is currently unstable and disabled by default.
+        router.route("/config", axum::routing::get(get_net_config))
+    } else {
+        router
+    };
+
+    router.with_state(state)
 }
 
 pub async fn handle_network_scan(

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -1044,6 +1044,10 @@ pub mod dto {
         ///
         /// Providing this option will cause the PCAP interceptor to be attached to each stream.
         pub capture_path: Option<Utf8PathBuf>,
+
+        /// Enable unstable API which may break at any point
+        #[serde(default)]
+        pub enable_unstable: bool,
     }
 
     /// Manual Default trait implementation just to make sure default values are deliberates
@@ -1056,6 +1060,7 @@ pub mod dto {
                 override_kdc: None,
                 log_directives: None,
                 capture_path: None,
+                enable_unstable: false,
             }
         }
     }


### PR DESCRIPTION
Until we are satisfied with the API for `/jet/net/config`, the endpoint is hidden by default.

The rationale is:
- Users may use a newer RDM/DVLS version which will poke the new endpoint without updating the Devolutions Gateway service, and
- the error may be cryptic if the endpoint already existed. It’s simpler to troubleshoot a 404 error (upgrade required) not found than, e.g., a de-serialization error (upgrade required? bug?).

Developers can enable the unstable API by setting the new debug flag:
```json
{
  // -- snip -- //
  "__debug__": {
    "enable_unstable": true
  }
}
```