### PR TITLE
ci: skip web client and packaging in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,7 @@ jobs:
     name: devolutions-gateway-web-ui
     runs-on: ubuntu-latest
     needs: preflight
+    if: github.repository_owner == 'Devolutions'
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -347,6 +348,7 @@ jobs:
 
       - name: Download webapp-client
         uses: actions/download-artifact@v4
+        if: github.repository_owner == 'Devolutions'
         with:
           name: webapp-client
           path: webapp/client
@@ -416,6 +418,7 @@ jobs:
 
       - name: Package
         shell: pwsh
+        if: github.repository_owner == 'Devolutions'
         env:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
           DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}


### PR DESCRIPTION
The web client can't be built in a fork, because it requires access to secrets. This also prevents packaging working.

This PR disables those features in different repos. For now that will allow the core CI to run but preclude building changes to the web client, .deb or Windows installer.