### PR TITLE
ci: build arm64 deb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,7 +415,6 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Package
-        if: matrix.arch != 'arm64'
         shell: pwsh
         env:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -12,3 +12,5 @@ override_dh_install:
 	dh_install
 	mkdir -p $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
 	cp -r {{ dgateway_webclient }} $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
+override_dh_shlibdeps:
+	{{ dh_shlibdeps }}


### PR DESCRIPTION
Build an arm64 .deb package.

I haven't been able to figure out to get `dh_shlibdeps` to operator on a sysroot (even when pointing it to an arm64 sysroot using the `-l` argument, it complains that it can't check `libc` dependencies because it's not installed by a package.

For now, dependency information is hardcoded for arm64.