### PR TITLE
fix(installer): properly write ARP InstallLocation on fresh installs

### DIFF
--- a/package/WindowsManaged/Actions/GatewayActions.cs
+++ b/package/WindowsManaged/Actions/GatewayActions.cs
@@ -80,7 +80,10 @@ internal static class GatewayActions
     /// </summary>
     private static readonly SetPropertyAction setArpInstallLocation = new("ARPINSTALLLOCATION", $"[{GatewayProperties.InstallDir}]")
     {
-        Condition = Condition.Always
+        Execute = Execute.immediate,
+        Sequence = Sequence.InstallExecuteSequence,
+        When = When.After,
+        Step = Step.CostFinalize,
     };
 
     /// <summary>


### PR DESCRIPTION
In the following conditions:

- Fresh installation
- Installing without UI (quiet or silent)
- Without passing a custom `INSTALLDIR` to msiexec

The action that sets the ARP (Add/Remove Programs) install location will use the default value for `INSTALLDIR`. However, it's sequenced too early: a default can't be resolved until after __CostFinalize__. In this case, we end up writing an empty string to the install location field.