### PR TITLE
fix(installer): use Win32 to set file permissions

### DIFF
--- a/package/WindowsManaged/Actions/GatewayActions.cs
+++ b/package/WindowsManaged/Actions/GatewayActions.cs
@@ -130,9 +130,9 @@ internal static class GatewayActions
     /// <summary>
     /// Set or reset the ACL on %programdata%\Devolutions\Gateway
     /// </summary>
-    private static readonly WixQuietExecAction setProgramDataDirectoryPermissions = new(
-        "cmd.exe",
-        $"/c ECHO Y| \"%windir%\\System32\\cacls.exe\" \"%ProgramData%\\{Includes.VENDOR_NAME}\\{Includes.SHORT_NAME}\" /S:{Includes.PROGRAM_DATA_SDDL} /C /t",
+    private static readonly ElevatedManagedAction setProgramDataDirectoryPermissions = new(
+        new Id($"CA.{nameof(setProgramDataDirectoryPermissions)}"),
+        CustomActions.SetProgramDataDirectoryPermissions,
         Return.ignore,
         When.After, new Step(createProgramDataDirectory.Id),
         Condition.Always,
@@ -145,22 +145,18 @@ internal static class GatewayActions
     /// <summary>
     /// Set or reset the ACL on %programdata%\Devolutions\Gateway\users.txt
     /// </summary>
-    private static readonly WixQuietExecAction setUserDatabasePermissions = new(
-        "cmd.exe",
-        $"/c ECHO Y| \"%windir%\\System32\\cacls.exe\" \"%ProgramData%\\{Includes.VENDOR_NAME}\\{Includes.SHORT_NAME}\\users.txt\" /S:{Includes.USERS_FILE_SDDL} /C",
-        Return.ignore,
-        When.Before, Step.InstallFinalize,
-        Condition.Always,
-        Sequence.InstallExecuteSequence)
+    private static readonly ElevatedManagedAction setUserDatabasePermissions = new(
+            new Id($"CA.{nameof(setUserDatabasePermissions)}"),
+            CustomActions.SetUsersDatabaseFilePermissions,
+            Return.ignore,
+            When.Before, Step.InstallFinalize,
+            Condition.Always,
+            Sequence.InstallExecuteSequence)
     {
         Execute = Execute.deferred,
         Impersonate = false,
     };
 
-    /// <summary>
-    /// </summary>
-    /// <remarks>
-    /// </remarks>
     private static readonly ElevatedManagedAction cleanGatewayConfigIfNeeded = new(
         new Id($"CA.{nameof(cleanGatewayConfigIfNeeded)}"),
         CustomActions.CleanGatewayConfig,
@@ -173,11 +169,7 @@ internal static class GatewayActions
         Impersonate = false,
         UsesProperties = UseProperties(new [] { GatewayProperties.installId })
     };
-
-    /// <summary>
-    /// </summary>
-    /// <remarks>
-    /// </remarks>
+    
     private static readonly ElevatedManagedAction cleanGatewayConfigIfNeededRollback = new(
         new Id($"CA.{nameof(cleanGatewayConfigIfNeededRollback)}"),
         CustomActions.CleanGatewayConfigRollback,

--- a/package/WindowsManaged/Actions/WinAPI.cs
+++ b/package/WindowsManaged/Actions/WinAPI.cs
@@ -11,6 +11,8 @@ internal static class WinAPI
 
     internal static uint CREATE_NO_WINDOW = 0x08000000;
 
+    internal const uint DACL_SECURITY_INFORMATION = 0x00000004;
+
     internal const int EM_SETCUEBANNER = 0x1501;
 
     internal static uint FILE_ATTRIBUTE_NORMAL = 0x00000080;
@@ -195,6 +197,10 @@ internal static class WinAPI
     [DllImport("advapi32", EntryPoint = "CloseServiceHandle")]
     internal static extern int CloseServiceHandle(IntPtr hSCObject);
 
+    [DllImport("advapi32", SetLastError = true, CharSet = CharSet.Unicode)]
+    internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptorW(string StringSecurityDescriptor, uint StringSDRevision, out IntPtr SecurityDescriptor, out UIntPtr SecurityDescriptorSize);
+
+
     [DllImport("advapi32", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool ControlService(IntPtr hService, uint dwControl, IntPtr lpServiceStatus);
@@ -250,6 +256,9 @@ internal static class WinAPI
         uint uUnique,
         [Out] StringBuilder lpTempFileName);
 
+    [DllImport("kernel32", SetLastError = true)]
+    internal static extern IntPtr LocalFree(IntPtr hMem);
+
     [DllImport("kernel32", EntryPoint = "MoveFileExW", CharSet = CharSet.Unicode, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool MoveFileEx(
@@ -282,6 +291,9 @@ internal static class WinAPI
         int msg,
         int wParam,
         [MarshalAs(UnmanagedType.LPWStr)] string lParam);
+
+    [DllImport("advapi32", SetLastError = true, CharSet = CharSet.Unicode)]
+    internal static extern bool SetFileSecurityW(string lpFileName, uint SecurityInformation, IntPtr pSecurityDescriptor);
 
     [DllImport("advapi32", EntryPoint = "StartServiceW", SetLastError = true)]
     internal static extern bool StartService(IntPtr hService, uint dwNumServiceArgs, IntPtr lpServiceArgVectors);


### PR DESCRIPTION
Use Win32 `SetFileSecurity` to fix the permissions on the program data and users database, instead of shelling out to cacls.exe.