### PR TITLE
ci: bump required Pester version to 5.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,7 +715,7 @@ jobs:
         - name: Install Pester module
           id: prepare
           shell: pwsh
-          run: Install-Module Pester -RequiredVersion 5.5.0 -Force
+          run: Install-Module Pester -RequiredVersion 5.6.0
 
         - name: Build module
           shell: pwsh


### PR DESCRIPTION
I also removed the `-Force` parameter as it does nothing as per the doc.

> The proxy cmdlet ignores this parameter since it's not supported
> by `Install-PSResource`.

https://learn.microsoft.com/en-us/powershell/module/powershellget/install-module?view=powershellget-3.x#-force