### PR TITLE
fix(dgw): make recording policy enforcing more robust

### DIFF
--- a/devolutions-gateway/src/session.rs
+++ b/devolutions-gateway/src/session.rs
@@ -510,15 +510,20 @@ impl Task for EnsureRecordingPolicyTask {
             Either::Right(_) => return,
         }
 
-        let is_not_recording = self
+        let is_recording = self
             .recording_manager_handle
             .get_state(self.session_id)
             .await
             .ok()
             .flatten()
-            .is_none();
+            .is_some();
 
-        if is_not_recording {
+        if is_recording {
+            let _ = self
+                .recording_manager_handle
+                .update_recording_policy(self.session_id, true)
+                .await;
+        } else {
             match self.session_manager_handle.kill_session(self.session_id).await {
                 Ok(KillResult::Success) => {
                     warn!(


### PR DESCRIPTION
Previously the policy wasn’t properly enforced when the session was started after the recording stream was opened.
In practice it’s very unlikely to happen since all clients we are aware of are opening the recording stream after the session is started. However, at the Devolutions Gateway level, opening the recording stream first is also a totally valid flow that we don’t forbid. This patch is accounting for this by updating the recording policy accordingly on recording manager side once the session is opened.