### PR TITLE
fix(dgw): IP restrictions fallback for ngrok TCP listeners

### DIFF
--- a/devolutions-gateway/src/ngrok.rs
+++ b/devolutions-gateway/src/ngrok.rs
@@ -59,6 +59,8 @@ impl NgrokSession {
                     builder = builder.metadata(metadata);
                 }
 
+                let before_cidrs = builder.clone();
+
                 builder = tcp_conf
                     .allow_cidrs
                     .iter()
@@ -68,6 +70,31 @@ impl NgrokSession {
                     .deny_cidrs
                     .iter()
                     .fold(builder, |builder, cidr| builder.deny_cidr(cidr));
+
+                // HACK: Find the subscription plan. This uses ngrok-rs internal API, so it’s not great.
+                // Ideally, we could use the `Session` to find out about the subscription plan without dirty tricks.
+                match builder
+                    .clone()
+                    .forwards_to("Devolutions Gateway Subscription probe")
+                    .listen()
+                    .await
+                {
+                    // https://ngrok.com/docs/errors/err_ngrok_9017/
+                    // "Your account is not authorized to use ip restrictions."
+                    Err(ngrok::session::RpcError::Response(e))
+                        if e.error_code.as_deref() == Some("ERR_NGROK_9017")
+                            || e.error_code.as_deref() == Some("9017") =>
+                    {
+                        info!(
+                            address = tcp_conf.remote_addr,
+                            "Detected a ngrok free plan subscription. IP restriction rules are disabled."
+                        );
+
+                        // Revert the builder to before applying the CIDR rules.
+                        builder = before_cidrs;
+                    }
+                    _ => {}
+                }
 
                 NgrokTunnel {
                     name: name.to_owned(),
@@ -115,8 +142,14 @@ impl NgrokSession {
                 {
                     // https://ngrok.com/docs/errors/err_ngrok_9017/
                     // "Your account is not authorized to use ip restrictions."
-                    Err(ngrok::session::RpcError::Response(e)) if e.error_code.as_deref() == Some("ERR_NGROK_9017") => {
-                        info!("Detected a ngrok free plan subscription. IP restriction rules are disabled.");
+                    Err(ngrok::session::RpcError::Response(e))
+                        if e.error_code.as_deref() == Some("ERR_NGROK_9017")
+                            || e.error_code.as_deref() == Some("9017") =>
+                    {
+                        info!(
+                            domain = http_conf.domain,
+                            "Detected a ngrok free plan subscription. IP restriction rules are disabled."
+                        );
 
                         // Revert the builder to before applying the CIDR rules.
                         builder = before_cidrs;


### PR DESCRIPTION
Now properly fallbacks to disabling IP restriction rules for TCP listeners as well.

Issue: DGW-193