### PR TITLE
ci: fix packaging of web client

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -325,6 +325,7 @@ jobs:
           name: ${{ matrix.project }}-${{ matrix.os }}
           path: ${{ runner.temp }}/${{ matrix.project }}
           if-no-files-found: error
+          retention-days: 1
 
   devolutions-gateway-merge:
     name: Merge Artifacts
@@ -367,7 +368,7 @@ jobs:
   web-app:
     name: Web App
     runs-on: ubuntu-latest
-    needs: [preflight]
+    needs: [preflight, codesign]
 
     steps:
       - name: Download artifacts


### PR DESCRIPTION
The package workflow has a sequencing error: we need to `tar` the web client _after_ repackaging the Windows Installer; otherwise the tarball gets packaged instead of the directory.