### PR TITLE
ci(dgw): add arm64 build for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           SECRET_VALUE: ${{ secrets.ARTIFACTORY_READ_TOKEN }}
         run: |
           $Jobs = @()
-          $Archs = @( 'x86_64' )
+          $Archs = @( 'x86_64', 'arm64' )
           $Platforms = @( 'linux' )
           if ($Env:SECRET_VALUE -Eq '') {
             echo "::warning::Secrets not available, some jobs will be skipped"
@@ -44,6 +44,10 @@ jobs:
           $Platforms | ForEach-Object {
               $Runner = switch ($_) { 'windows' { 'windows-2022' } 'linux' { 'ubuntu-20.04' } }
               foreach ($Arch in $Archs) {
+                  if ($Arch -Eq 'arm64' -And $_ -Eq 'windows') {
+                    continue
+                  }
+
                   $Jobs += @{
                       arch = $Arch
                       os = $_
@@ -55,7 +59,6 @@ jobs:
           echo "gateway-build-matrix=$GatewayMatrix" >> $Env:GITHUB_OUTPUT
 
           $Jobs = @()
-          $Archs += 'arm64'
           $Platforms += 'macos'
 
           $Platforms | ForEach-Object {
@@ -372,6 +375,7 @@ jobs:
           sudo dpkg --add-architecture arm64
           sudo apt-get -o Acquire::Retries=3 install -qy binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
           rustup target add aarch64-unknown-linux-gnu
+          echo "STRIP_EXECUTABLE=aarch64-linux-gnu-strip" >> $GITHUB_ENV
 
       # WiX is installed on Windows runners but not in the PATH
       - name: Configure Windows runner
@@ -397,6 +401,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Package
+        if: matrix.arch != 'arm64'
         shell: pwsh
         env:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "ceviche"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1a44085e79b3b02c2a5d18a54c8cb943bc7ae85207f76679b89f1e1c3c68c9"
+checksum = "ddeea570a42ad62fcc3a0f76ae1a29a610204f7bc78af1d9c5b3e86741fdf152"
 dependencies = [
  "cfg-if",
  "chrono",
@@ -519,7 +519,6 @@ dependencies = [
  "libc",
  "log",
  "system-configuration-sys 0.5.0",
- "systemd-rs",
  "timer",
  "widestring 0.4.3",
  "winapi",
@@ -717,7 +716,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
- "nix 0.27.1",
+ "nix",
  "windows-sys 0.52.0",
 ]
 
@@ -1090,16 +1089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "epoll"
-version = "4.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74351c3392ea1ff6cd2628e0042d268ac2371cb613252ff383b6dfa50d22fa79"
-dependencies = [
- "bitflags 2.4.2",
- "libc",
 ]
 
 [[package]]
@@ -2034,15 +2023,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2293,18 +2273,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -3335,7 +3303,7 @@ dependencies = [
  "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.27.1",
+ "nix",
  "thiserror",
  "tokio",
 ]
@@ -3986,29 +3954,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "systemd-rs"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba28cdec1491faf8b9820305aa6cf9df1dff3378c1adfe41d5bd1261d4a17b59"
-dependencies = [
- "epoll",
- "libc",
- "log",
- "nix 0.24.3",
- "systemd-sys",
-]
-
-[[package]]
-name = "systemd-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4816f770cdd05c0a0b8bd048178c3eb3048221016945469c6124a1dd1afc6400"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -220,7 +220,7 @@ class TlkTarget
         switch ($this.Architecture) {
             "x86" { "i386" }
             "x86_64" { "amd64" }
-            "aarch64" { "arm64" }
+            "arm64" { "arm64" }
         }
         
         return $DebianArchitecture

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -21,7 +21,7 @@ jmux-proxy = { path = "../crates/jmux-proxy" }
 devolutions-gateway-task = { path = "../crates/devolutions-gateway-task" }
 ironrdp-pdu = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "4844e77b7f65024d85ba74b1824013eda6eb32b2" }
 ironrdp-rdcleanpath = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "4844e77b7f65024d85ba74b1824013eda6eb32b2" }
-ceviche = "0.5"
+ceviche = "0.6"
 picky-krb = "0.8"
 network-scanner = { version = "0.0.0", path = "../crates/network-scanner" }
 


### PR DESCRIPTION
Add an arm64 build for Devolutions Gateway on Linux. Currently the binary is not packaged in a .deb nor is a container created. This will follow after the next round of updates to .deb packaging.