### PR TITLE
 ci: update package workflow actions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -33,22 +33,9 @@ jobs:
     outputs:
       run: ${{ steps.get-run.outputs.run }}
       commit: ${{ steps.get-commit.outputs.commit }}
-      dl-strategy: ${{ steps.get-dl-strategy.outputs.dl-strategy }}
       version: ${{ steps.get-version.outputs.version }}
 
     steps:
-      ## workflow_dispatch: CI run artifacts are downloaded using `gh` (specifying the CI workflow run_id)
-      ## workflow_call:     CI run artifacts are downloaded using actions/download-artifact (using the current run_id)
-      - name: Get download strategy
-        id: get-dl-strategy
-        shell: pwsh
-        run: |
-          if ('${{ inputs.dispatch }}') {
-            echo "dl-strategy=action" >> $Env:GITHUB_OUTPUT
-          } else {
-            echo "dl-strategy=cli" >> $Env:GITHUB_OUTPUT
-          }
-
       ## workflow_dispatch: The run_id is read from the inputs
       ## workflow_call:     The run_id is the current run_id
       - name: Get run
@@ -98,24 +85,24 @@ jobs:
           echo "::notice::Packaging artifacts built from commit $Ref in run ${{ steps.get-run.outputs.run }}"
 
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ steps.get-commit.outputs.commit }}
 
       - name: Upload version artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: version
           path: VERSION
 
       - name: Upload docker file artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docker
           path: package/**/Dockerfile
 
       - name: Upload changelog artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: CHANGELOG.md
@@ -146,24 +133,14 @@ jobs:
         exclude:
           - project: devolutions-gateway
             os: macos
-          - project: devolutions-gateway
-            os: linux
 
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.preflight.outputs.commit }}
 
-      - name: Download artifacts (action)
-        if: needs.preflight.outputs.dl-strategy == 'action'
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ matrix.project }}
-          path: ${{ runner.temp }}/${{ matrix.project }}
-
-      - name: Download artifacts (cli)
-        if: needs.preflight.outputs.dl-strategy == 'cli'
+      - name: Download artifacts
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -177,9 +154,8 @@ jobs:
         shell: pwsh
         run: |
           $Destination = Join-Path ${{ runner.temp }} ${{ matrix.project }}
-          if ('${{ matrix.project }}' -Eq 'jetsocat') {
-            Get-ChildItem "$Destination" -Exclude ${{ matrix.os }} | Remove-Item -Recurse
-          }
+          $Exclusions = @('${{ matrix.os }}', 'Powershell')
+          Get-ChildItem "$Destination" -Exclude $Exclusions | Remove-Item -Recurse
 
       - name: Install AzureSignTool
         if: matrix.os == 'windows'
@@ -248,15 +224,8 @@ jobs:
             }
           }
 
-      - name: Download web client artifacts (action)
-        if: needs.preflight.outputs.dl-strategy == 'action' && matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
-        uses: actions/download-artifact@v3
-        with:
-          name: webapp-client
-          path: webapp/client
-
-      - name: Download web client artifacts (cli)
-        if: needs.preflight.outputs.dl-strategy == 'cli' && matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
+      - name: Download web client artifacts
+        if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -266,10 +235,10 @@ jobs:
 
       - name: Add msbuild to PATH
         if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
 
       - name: Regenerate MSI
-        if: matrix.project == 'devolutions-gateway'
+        if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
@@ -284,7 +253,7 @@ jobs:
           ./ci/tlk.ps1 package -PackageOption generate
 
       - name: Sign msi runtime
-        if: matrix.project == 'devolutions-gateway'
+        if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'
         shell: pwsh
         working-directory: package/WindowsManaged/Release
         run: |
@@ -301,7 +270,7 @@ jobs:
           }
 
       - name: Repackage
-        if: matrix.project == 'devolutions-gateway'
+        if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
@@ -310,7 +279,7 @@ jobs:
           ./ci/tlk.ps1 package -PackageOption assemble
 
       - name: Sign packages
-        if: matrix.project == 'devolutions-gateway'
+        if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'
         shell: pwsh
         run: |
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include '*.msi' | % {
@@ -350,11 +319,37 @@ jobs:
           }
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.project }}
+          name: ${{ matrix.project }}-${{ matrix.os }}
           path: ${{ runner.temp }}/${{ matrix.project }}
           if-no-files-found: error
+
+  devolutions-gateway-merge:
+    name: devolutions gateway merge artifacts
+    runs-on: ubuntu-latest
+    needs: [preflight, codesign]
+
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: devolutions-gateway
+          pattern: devolutions-gateway-*
+          delete-merged: true
+
+  jetsocat-merge:
+    name: jetsocat merge artifacts
+    runs-on: ubuntu-latest
+    needs: [preflight, codesign]
+
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: jetsocat
+          pattern: jetsocat-*
+          delete-merged: true
 
   web-app:
     name: Web App
@@ -362,15 +357,7 @@ jobs:
     needs: [preflight]
 
     steps:
-      - name: Download artifacts (action)
-        if: needs.preflight.outputs.dl-strategy == 'action'
-        uses: actions/download-artifact@v3
-        with:
-          name: webapp-client
-          path: webapp-client
-
-      - name: Download artifacts (cli)
-        if: needs.preflight.outputs.dl-strategy == 'cli'
+      - name: Download artifacts
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -380,7 +367,7 @@ jobs:
         run: tar -czvf devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz webapp-client
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: webapp-client
           path: devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz
@@ -389,16 +376,16 @@ jobs:
   nuget:
     name: Nuget
     runs-on: ubuntu-latest
-    needs: [preflight, codesign]
+    needs: [preflight, codesign, jetsocat-merge]
 
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: jetsocat
           path: jetsocat/nuget/bin
@@ -440,7 +427,7 @@ jobs:
           Set-ZipItUnixFilePermissions $NugetPackage -FilePattern "native/jetsocat$" -FilePermissions "r-xr-xr-x"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jetsocat-nuget
           path: jetsocat/nuget/*.nupkg
@@ -453,12 +440,12 @@ jobs:
 
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.preflight.outputs.commit }}
 
       - name: Check out Devolutions/actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: Devolutions/actions
           ref: v1
@@ -474,7 +461,7 @@ jobs:
         uses: ./.github/workflows/cdxgen
 
       - name: Save SBOM
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bom.xml
           path: bom.xml


### PR DESCRIPTION
Follow up to #778. Upgrade actions versions in the package workflow.

Historically we had a dual mechanism for downloading CI artifacts. Why? We are specifying the run number of the CI workflow to download artifacts from. If the individual workflows (CI -> Package -> Release) are run individually by `workflow_dispatch`, each workflow will have a distinct run number and we can download it's artifacts using `gh`. If the workflows are dispatched from the `create_new_release` wrapper (`workflow_call`), there is one common run number. However, historically `gh` couldn't handle this situation and we were forced to use `actions/download-artifact` to get the artifacts for the _current_ run.

According to [#5625](https://github.com/cli/cli/issues/5625#issuecomment-1806284038) this issue is corrected when using `upload-artifact@v4`, so we can now use a common download strategy across the board.

Finally, the workflow still complains about deprecated actions versions in actions from [devolutions/actions](https://github.com/Devolutions/actions). I've asked devops for clarification on what to do here.