### PR TITLE
ci: update macOS runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           $Platforms += 'macos'
 
           $Platforms | ForEach-Object {
-              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'macos' { 'macos-11' } 'linux' { 'ubuntu-20.04' } }
+              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'macos' { 'macos-12' } 'linux' { 'ubuntu-20.04' } }
               foreach ($Arch in $Archs) {
                   $Jobs += @{
                       arch = $Arch


### PR DESCRIPTION
`macos-11` runners are deprecated and need to be updated.

I've moved incrementally to `macos-12` to reduce headaches right now: later versions (13 and 14) require us to choose between Intel and Apple Silicon runners, which might require some further tweaking on our side. So I'm kicking that can down the road 🙄 