### PR TITLE
ci(package): fix WiX Toolset path

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -209,7 +209,9 @@ jobs:
         if: matrix.os == 'windows'
         run: |
           echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          $WixToolsetItem = Get-ChildItem -Path "C:\Program Files (x86)\" -Filter "WiX Toolset v*" | Select-Object -First 1
+          echo "C:\Program Files (x86)\$($WixToolsetItem.Name)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Sign executables
         if: matrix.os == 'windows' || matrix.os == 'macos'


### PR DESCRIPTION
We hardcoded the path to the WiX Toolset binaries as `C:\Program Files (x86)\WiX Toolset v3.11\bin`, but the actual path is now different. Probably because GitHub updated the runner. Now it’s `Wix Toolset v3.14`. I used a regex to select the right folder regardless of the installed version so we don’t have to lose time updating the workflow each time.