### PR TITLE
fix(dotnet-utils): handle invalid ports in TargetAddr constructor

### DIFF
--- a/utils/dotnet/Devolutions.Gateway.Utils.Tests/JsonSerializationTests.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils.Tests/JsonSerializationTests.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace Devolutions.Gateway.Utils.Tests;
 
-public class JsonSerialization
+public class JsonSerializationTests
 {
     static readonly Guid gatewayId = new Guid("ccbaad3f-4627-4666-8bb5-cb6a1a7db815");
     static readonly Guid sessionId = new Guid("3e7c1854-f1eb-42d2-b9cb-9303036e50da");

--- a/utils/dotnet/Devolutions.Gateway.Utils.Tests/TargetAddrTests.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils.Tests/TargetAddrTests.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+
+namespace Devolutions.Gateway.Utils.Tests;
+
+public class TargetAddrTests
+{
+    [Fact]
+    public void Smoke()
+    {
+        TargetAddr addr = new TargetAddr("tcp", "devolutions.net", 443);
+        Assert.Equal("tcp", addr.Scheme);
+        Assert.Equal("devolutions.net", addr.Host);
+        Assert.Equal(443, addr.Port);
+        Assert.Equal("tcp://devolutions.net:443", addr.ToString());
+    }
+
+    [Fact]
+    public void NegativePortIsIgnored()
+    {
+        TargetAddr addr = new TargetAddr("tcp", "devolutions.net", -1);
+        Assert.Equal("tcp", addr.Scheme);
+        Assert.Equal("devolutions.net", addr.Host);
+        Assert.Null(addr.Port);
+    }
+
+    [Fact]
+    public void TooBigPortIsIgnored()
+    {
+        TargetAddr addr = new TargetAddr("tcp", "devolutions.net", 65539);
+        Assert.Equal("tcp", addr.Scheme);
+        Assert.Equal("devolutions.net", addr.Host);
+        Assert.Null(addr.Port);
+    }
+}

--- a/utils/dotnet/Devolutions.Gateway.Utils.Tests/TokenUtilsTests.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils.Tests/TokenUtilsTests.cs
@@ -2,7 +2,7 @@ using System.Text.Json;
 
 namespace Devolutions.Gateway.Utils.Tests;
 
-public class TestUtils
+public class TokenUtilsTests
 {
     private static readonly string privKeyPemRepr = @"-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDkrPiL/5dmGIT5

--- a/utils/dotnet/Devolutions.Gateway.Utils/Devolutions.Gateway.Utils.csproj
+++ b/utils/dotnet/Devolutions.Gateway.Utils/Devolutions.Gateway.Utils.csproj
@@ -11,7 +11,7 @@
     <Description>Useful classes to use Devolutions Gateway</Description>
     <Copyright>© Devolutions Inc. All rights reserved.</Copyright>
     <RootNamespace>Devolutions.Gateway.Utils</RootNamespace>
-    <Version>2024.1.30.0</Version>
+    <Version>2024.6.13.0</Version>
     <PackageLicenseExpression>MIT OR Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Devolutions/devolutions-gateway.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/utils/dotnet/Devolutions.Gateway.Utils/src/TargetAddr.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils/src/TargetAddr.cs
@@ -12,11 +12,19 @@ public class TargetAddr
 
     public int? Port { get; set; }
 
-    public TargetAddr(string scheme, string host, int port)
+    public TargetAddr(string scheme, string host, int? port)
     {
         this.Scheme = scheme;
         this.Host = host;
-        this.Port = port;
+
+        if (port < 0 || port > 65535)
+        {
+            this.Port = null;
+        }
+        else
+        {
+            this.Port = port;
+        }
     }
 
     public TargetAddr(Uri uri)


### PR DESCRIPTION
Make the `TargetAddr` more robust and easier to use by checking for invalid ports in its constructor.