### PR TITLE
feat(webapp): bump iron-remote-gui-vnc to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "devolutions-gateway",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/router": "16.2.1",
         "@devolutions/icons": "3.4.6",
         "@devolutions/iron-remote-gui": "^0.11.5",
-        "@devolutions/iron-remote-gui-vnc": "^0.1.6",
+        "@devolutions/iron-remote-gui-vnc": "^0.2.1",
         "@devolutions/web-ssh-gui": "^0.2.14",
         "@devolutions/web-telnet-gui": "^0.2.15",
         "primeflex": "3.3.1",
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@devolutions/iron-remote-gui-vnc": {
-      "version": "0.1.6",
-      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-gui-vnc/-/@devolutions/iron-remote-gui-vnc-0.1.6.tgz",
-      "integrity": "sha512-u/D6bOuVNtx+uL9ZULO399mJV+s1E+lKGn9bH63wA/PoMHpQX9fMrxZCtBS+hGSuLPkE7OAC/AjNzy1qSBxazA==",
+      "version": "0.2.1",
+      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-gui-vnc/-/@devolutions/iron-remote-gui-vnc-0.2.1.tgz",
+      "integrity": "sha512-EeI01cqcB1U9RoMJR0Di5w8Ram1BRNbKSesJlO9yx5FMF7Ll6VZJO0Eym5QvP0eHUS3ngLIazPEVZJifPIlfDg==",
       "dependencies": {
         "rxjs": "^6.6.7"
       }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,7 +21,7 @@
     "@angular/router": "16.2.1",
     "@devolutions/icons": "3.4.6",
     "@devolutions/iron-remote-gui": "^0.11.5",
-    "@devolutions/iron-remote-gui-vnc": "^0.1.6",
+    "@devolutions/iron-remote-gui-vnc": "^0.2.1",
     "@devolutions/web-telnet-gui": "^0.2.15",
     "@devolutions/web-ssh-gui": "^0.2.14",
     "primeflex": "3.3.1",


### PR DESCRIPTION
- Support for client-side rendered hardware-accelerated cursors