### PR TITLE
fix(dgw): better support for ngrok free plan

### DIFF
--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -227,7 +227,7 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<Tasks> {
             .context("couldn’t create ngrok session")?;
 
         for (name, conf) in &ngrok_conf.tunnels {
-            let tunnel = session.configure_endpoint(name, conf);
+            let tunnel = session.configure_endpoint(name, conf).await;
             tasks.register(devolutions_gateway::ngrok::NgrokTunnelTask {
                 tunnel,
                 state: state.clone(),


### PR DESCRIPTION
Our installer is allowing the 0.0.0.0/0 CIDR by default because premium plans need the IP restrictions to be configured or just all external traffic. However this doesn’t play well with the free plan. This patch is using a dirty trick to detect the free plan and ignores the IP restriction configuration when it is detected.

Issue: DGW-134