### PR TITLE
ci: fix artifact idempotency

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,7 @@ Use the [Create New Release](create-new-release.yml) to run a full build and tes
 ##### Parameters
 
 - `ref` Optional SHA value of the commit to release.
+- `dry-run` If selected, the workflow will only indicate the actions to be taken. No deployment will occur.
 
 ## Making a Release (manual)
 
@@ -35,6 +36,7 @@ It's possible to run the individual workflows and generate a release manually.
  - Find the run ID of the [Package](#package) workflow and use it to call the [Release](#release) workflow. For example:
  
 `gh workflow run release.yml -f run=654321`
+
 ### CI
 
 The "CI" workflow builds, tests and packages `devolutions-gateway` and builds `jetsocat`, for supported platforms. The workflow is run automatically for pull requests and merges, or may be run manually.
@@ -77,10 +79,3 @@ Re-releasing the same version multiple times is not supported. The "Release" wor
 
 - `run` The run-id of the [Package](#package) workflow run containing the artifacts to package
 - `dry-run` If selected, the workflow will only indicate the actions to be taken. No deployment will occur.
-
-### JETSOCAT NUGET
-
-A separate workflow (Release jetsocat nuget package) is provided to generate the nuget package for jetsocat. It will retrieve the jetsocat binaries from the latest GitHub release, wrap them in a nuget package and deploy to Artifactory.
-##### Parameters
-
-- `version` The version for the nuget package. Note that this is distinct from the jetsocat binary version.

--- a/.github/workflows/create-new-release.yml
+++ b/.github/workflows/create-new-release.yml
@@ -18,20 +18,20 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
     with:
-      ref: ${{ github.event.inputs.ref }}
+      ref: ${{ inputs.ref }}
 
   call-package-workflow:
     uses: ./.github/workflows/package.yml
     secrets: inherit
     needs: [ call-ci-workflow ]
     with:
-      ref: ${{ github.event.inputs.ref }}
+      ref: ${{ inputs.ref }}
 
   call-release-workflow:
     ## Only builds from master enable LTO
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || ${{ inputs.dry-run == true }}
     uses: ./.github/workflows/release.yml
     secrets: inherit
     needs: [ call-package-workflow ]
     with:
-      dry-run: ${{ github.event.inputs.dry-run }}
+      dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           name: version
           path: VERSION
+          overwrite: true
 
       - name: Upload docker file artifacts
         uses: actions/upload-artifact@v4
@@ -326,30 +327,42 @@ jobs:
           if-no-files-found: error
 
   devolutions-gateway-merge:
-    name: devolutions gateway merge artifacts
+    name: Merge Artifacts
     runs-on: ubuntu-latest
     needs: [preflight, codesign]
 
     steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: devolutions-gateway
           pattern: devolutions-gateway-*
-          delete-merged: true
+          merge-multiple: true
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ github.workspace }}/**/*
+          name: devolutions-gateway
+          overwrite: true
 
   jetsocat-merge:
-    name: jetsocat merge artifacts
+    name: Merge Artifacts
     runs-on: ubuntu-latest
     needs: [preflight, codesign]
 
     steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: jetsocat
           pattern: jetsocat-*
-          delete-merged: true
+          merge-multiple: true
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ github.workspace }}/**/*
+          name: jetsocat
+          overwrite: true
 
   web-app:
     name: Web App
@@ -372,6 +385,7 @@ jobs:
           name: webapp-client
           path: devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz
           if-no-files-found: error
+          overwrite: true
 
   nuget:
     name: Nuget

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
       run: ${{ steps.get-run.outputs.run }}
       version: ${{ steps.get-version.outputs.version }}
       skip-publishing: ${{ steps.check-release.outputs.skip-publishing }}
-      dry-run: ${{ steps.get-dry-run.outputs.dry-run }}
 
     steps:
       ## workflow_dispatch: The run_id is read from the inputs
@@ -56,11 +55,8 @@ jobs:
           $DryRun = "false"
           if ('${{ inputs.dry-run }}') {
             $DryRun = "${{ inputs.dry-run }}"
-          } elseif ('${{ github.event.inputs.dry-run }}') {
-            $DryRun = "${{ github.event.inputs.dry-run }}"
           }
-          echo "dry-run=$DryRun" >> $Env:GITHUB_OUTPUT
-
+          
           if ([System.Convert]::ToBoolean($DryRun)) {
             echo "::notice::This is a dry run; publishing will be skipped"
           } else {
@@ -108,7 +104,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment: publish-prod
     needs: preflight
-    if: needs.preflight.outputs.skip-publishing == 'false' || needs.preflight.outputs.dry-run == 'true'
+    if: needs.preflight.outputs.skip-publishing == 'false' || ${{ inputs.dry-run }}
     strategy:
       matrix:
         arch: [ x86_64 ]
@@ -194,11 +190,7 @@ jobs:
           $DockerPushCmd = 'docker push ${{ steps.build-container.outputs.image-name }}'
           Write-Host $DockerPushCmd
 
-          $DryRun = $false
-          if ('${{ needs.preflight.outputs.dry-run }}') {
-            $DryRun = [System.Convert]::ToBoolean('${{ needs.preflight.outputs.dry-run }}')
-          }
-
+          $DryRun = [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
           if (-Not $DryRun) {
             Invoke-Expression $DockerPushCmd
           }
@@ -208,7 +200,7 @@ jobs:
     runs-on: ubuntu-20.04
     environment: publish-prod
     needs: preflight
-    if: needs.preflight.outputs.skip-publishing == 'false' || needs.preflight.outputs.dry-run == 'true'
+    if: needs.preflight.outputs.skip-publishing == 'false' || ${{ inputs.dry-run }}
 
     steps:
       - name: Configure runner
@@ -250,11 +242,7 @@ jobs:
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", $Env:GITHUB_REPOSITORY, "--notes-file", $ChangesPath, $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
 
-          $DryRun = $false
-          if ('${{ needs.preflight.outputs.dry-run }}') {
-            $DryRun = [System.Convert]::ToBoolean('${{ needs.preflight.outputs.dry-run }}')
-          }
-
+          $DryRun =  [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
           if (-Not $DryRun) {
             Invoke-Expression $GhCmd
           }
@@ -264,7 +252,7 @@ jobs:
     runs-on: ubuntu-20.04
     environment: publish-prod
     needs: preflight
-    if: needs.preflight.outputs.skip-publishing == 'false' || needs.preflight.outputs.dry-run == 'true'
+    if: needs.preflight.outputs.skip-publishing == 'false' || ${{ inputs.dry-run }}
 
     steps:
       - name: Download artifacts
@@ -286,11 +274,7 @@ jobs:
 
           $PublishCmd = @('Publish-Module', '-Force', '-Path', (Join-Path PowerShell DevolutionsGateway), '-NugetApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
 
-          $DryRun = $false
-          if ('${{ needs.preflight.outputs.dry-run }}') {
-            $DryRun = [System.Convert]::ToBoolean('${{ needs.preflight.outputs.dry-run }}')
-          }
-
+          $DryRun = [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
           if ($DryRun) {
             $PublishCmd += '-WhatIf'
           }
@@ -313,7 +297,7 @@ jobs:
     name: OneDrive
     runs-on: ubuntu-20.04
     needs: preflight
-    if: needs.preflight.outputs.skip-publishing == 'false' || needs.preflight.outputs.dry-run == 'true'
+    if: needs.preflight.outputs.skip-publishing == 'false' || ${{ inputs.dry-run }}
 
     steps:
       - name: Check out Devolutions/actions
@@ -353,7 +337,7 @@ jobs:
 
       - name: Upload to OneDrive
         uses: ./.github/workflows/onedrive-upload
-        if: needs.preflight.outputs.skip-publishing == 'false' && needs.preflight.outputs.dry-run == 'false'
+        if: (needs.preflight.outputs.skip-publishing == 'false') && (inputs.dry-run == false)
         with:
           azure_client_id: ${{ secrets.ONEDRIVE_AUTOMATION_CLIENT_ID }}
           azure_client_secret: ${{ secrets.ONEDRIVE_AUTOMATION_CLIENT_SECRET }}


### PR DESCRIPTION
Fixes issues with immutable artifacts when running the overall "create new release" workflow. Additionally, adds a "dry-run" option to that workflow and does some small cleanup (inputs from both `workflow_dispatch` and `workflow_call` are now both accessible through the `inputs` context).