### PR TITLE
DGW-164-Webapp-Suspicious-e-logs-in-web-application

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -24,7 +24,7 @@
         "@devolutions/web-telnet-gui": "^0.2.15",
         "primeflex": "3.3.1",
         "primeicons": "6.0.1",
-        "primeng": "16.5.0",
+        "primeng": "16.2.0",
         "prismjs": "1.29.0",
         "rxjs": "^6.6.7",
         "tslib": "2.6.1",
@@ -10246,9 +10246,9 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "node_modules/primeng": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/primeng/-/primeng-16.5.0.tgz",
-      "integrity": "sha512-fgtTJZ76YODexoZctqCEg0on4BG4uCcJy1l4iaCoaHhMFzcgP89U4gdQ5debz0oEF4TekmBLLKvfEzGtF5fEgg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-16.2.0.tgz",
+      "integrity": "sha512-crJ5Ef6KOND2G70k6rPtkCA/AcDfbzWtFN9v/oaYjmEVQVSpyr4nux2vEHFBOs+zYBjQQOpSNtXRZmIkln5Ulg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -26,7 +26,7 @@
     "@devolutions/web-ssh-gui": "^0.2.14",
     "primeflex": "3.3.1",
     "primeicons": "6.0.1",
-    "primeng": "16.5.0",
+    "primeng": "16.2.0",
     "prismjs": "1.29.0",
     "rxjs": "^6.6.7",
     "tslib": "2.6.1",


### PR DESCRIPTION
Downgraded the Primeng package as the console log was introduced in version 16.5.0.

Upgrading to the next Primeng version would cause a cascade of updates for the majority of the angular dependencies. This includes upgrading the rxjs package, however, in doing so would cause a conflict in the web packages for IronRDP & IronVNC. We should make future plans to perform this update.

Issue: DGW-164