### PR TITLE
ci: set content type on macOS jetsocat binary

### DIFF
--- a/jetsocat/nuget/Devolutions.Jetsocat.targets
+++ b/jetsocat/nuget/Devolutions.Jetsocat.targets
@@ -15,11 +15,11 @@
         </None>
     </ItemGroup>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-        <Content Include="$(MSBuildThisFileDirectory)../runtimes/osx-universal/native/jetsocat">
+        <None Include="$(MSBuildThisFileDirectory)../runtimes/osx-universal/native/jetsocat" CopyToPublishDirectory="Always" PublishFolderType="Resource">
             <Link>%(Filename)</Link>
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
             <PublishState>Included</PublishState>
-        </Content>
+        </None>
     </ItemGroup>
     <ItemGroup Condition="'$(IsPowerShell)' == 'true'">
         <Content Include="$(MSBuildThisFileDirectory)../runtimes/osx-arm64/native/jetsocat">


### PR DESCRIPTION
In NET 8, the final build does not deploy `jetsocat` to the application bundle "Resources" directory because it doesn't have a content type set. This is documented [here](https://github.com/xamarin/xamarin-macios/blob/main/dotnet/BundleContents.md).