### PR TITLE
build(webapp): build using production profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
       - name: Build
         shell: pwsh
         working-directory: webapp
-        run: ng build
+        run: npm run build
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Current CI build web app without optimization, we hence packed source map together with our Windows installer.

This will allow analytic data to get sent under correct index.