### PR TITLE
fix(webapp): fix netscan result duplicate and performance improvement

### DIFF
--- a/webapp/src/client/app/shared/services/net-scan.services.ts
+++ b/webapp/src/client/app/shared/services/net-scan.services.ts
@@ -24,6 +24,8 @@ export class NetScanService {
   private serviceUpdatePipe: Subject<NetScanEntry> =
     new Subject<NetScanEntry>();
 
+  private serviceCache: Set<String> = new Set<String>();
+
   constructor(private webClientService: WebClientService) {}
 
   public startScan(): Observable<NetScanEntry> {
@@ -59,6 +61,10 @@ export class NetScanService {
                 return ProtocolIconMap[protocol];
               }
             };
+            if (this.serviceCache.has(JSON.stringify(value))) {
+              return;
+            }
+            this.serviceCache.add(JSON.stringify(value));
             observer.next(value);
           };
 

--- a/webapp/src/client/app/shared/services/net-scan.services.ts
+++ b/webapp/src/client/app/shared/services/net-scan.services.ts
@@ -26,59 +26,36 @@ export class NetScanService {
 
   // JS set doesn't allow customized equality check, so we stringify for deep comparison
   private serviceCache: Set<String> = new Set<String>();
+  private scanSubject = new Subject<NetScanEntry>();
 
-  constructor(private webClientService: WebClientService) {}
+  constructor(private webClientService: WebClientService) {
+    this.webClientService
+      .fetchNetScanToken()
+      .pipe(
+        map((token: string) => {
+          let path = `${this.scanUrl}?token=${token}`;
+          let url_http = new URL(path, window.location.href).toString();
+          let url = url_http.replace('http', 'ws');
+          return new WebSocket(url);
+        })
+      )
+      .subscribe((socket: WebSocket) => {
+        socket.onmessage = (event) => {
+          this.socketOnMessage(event);
+        };
+        socket.onclose = () => {
+          this.scanSubject.complete();
+        };
+        socket.onerror = () => {
+          this.scanSubject.error('Error scanning network');
+        };
+      });
+  }
 
   public startScan(): Observable<NetScanEntry> {
-    const newObserveable = new Observable<NetScanEntry>((observer) => {
-      this.webClientService
-        .fetchNetScanToken()
-        .pipe(
-          map((token: string) => {
-            let path = `${this.scanUrl}?token=${token}`;
-            let url_http = new URL(path, window.location.href).toString();
-            let url = url_http.replace('http', 'ws');
-            return new WebSocket(url);
-          })
-        )
-        .subscribe((socket: WebSocket) => {
-          // listen for new entries from the server
-          socket.onmessage = (event) => {
-            let entry: {
-              ip: string;
-              hostname: string;
-              protocol: string;
-            } = JSON.parse(event.data);
-
-            let protocol = ProtocolNameToProtocolMap[entry.protocol];
-            // We don't yet support this protocol
-            if (!protocol) {
-              return;
-            }
-            let value = {
-              ip: entry.ip,
-              hostname: entry.hostname,
-              protocol: protocol,
-              icon: () => {
-                return ProtocolIconMap[protocol];
-              }
-            };
-            if (this.serviceCache.has(JSON.stringify(value))) {
-              return;
-            }
-            this.serviceCache.add(JSON.stringify(value));
-            observer.next(value);
-          };
-
-          socket.onclose = () => {
-            observer.complete();
-          };
-        });
-    });
-
     const existingObservable = from(this.serviceCache).pipe(
       map((entry: string) => {
-        let toAdd =  JSON.parse(entry);
+        let toAdd = JSON.parse(entry);
         toAdd.icon = () => {
           return ProtocolIconMap[toAdd.protocol];
         };
@@ -86,9 +63,8 @@ export class NetScanService {
       })
     );
 
-    return merge(newObserveable, existingObservable);
+    return merge(existingObservable, this.scanSubject.asObservable());
   }
-
 
   serviceSelected(entry: NetScanEntry) {
     this.serviceUpdatePipe.next(entry);
@@ -96,5 +72,36 @@ export class NetScanService {
 
   onServiceSelected(): Observable<NetScanEntry> {
     return this.serviceUpdatePipe.asObservable();
+  }
+
+  socketOnMessage(event) {
+    let entry: {
+      ip: string;
+      hostname: string;
+      protocol: string;
+    } = JSON.parse(event.data);
+
+    let protocol = ProtocolNameToProtocolMap[entry.protocol];
+    // We don't yet support this protocol
+    if (!protocol) {
+      return;
+    }
+
+    let value = {
+      ip: entry.ip,
+      hostname: entry.hostname,
+      protocol: protocol,
+    };
+
+    if (this.serviceCache.has(JSON.stringify(value))) {
+      return;
+    }
+    this.serviceCache.add(JSON.stringify(value));
+    this.scanSubject.next({
+      ...value,
+      icon: () => {
+        return ProtocolIconMap[protocol];
+      },
+    });
   }
 }

--- a/webapp/src/client/app/shared/services/net-scan.services.ts
+++ b/webapp/src/client/app/shared/services/net-scan.services.ts
@@ -39,16 +39,23 @@ export class NetScanService {
           return new WebSocket(url);
         })
       )
-      .subscribe((socket: WebSocket) => {
-        socket.onmessage = (event) => {
-          this.socketOnMessage(event);
-        };
-        socket.onclose = () => {
-          this.scanSubject.complete();
-        };
-        socket.onerror = () => {
-          this.scanSubject.error('Error scanning network');
-        };
+      .subscribe({
+        next: (socket: WebSocket) => {
+          socket.onmessage = (event) => {
+            this.socketOnMessage(event);
+          };
+          socket.onclose = () => {
+            this.scanSubject.complete();
+          };
+          socket.onerror = () => {
+            this.scanSubject.error('Error scanning network');
+          };
+        },
+
+        error: (error) => {
+          // Error create the websocket
+          this.scanSubject.error(error);
+        },
       });
   }
 


### PR DESCRIPTION
Before: Netscan request is fired whenever this netscan component is mounted
After: Netscan request only one time per each web session. All results are cached in memory.