### PR TITLE
fix(dgw): properly stop session and recording manager tasks

### DIFF
--- a/devolutions-gateway/src/subscriber.rs
+++ b/devolutions-gateway/src/subscriber.rs
@@ -233,7 +233,7 @@ async fn subscriber_task(
             }
             msg = rx.recv() => {
                 let Some(msg) = msg else {
-                    warn!("All senders are dead");
+                    debug!("All senders are dead");
                     break;
                 };
 


### PR DESCRIPTION
The session and recording manager tasks were waiting for each other. This prevent the service from shutting down gracefully.