### PR TITLE
fix(pwsh): fix reading .pem files from PowerShell runspace

### DIFF
--- a/powershell/DevolutionsGateway/Private/CertificateHelper.ps1
+++ b/powershell/DevolutionsGateway/Private/CertificateHelper.ps1
@@ -230,28 +230,25 @@ function Get-PemCertificate
             $PrivateKey = $expanded.PrivateKey.ToPem().ToRepr()
         }
     } else {
-        $utf8 = New-Object System.Text.UTF8Encoding
-
-        $PemData = [System.IO.File]::ReadAllBytes($CertificateFile)
-
+        
         try {
+            $PemData = [System.IO.File]::ReadAllBytes($CertificateFile)
             # Try to parse the file as if it was a DER binary file.
             $Cert = [Devolutions.Picky.Cert]::FromDer($PemData);
             $PemData = $Cert.ToPem().ToRepr();
         } catch {
             # Assume we have a PEM.
-            $PemData = $utf8.GetString($PemData)
+            $PemData = Get-Content -Path $CertificateFile -Encoding UTF8 -Raw
         }
 
-        $PrivateKey = [System.IO.File]::ReadAllBytes($PrivateKeyFile)
-
         try {
+            $PrivateKey = [System.IO.File]::ReadAllBytes($PrivateKeyFile)
             # Try to parse the file as if it was a DER binary file.
             $PrivateKey = [Devolutions.Picky.PrivateKey]::FromPkcs8($PrivateKey);
             $PrivateKey = $PrivateKey.ToPem().ToRepr();
         } catch {
             # Assume we have a PEM.
-            $PrivateKey = $utf8.GetString($PrivateKey)
+            $PrivateKey = Get-Content -Path $PrivateKeyFile -Encoding UTF8 -Raw
         }
     }
 


### PR DESCRIPTION
When we call [Encoding.GetString(byte[])](https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getstring?view=net-8.0#system-text-encoding-getstring(system-byte())) from a C# PowerShell runspace (e.g. DPS Console), we are getting the following error:

>The following exception occurred while retrieving member "GetString": "GenericArguments[0], 'System.ReadOnlySpan`1[System.Byte]', on 'System.Func`2[T,TResult]' violates the constraint of type 'T'."

I don't know why. This results in an empty `$PemData` which obviously can't be parsed.

The workaround is to read the certificate and private key file directly as UTF8, rather than getting the UTF8 representation of the data.