### PR TITLE
fix lib prefix for PowerShell native library loader

### DIFF
--- a/powershell/build.ps1
+++ b/powershell/build.ps1
@@ -25,9 +25,15 @@ $Env:NUGET_CERT_REVOCATION_MODE='offline'
 
 $ManagedBasePath = "$PSScriptRoot\$ModuleName\bin"
 Get-Item "$ManagedBasePath\runtimes\*\native*" | ForEach-Object {
-	$NativeDirName = $_.Parent.Name
+    $NativeDirName = $_.Parent.Name
     Remove-Item "$ManagedBasePath\$NativeDirName" -Recurse -ErrorAction SilentlyContinue
-	Move-Item $_ "$ManagedBasePath\$NativeDirName" -Force
+    Move-Item $_ "$ManagedBasePath\$NativeDirName" -Force
+
+    Get-ChildItem "$ManagedBasePath\$NativeDirName" -Recurse |
+        Where-Object { $_.Name -match '^lib' } | ForEach-Object {
+        $newName = $_.Name -replace '^lib', '' # Remove "lib" prefix
+        Rename-Item $_.FullName -NewName $newName -Force
+    }
 }
 Remove-Item "$ManagedBasePath\runtimes" -Recurse -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
PowerShell uses a default directory structure for native DLLs than the .NET runtime, but it also (annoyingly) always assumes there is no "lib" prefix, while .NET expects prefix-less library names on Windows, and prefixed library names on non-Windows. This pull request just removes the "lib" prefix as does the native DLL directory structure conversion.

https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/writing-portable-modules?view=powershell-7.4&viewFallbackFrom=powershell-7#dependency-on-native-libraries
