### PR TITLE
feat(dgw): add /jet/jrec/delete/<ID> endpoint

### DIFF
--- a/devolutions-gateway/src/extract.rs
+++ b/devolutions-gateway/src/extract.rs
@@ -257,6 +257,25 @@ where
 }
 
 #[derive(Clone, Copy)]
+pub struct RecordingDeleteScope;
+
+#[async_trait]
+impl<S> FromRequestParts<S> for RecordingDeleteScope
+where
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match ScopeToken::from_request_parts(parts, state).await?.0.scope {
+            AccessScope::Wildcard => Ok(Self),
+            AccessScope::RecordingDelete => Ok(Self),
+            _ => Err(HttpError::forbidden().msg("invalid scope for route")),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
 pub struct RecordingsReadScope;
 
 #[async_trait]

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -406,6 +406,8 @@ pub enum AccessScope {
     ConfigWrite,
     #[serde(rename = "gateway.heartbeat.read")]
     HeartbeatRead,
+    #[serde(rename = "gateway.recording.delete")]
+    RecordingDelete,
     #[serde(rename = "gateway.recordings.read")]
     RecordingsRead,
 }

--- a/utils/dotnet/Devolutions.Gateway.Utils/src/AccessScope.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils/src/AccessScope.cs
@@ -20,6 +20,7 @@ public struct AccessScope
     public static AccessScope GatewayJrlRead = new AccessScope("gateway.jrl.read");
     public static AccessScope GatewayConfigWrite = new AccessScope("gateway.config.write");
     public static AccessScope GatewayHeartbeatRead = new AccessScope("gateway.heartbeat.read");
+    public static AccessScope GatewayRecordingDelete = new AccessScope("gateway.recording.delete");
     public static AccessScope GatewayRecordingsRead = new AccessScope("gateway.recordings.read");
 
     public override string? ToString()


### PR DESCRIPTION
This new endpoint is used for deleting recordings and allow the service provider (e.g.: DVLS) to delete them according to its policy.

Issue: DGW-96