### PR TITLE
fix(installer)!: install Gateway service as NetworkService

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,11 @@ jobs:
       # WiX is installed on Windows runners but not in the PATH
       - name: Configure Windows runner
         if: matrix.os == 'windows'
-        run: echo "C:\Program Files (x86)\WiX Toolset v3.11\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: |
+          # https://github.com/actions/runner-images/issues/9667
+          choco uninstall wixtoolset
+          choco install wixtoolset --version 3.14.0 --allow-downgrade --force
+          echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -187,8 +187,10 @@ jobs:
         run: |
           echo "C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-          $WixToolsetItem = Get-ChildItem -Path "C:\Program Files (x86)\" -Filter "WiX Toolset v*" | Select-Object -First 1
-          echo "C:\Program Files (x86)\$($WixToolsetItem.Name)\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # https://github.com/actions/runner-images/issues/9667
+          choco uninstall wixtoolset
+          choco install wixtoolset --version 3.14.0 --allow-downgrade --force
+          echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Sign executables
         if: matrix.os == 'windows' || matrix.os == 'macos'

--- a/package/WindowsManaged/DevolutionsGateway.csproj
+++ b/package/WindowsManaged/DevolutionsGateway.csproj
@@ -26,7 +26,6 @@
 	<PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="WixSharp" Version="1.25.1" />
     <PackageReference Include="WixSharp.bin" Version="1.25.1" />
-    <PackageReference Include="WixSharp.wix.bin" Version="3.14.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Security" />

--- a/package/WindowsManaged/Program.cs
+++ b/package/WindowsManaged/Program.cs
@@ -1,4 +1,4 @@
-﻿using DevolutionsGateway.Actions;
+using DevolutionsGateway.Actions;
 using DevolutionsGateway.Dialogs;
 using DevolutionsGateway.Properties;
 using DevolutionsGateway.Resources;
@@ -242,6 +242,7 @@ internal class Program
                         ServiceInstaller = new ServiceInstaller()
                         {
                             Type = SvcType.ownProcess,
+                            Account = "NT AUTHORITY\\NetworkService",
                             Interactive = false,
                             Vital = true,
                             Name = Includes.SERVICE_NAME,

--- a/package/WindowsManaged/Resources/Includes.cs
+++ b/package/WindowsManaged/Resources/Includes.cs
@@ -28,13 +28,28 @@ namespace DevolutionsGateway.Resources
         /// <summary>
         /// SDDL string representing desired %programdata%\devolutions\gateway ACL
         /// Easiest way to generate an SDDL is to configure the required access, and then query the path with PowerShell: `Get-Acl | Format-List`
-        /// SYSTEM/BuiltInAdministrators = Full Control, LocalService = Read / Write / Execute, BuiltInUsers - Read/Execute
         /// </summary>
-        internal static string PROGRAM_DATA_SDDL = "D:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)";
+        /// <remarks>
+        /// Owner  : NT AUTHORITY\SYSTEM
+        /// Group  : NT AUTHORITY\SYSTEM
+        /// Access :
+        ///    NT AUTHORITY\SYSTEM Allow  FullControl
+        ///    NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize
+        ///    NT AUTHORITY\NETWORK SERVICE Allow Modify, Synchronize
+        ///    BUILTIN\Administrators Allow  FullControl
+        ///    BUILTIN\Users Allow ReadAndExecute, Synchronize
+        /// </remarks>
+        internal static string PROGRAM_DATA_SDDL = "O:SYG:SYD:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;0x1301bf;;;NS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)";
 
-        /// <summary>
-        /// NT AUTHORITY\SYSTEM Allow  FullControl, NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize, BUILTIN\Administrators Allow  FullControl
-        /// </summary>
-        internal static string USERS_FILE_SDDL = "O:SYG:SYD:PAI(A;;FA;;;SY)(A;;0x1201bf;;;LS)(A;;FA;;;BA)";
+        /// <remarks>
+        /// Owner  : NT AUTHORITY\SYSTEM
+        /// Group  : NT AUTHORITY\SYSTEM
+        /// Access :
+        ///    NT AUTHORITY\SYSTEM Allow  FullControl
+        ///    NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize
+        ///    NT AUTHORITY\NETWORK SERVICE Allow Write, ReadAndExecute, Synchronize
+        ///    BUILTIN\Administrators Allow  FullControl
+        /// </remarks>
+        internal static string USERS_FILE_SDDL = "O:SYG:SYD:PAI(A;;FA;;;SY)(A;;0x1201bf;;;LS)(A;;0x1201bf;;;NS)(A;;FA;;;BA)";
     }
 }


### PR DESCRIPTION
Install the Devolutions Gateway service under the `NetworkService` account instead of `LocalSystem`. This significantly reduces the permissions available to the service account.

Relevant file paths are updated to grant `NetworkService` the appropriate access. Broadly, file permissions in %programdata%/Devolutions/Gateway are inherited from the "Gateway" parent directory. In my tests there is no issue; however it could cause a problem if users have manually adjusted file permissions or customized their setup in unforeseen ways.

> [!WARNING]  
> We attempted this modification before but backed out again after at least one breaking problem in a customer environment. This is a change that we must make and we are likely in a better footing now to diagnose and deal with any resultant problems. If possible, we should call this out in the release notes as a potentially breaking change.

Additionally, rollback the `wixtoolset` version in CI. Latest GitHub runners ship version 3.14.1, which is [broken](https://github.com/actions/runner-images/issues/9667). This can be reverted once 3.14.2 is published to chocolatey and the runner images are updated.

Issue: VM-1923