### PR TITLE
feat(dgw): return disk space available for recordings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,6 +897,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smol_str",
+ "sysinfo",
  "tap",
  "thiserror",
  "time",
@@ -1053,6 +1054,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "elliptic-curve"
@@ -3035,6 +3042,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rc2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,6 +3885,7 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
+ "rayon",
  "windows 0.52.0",
 ]
 

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -48,6 +48,7 @@ anyhow = "1.0"
 thiserror = "1"
 typed-builder = "0.18"
 backoff = "0.4"
+sysinfo = "0.30"
 
 # Security, crypto…
 picky = { version = "7.0.0-rc.8", default-features = false, features = ["jose", "x509", "pkcs12"] }

--- a/devolutions-gateway/src/api/heartbeat.rs
+++ b/devolutions-gateway/src/api/heartbeat.rs
@@ -17,6 +17,12 @@ pub(crate) struct Heartbeat {
     version: &'static str,
     /// Number of running sessions
     running_session_count: usize,
+    /// The total space of the disk used to store recordings, in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recording_storage_total_space: Option<u64>,
+    /// The remaining available space to store recordings, in bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    recording_storage_available_space: Option<u64>,
 }
 
 /// Performs a heartbeat check
@@ -39,6 +45,8 @@ pub(super) async fn get_heartbeat(
     }): State<DgwState>,
     _scope: HeartbeatReadScope,
 ) -> Result<Json<Heartbeat>, HttpError> {
+    use sysinfo::Disks;
+
     let conf = conf_handle.get_conf();
 
     let running_session_count = sessions
@@ -46,10 +54,51 @@ pub(super) async fn get_heartbeat(
         .await
         .map_err(HttpError::internal().err())?;
 
+    let (recording_storage_total_space, recording_storage_available_space) = if sysinfo::IS_SUPPORTED_SYSTEM {
+        trace!("System is supporting listing storage disks");
+
+        let recording_path = conf
+            .recording_path
+            .canonicalize()
+            .unwrap_or_else(|_| conf.recording_path.clone().into_std_path_buf());
+
+        let disks = Disks::new_with_refreshed_list();
+
+        debug!(?disks, "Found disks");
+
+        let mut recording_disk = None;
+        let mut longest_path = 0;
+
+        for disk in disks.list() {
+            let mount_point = disk.mount_point();
+            let path_len = mount_point.components().count();
+            if recording_path.starts_with(mount_point) && longest_path < path_len {
+                recording_disk = Some(disk);
+                longest_path = path_len;
+            }
+        }
+
+        if let Some(disk) = recording_disk {
+            debug!(?disk, "Disk used to store recordings");
+
+            (Some(disk.total_space()), Some(disk.available_space()))
+        } else {
+            warn!("Failed to find disk used for recording storage");
+
+            (None, None)
+        }
+    } else {
+        debug!("This system does not support listing storage disks");
+
+        (None, None)
+    };
+
     Ok(Json(Heartbeat {
         id: conf.id,
         hostname: conf.hostname.clone(),
         version: env!("CARGO_PKG_VERSION"),
         running_session_count,
+        recording_storage_total_space,
+        recording_storage_available_space,
     }))
 }


### PR DESCRIPTION
The total and available space used for storing recordings is now returned in the heartbeat response.

If the system does not support this operation, the fields are excluded from the response.

Issue: DGW-100

# Example using curl

```
$ curl -H "Accept: application/json" -H "Authorization: Bearer $(./tools/tokengen/target/release/tokengen --provisioner-key ./config/provisioner.priv.key scope gateway.heartbeat.read)" http://127.0.0.1:7171/jet/heartbeat

{"id":"aa0b2a02-bbbb-aaaa-bbbb-03c6391b86fb","hostname":"localhost","version":"2024.1.5","running_session_count":0,"recording_storage_total_space":737616650240,"recording_storage_available_space":199578578944}
```