### PR TITLE
fix(webapp): fix version compare logic

### DIFF
--- a/webapp/src/client/app/modules/base/menu/app-menu.component.ts
+++ b/webapp/src/client/app/modules/base/menu/app-menu.component.ts
@@ -118,19 +118,19 @@ export class AppMenuComponent extends BaseComponent implements  OnInit {
   }
 
   hasNewVersion() {
-    return this.version && this.latestVersion && !isSameVersion(this.version, this.latestVersion);
+    return this.version && this.latestVersion && compareVersion(this.version, this.latestVersion) < 0;
   }
-
 }
 
-function isSameVersion(a: string, b: string): boolean {
-  const aParts = a.split('.').map(Number);
-  const bParts = b.split('.').map(Number);
-  for (let i = 0; i < Math.min(aParts.length,bParts.length); i++) {
-    if (aParts[i] !== bParts[i]) {
-      return false;
+function compareVersion(a:string,b:string) {
+  const partsA = a.split('.');
+  const partsB = b.split('.');
+  for (let i = 0; i < partsA.length; i++) {
+    if (parseInt(partsA[i]) > parseInt(partsB[i])) {
+      return 1;
+    } else if (parseInt(partsA[i]) < parseInt(partsB[i])) {
+      return -1;
     }
   }
-
-  return true;
+  return 0;
 }


### PR DESCRIPTION
Before:  show version update icon when version  is different, the logic is that user would not be able to install a version we haven't released.

After: strictly check the version, only show icon if the latest version is greater than the current version

Issue: DGW-182