### PR TITLE
fix(installer): fix parsing errors with configuration check

### DIFF
--- a/package/WindowsManaged/Actions/FileAccess.cs
+++ b/package/WindowsManaged/Actions/FileAccess.cs
@@ -9,6 +9,7 @@ namespace DevolutionsGateway.Actions
 {
     internal enum FileAccess
     {
+        None,
         Read,
         Write,
         Modify,

--- a/package/WindowsManaged/Configuration/Ngrok.cs
+++ b/package/WindowsManaged/Configuration/Ngrok.cs
@@ -6,9 +6,9 @@ namespace DevolutionsGateway.Configuration
     {
         public string AuthToken { get; set; }
 
-        public int HeartbeatInterval { get; set; }
+        public int? HeartbeatInterval { get; set; }
 
-        public int HeartbeatTolerance { get; set; }
+        public int? HeartbeatTolerance { get; set; }
 
         public string Metadata { get; set; }
 

--- a/package/WindowsManaged/Configuration/WebApp.cs
+++ b/package/WindowsManaged/Configuration/WebApp.cs
@@ -9,9 +9,9 @@ namespace DevolutionsGateway.Configuration
 
         public string Authentication { get; set; }
 
-        public int AppTokenMaximumLifetime { get; set; }
+        public int? AppTokenMaximumLifetime { get; set; }
 
-        public int LoginLimitRate { get; set; }
+        public int? LoginLimitRate { get; set; }
 
         [DefaultValue(Actions.CustomActions.DefaultUsersFile)]
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Populate)]


### PR DESCRIPTION
There are places in Gateway.json where the service encodes `null` instead of omitting the key; the deserialization in the installer did not account for this behaviour.

Further, write general parsing errors to the configuration report so we don't need to dig the logs to find subsequent problems here.