### PR TITLE
ci: fix OneDrive upload step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,8 @@ jobs:
 
           New-Item -Path "$destinationFolder" -ItemType "directory"
           Move-Item -Path "./windows/x86_64/DevolutionsGateway-x86_64-${version}.msi" -Destination "$destinationFolder/DevolutionsGateway-x86_64-${version}.0.msi"
-          Move-Item -Path "./linux/x86_64/devolutions-gateway_${version}_amd64.deb" -Destination "$destinationFolder/devolutions-gateway_${version}.0_amd64.deb"
+
+          # Note that at this point the deb package is already named using the ".0" suffix, so we don’t rename.
 
       - name: Upload to OneDrive
         uses: ./.github/workflows/onedrive-upload


### PR DESCRIPTION
We are trying to rename the filename of the deb package to append the ".0", but it already contains this suffix.

![image](https://github.com/Devolutions/devolutions-gateway/assets/3809077/a855d312-646e-42db-beac-d6252c7caa23)

![image](https://github.com/Devolutions/devolutions-gateway/assets/3809077/282e78bf-b810-45fd-a716-106970e2bffc)
