### PR TITLE
ci: add a webclient archive to the GitHub release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -356,6 +356,36 @@ jobs:
           path: ${{ runner.temp }}/${{ matrix.project }}
           if-no-files-found: error
 
+  web-app:
+    name: Web App
+    runs-on: ubuntu-latest
+    needs: [preflight]
+
+    steps:
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
+          name: webapp-client
+          path: webapp-client
+
+      - name: Download artifacts (cli)
+        if: needs.preflight.outputs.dl-strategy == 'cli'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -R $Env:GITHUB_REPOSITORY -D webapp-client
+
+      - name: Create tarball
+        run: tar -czvf devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz webapp-client
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: webapp-client
+          path: devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz
+          if-no-files-found: error
+
   nuget:
     name: Nuget
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,13 @@ jobs:
         if: needs.preflight.outputs.dl-strategy == 'action'
         uses: actions/download-artifact@v3
         with:
+          name: webapp-client
+          path: webapp-client
+
+      - name: Download artifacts (action)
+        if: needs.preflight.outputs.dl-strategy == 'action'
+        uses: actions/download-artifact@v3
+        with:
           name: changelog
           path: changelog
 
@@ -243,7 +250,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ needs.preflight.outputs.run }} -n jetsocat -n devolutions-gateway -n changelog --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n jetsocat -n devolutions-gateway -n webapp-client -n changelog --repo $Env:GITHUB_REPOSITORY
 
       - name: Manage artifacts
         shell: pwsh


### PR DESCRIPTION
Add an archive of the web client to the GitHub release. The archive is named `devolutions_gateway_webapp_{version}.tar.gz`