### PR TITLE
feat(agent): initial NOW-PROTO implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,7 @@ dependencies = [
  "futures",
  "hex",
  "notify-debouncer-mini",
+ "now-proto-pdu",
  "parking_lot",
  "reqwest",
  "serde",
@@ -1092,6 +1093,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dissimilar"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+
+[[package]]
 name = "dlopen"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,6 +1243,16 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
+name = "expect-test"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
 
 [[package]]
 name = "fastrand"
@@ -2467,6 +2484,15 @@ dependencies = [
  "crossbeam-channel",
  "log",
  "notify",
+]
+
+[[package]]
+name = "now-proto-pdu"
+version = "0.1.0"
+dependencies = [
+ "bitflags 2.4.2",
+ "expect-test",
+ "rstest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 ]
 default-members = [
     "devolutions-gateway",
+    "devolutions-agent",
     "jetsocat",
 ]
 

--- a/crates/now-proto-pdu/Cargo.toml
+++ b/crates/now-proto-pdu/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "now-proto-pdu"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bitflags = "2"
+
+
+[dev-dependencies]
+rstest = "0.19"
+expect-test = "1"
+
+[features]
+default = ["std"]
+std = []

--- a/crates/now-proto-pdu/src/core/buffer.rs
+++ b/crates/now-proto-pdu/src/core/buffer.rs
@@ -1,0 +1,183 @@
+//! Buffer types for NOW protocol.
+
+use alloc::vec::Vec;
+
+use super::VarU32;
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    PduDecode, PduEncode, PduResult,
+};
+
+/// String value up to 2^32 bytes long.
+///
+/// NOW-PROTO: NOW_LRGBUF
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowLrgBuf(Vec<u8>);
+
+impl NowLrgBuf {
+    const NAME: &'static str = "NOW_LRGBUF";
+    const FIXED_PART_SIZE: usize = 4;
+
+    /// Create a new `NowLrgBuf` instance. Returns an error if the provided value is too large.
+    pub fn new(value: impl Into<Vec<u8>>) -> PduResult<Self> {
+        let value = value.into();
+
+        let _: u32 = value
+            .len()
+            .try_into()
+            .map_err(|_| invalid_message_err!("data", "data is too large for NOW_LRGBUF"))?;
+
+        Ok(NowLrgBuf(value))
+    }
+
+    /// Get the buffer value.
+    pub fn value(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl PduEncode for NowLrgBuf {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+        ensure_size!(in: dst, size: encoded_size);
+
+        let len: u32 = self.0.len().try_into().expect("BUG: validated in constructor");
+
+        dst.write_u32(len);
+        dst.write_slice(self.0.as_slice());
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE  /* u32 size */
+            + self.0.len() /* data bytes */
+    }
+}
+
+impl PduDecode<'_> for NowLrgBuf {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let len: usize = cast_length!("len", src.read_u32())?;
+
+        ensure_size!(in: src, size: len);
+        let bytes = src.read_slice(len);
+
+        Ok(NowLrgBuf(bytes.to_vec()))
+    }
+}
+
+impl From<NowLrgBuf> for Vec<u8> {
+    fn from(buf: NowLrgBuf) -> Self {
+        buf.0
+    }
+}
+
+/// Buffer up to 2^31 bytes long (Length has compact variable length encoding).
+///
+/// NOW-PROTO: NOW_VARBUF
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowVarBuf(Vec<u8>);
+
+impl NowVarBuf {
+    const NAME: &'static str = "NOW_VARBUF";
+
+    /// Create a new `NowVarBuf` instance. Returns an error if the provided value is too large.
+    pub fn new(value: impl Into<Vec<u8>>) -> PduResult<Self> {
+        let value = value.into();
+
+        let _: u32 = value
+            .len()
+            .try_into()
+            .ok()
+            .and_then(|val| if val <= VarU32::MAX { Some(val) } else { None })
+            .ok_or_else(|| invalid_message_err!("string value", "too large string"))?;
+
+        Ok(NowVarBuf(value))
+    }
+
+    /// Get the buffer value.
+    pub fn value(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl PduEncode for NowVarBuf {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+        ensure_size!(in: dst, size: encoded_size);
+
+        let len: u32 = self.0.len().try_into().expect("BUG: validated in constructor");
+
+        VarU32::new(len)?.encode(dst)?;
+        dst.write_slice(self.0.as_slice());
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        VarU32::new(self.0.len().try_into().unwrap()).unwrap().size() /* variable-length size */
+            + self.0.len() /* data bytes */
+    }
+}
+
+impl PduDecode<'_> for NowVarBuf {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let len_u32 = VarU32::decode(src)?.value();
+        let len: usize = cast_length!("len", len_u32)?;
+
+        ensure_size!(in: src, size: len);
+        let bytes = src.read_slice(len);
+
+        Ok(NowVarBuf(bytes.to_vec()))
+    }
+}
+
+impl From<NowVarBuf> for Vec<u8> {
+    fn from(buf: NowVarBuf) -> Self {
+        buf.0
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(b"hello", &[0x05, 0x00, 0x00, 0x00, b'h', b'e', b'l', b'l', b'o'])]
+    #[case(&[], &[0x00, 0x00, 0x00, 0x00])]
+    fn now_lrgbuf_roundtrip(#[case] value: &[u8], #[case] expected_encoded: &[u8]) {
+        let mut encoded_value = [0u8; 32];
+        let encoded_size = crate::encode(&NowLrgBuf::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<NowLrgBuf>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[rstest]
+    #[case(b"hello", &[0x05, b'h', b'e', b'l', b'l', b'o'])]
+    #[case(&[], &[0x00])]
+    fn now_varbuf_roundtrip(#[case] value: &[u8], #[case] expected_encoded: &[u8]) {
+        let mut encoded_value = [0u8; 32];
+        let encoded_size = crate::encode(&NowVarBuf::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<NowVarBuf>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+}

--- a/crates/now-proto-pdu/src/core/header.rs
+++ b/crates/now-proto-pdu/src/core/header.rs
@@ -1,0 +1,97 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    PduDecode, PduEncode, PduResult,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NowMessageClass(pub u8);
+
+impl NowMessageClass {
+    /// NOW-PROTO: NOW_SYSTEM_MSG_CLASS_ID
+    pub const SYSTEM: Self = Self(0x11);
+
+    /// NOW-PROTO: NOW_SESSION_MSG_CLASS_ID
+    pub const SESSION: Self = Self(0x12);
+
+    /// NOW-PROTO: NOW_EXEC_MSG_CLASS_ID
+    pub const EXEC: Self = Self(0x13);
+}
+
+/// The NOW_HEADER structure is the header common to all NOW protocol messages.
+///
+/// NOW-PROTO: NOW_HEADER
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowHeader {
+    pub size: u32,
+    pub class: NowMessageClass,
+    pub kind: u8,
+    pub flags: u16,
+}
+
+impl NowHeader {
+    const NAME: &'static str = "NOW_HEADER";
+    pub const FIXED_PART_SIZE: usize = 8;
+}
+
+impl PduEncode for NowHeader {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        ensure_fixed_part_size!(in: dst);
+
+        dst.write_u32(self.size);
+        dst.write_u8(self.class.0);
+        dst.write_u8(self.kind);
+        dst.write_u16(self.flags);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl PduDecode<'_> for NowHeader {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let size = src.read_u32();
+        let class = NowMessageClass(src.read_u8());
+        let kind = src.read_u8();
+        let flags = src.read_u16();
+
+        Ok(NowHeader {
+            size,
+            class,
+            kind,
+            flags,
+        })
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_header_roundtrip() {
+        let header = NowHeader {
+            size: 0x12345678,
+            class: NowMessageClass::SYSTEM,
+            kind: 0x42,
+            flags: 0x1234,
+        };
+
+        let mut buf = [0; 8];
+        let mut cursor = WriteCursor::new(&mut buf);
+        header.encode(&mut cursor).unwrap();
+
+        let mut cursor = ReadCursor::new(&buf);
+        let decoded = NowHeader::decode(&mut cursor).unwrap();
+
+        assert_eq!(header, decoded);
+    }
+}

--- a/crates/now-proto-pdu/src/core/mod.rs
+++ b/crates/now-proto-pdu/src/core/mod.rs
@@ -1,0 +1,14 @@
+//! This module contains `NOW-PROTO` core types definitions.
+
+mod buffer;
+mod header;
+mod number;
+mod status;
+mod string;
+
+pub(crate) use header::{NowHeader, NowMessageClass};
+
+pub use buffer::{NowLrgBuf, NowVarBuf};
+pub use number::{VarI16, VarI32, VarI64, VarU16, VarU32, VarU64};
+pub use status::{NowSeverity, NowStatus, NowStatusCode};
+pub use string::{NowLrgStr, NowString128, NowString16, NowString256, NowString32, NowString64, NowVarStr};

--- a/crates/now-proto-pdu/src/core/number.rs
+++ b/crates/now-proto-pdu/src/core/number.rs
@@ -1,0 +1,816 @@
+//! Variable-length number types.
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    PduDecode, PduEncode, PduError, PduResult,
+};
+
+/// Variable-length encoded u16.
+/// Value range:`[0..0x7FFF]`
+///
+/// NOW-PROTO: NOW_VARU16
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarU16(u16);
+
+impl VarU16 {
+    pub const MIN: u16 = 0x0000;
+    pub const MAX: u16 = 0x7FFF;
+
+    const NAME: &'static str = "NOW_VARU16";
+
+    pub fn new(value: u16) -> PduResult<Self> {
+        if value > Self::MAX {
+            return Err(invalid_message_err!("value", "too large number"));
+        }
+
+        Ok(VarU16(value))
+    }
+
+    pub fn value(&self) -> u16 {
+        self.0
+    }
+}
+
+impl PduEncode for VarU16 {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+
+        ensure_size!(in: dst, size: encoded_size);
+
+        let mut shift = (encoded_size - 1) * 8;
+        let mut bytes = [0u8; 2];
+
+        for byte in bytes.iter_mut().take(encoded_size) {
+            *byte = ((self.0 >> shift) & 0xFF).try_into().unwrap();
+
+            if shift != 0 {
+                shift -= 8;
+            }
+        }
+
+        let c: u8 = (encoded_size - 1).try_into().unwrap();
+        bytes[0] |= c << 7;
+
+        dst.write_slice(&bytes[..encoded_size]);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self.0 {
+            0x00..=0x7F => 1,
+            0x80..=0x7FFF => 2,
+            _ => unreachable!("BUG: value is out of range!"),
+        }
+    }
+}
+
+impl PduDecode<'_> for VarU16 {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        // Ensure we have at least 1 byte available to determine the size of the value
+        ensure_size!(in: src, size: 1);
+
+        let header = src.read_u8();
+        let c: usize = ((header >> 7) & 0x01).into();
+
+        if c == 0 {
+            return Ok(VarU16((header & 0x7F).into()));
+        }
+
+        ensure_size!(in: src, size: c);
+        let bytes = src.read_slice(c);
+
+        let val1 = header & 0x7F;
+        let mut shift = c * 8;
+        let mut num = u16::from(val1) << shift;
+
+        // Read val2..valN
+        for val in bytes.iter().take(c) {
+            shift -= 8;
+            num |= (u16::from(*val)) << shift;
+        }
+
+        Ok(VarU16(num))
+    }
+}
+
+impl From<VarU16> for u16 {
+    fn from(value: VarU16) -> Self {
+        value.value()
+    }
+}
+
+impl TryFrom<u16> for VarU16 {
+    type Error = PduError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Variable-length encoded i16.
+/// Value range:`[-0x3FFF..0x3FFF]`
+///
+/// NOW-PROTO: NOW_VARI16
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarI16(i16);
+
+impl VarI16 {
+    pub const MIN: i16 = -0x3FFF;
+    pub const MAX: i16 = 0x3FFF;
+
+    const NAME: &'static str = "NOW_VARI16";
+
+    pub fn new(value: i16) -> PduResult<Self> {
+        if value.abs() > Self::MAX {
+            return Err(invalid_message_err!("value", "too large number"));
+        }
+
+        Ok(VarI16(value))
+    }
+
+    pub fn value(&self) -> i16 {
+        self.0
+    }
+}
+
+impl PduEncode for VarI16 {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+
+        ensure_size!(in: dst, size: encoded_size);
+
+        let mut shift = (encoded_size - 1) * 8;
+        let mut bytes = [0u8; 2];
+
+        let abs_value = self.0.unsigned_abs();
+
+        for byte in bytes.iter_mut().take(encoded_size) {
+            *byte = ((abs_value >> shift) & 0xFF).try_into().unwrap();
+
+            if shift != 0 {
+                shift -= 8;
+            }
+        }
+
+        let c: u8 = (encoded_size - 1).try_into().unwrap();
+        bytes[0] |= c << 7;
+        if self.0 < 0 {
+            // set sign bit
+            bytes[0] |= 0x40;
+        }
+
+        dst.write_slice(&bytes[..encoded_size]);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self.0.unsigned_abs() {
+            0..=0x3F => 1,
+            0x40..=0x3FFF => 2,
+            _ => unreachable!("BUG: value is out of range!"),
+        }
+    }
+}
+
+impl PduDecode<'_> for VarI16 {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        // Ensure we have at least 1 byte available to determine the size of the value
+        ensure_size!(in: src, size: 1);
+
+        let header = src.read_u8();
+        let c: usize = ((header >> 7) & 0x01).into();
+        let is_negative = (header & 0x40) != 0;
+
+        if c == 0 {
+            let val = i16::from(header & 0x3F);
+            return Ok(VarI16(if is_negative { -val } else { val }));
+        }
+
+        ensure_size!(in: src, size: c);
+        let bytes = src.read_slice(c);
+
+        let val1 = header & 0x3F;
+        let mut shift = c * 8;
+        let mut num = i16::from(val1) << shift;
+
+        // Read val2..valN
+        for val in bytes.iter().take(c) {
+            shift -= 8;
+            num |= (i16::from(*val)) << shift;
+        }
+
+        Ok(VarI16(if is_negative { -num } else { num }))
+    }
+}
+
+impl From<VarI16> for i16 {
+    fn from(value: VarI16) -> Self {
+        value.value()
+    }
+}
+
+impl TryFrom<i16> for VarI16 {
+    type Error = PduError;
+
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Variable-length encoded u32.
+/// Value range: `[0..0x3FFFFFFF]`
+///
+/// NOW-PROTO: NOW_VARU32
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarU32(u32);
+
+impl VarU32 {
+    pub const MIN: u32 = 0x00000000;
+    pub const MAX: u32 = 0x3FFFFFFF;
+
+    const NAME: &'static str = "NOW_VARU32";
+
+    pub fn new(value: u32) -> PduResult<Self> {
+        if value > Self::MAX {
+            return Err(invalid_message_err!("value", "too large number"));
+        }
+
+        Ok(VarU32(value))
+    }
+
+    pub fn value(&self) -> u32 {
+        self.0
+    }
+}
+
+impl PduEncode for VarU32 {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+
+        ensure_size!(in: dst, size: encoded_size);
+
+        let mut shift = (encoded_size - 1) * 8;
+        let mut bytes = [0u8; 4];
+
+        for byte in bytes.iter_mut().take(encoded_size) {
+            *byte = ((self.0 >> shift) & 0xFF).try_into().unwrap();
+
+            if shift != 0 {
+                shift -= 8;
+            }
+        }
+
+        let c: u8 = (encoded_size - 1).try_into().unwrap();
+        bytes[0] |= c << 6;
+
+        dst.write_slice(&bytes[..encoded_size]);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self.0 {
+            0x00..=0x3F => 1,
+            0x40..=0x3FFF => 2,
+            0x4000..=0x3FFFFF => 3,
+            0x400000..=0x3FFFFFFF => 4,
+            _ => unreachable!("BUG: value is out of range!"),
+        }
+    }
+}
+
+impl PduDecode<'_> for VarU32 {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        // Ensure we have at least 1 byte available to determine the size of the value
+        ensure_size!(in: src, size: 1);
+
+        let header = src.read_u8();
+        let c: usize = ((header >> 6) & 0x03).into();
+
+        if c == 0 {
+            return Ok(VarU32((header & 0x3F).into()));
+        }
+
+        ensure_size!(in: src, size: c);
+        let bytes = src.read_slice(c);
+
+        let val1 = header & 0x3F;
+        let mut shift = c * 8;
+        let mut num = u32::from(val1) << shift;
+
+        // Read val2..valN
+        for val in bytes.iter().take(c) {
+            shift -= 8;
+            num |= (u32::from(*val)) << shift;
+        }
+
+        Ok(VarU32(num))
+    }
+}
+
+impl From<VarU32> for u32 {
+    fn from(value: VarU32) -> Self {
+        value.value()
+    }
+}
+
+impl TryFrom<u32> for VarU32 {
+    type Error = PduError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Variable-length encoded i32.
+/// Value range: `[-0x1FFFFFFF..0x1FFFFFFF]`
+///
+/// NOW-PROTO: NOW_VARI32
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarI32(i32);
+
+impl VarI32 {
+    pub const MIN: i32 = -0x1FFFFFFF;
+    pub const MAX: i32 = 0x1FFFFFFF;
+
+    const NAME: &'static str = "NOW_VARI32";
+
+    pub fn new(value: i32) -> PduResult<Self> {
+        if value.abs() > Self::MAX {
+            return Err(invalid_message_err!("value", "too large number"));
+        }
+
+        Ok(VarI32(value))
+    }
+
+    pub fn value(&self) -> i32 {
+        self.0
+    }
+}
+
+impl PduEncode for VarI32 {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+
+        ensure_size!(in: dst, size: encoded_size);
+
+        let mut shift = (encoded_size - 1) * 8;
+        let mut bytes = [0u8; 4];
+
+        let abs_value = self.0.unsigned_abs();
+
+        for byte in bytes.iter_mut().take(encoded_size) {
+            *byte = ((abs_value >> shift) & 0xFF).try_into().unwrap();
+
+            if shift != 0 {
+                shift -= 8;
+            }
+        }
+
+        let c: u8 = (encoded_size - 1).try_into().unwrap();
+        bytes[0] |= c << 6;
+        if self.0 < 0 {
+            // set sign bit
+            bytes[0] |= 0x20;
+        }
+
+        dst.write_slice(&bytes[..encoded_size]);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self.0.unsigned_abs() {
+            0..=0x1F => 1,
+            0x20..=0x1FFF => 2,
+            0x2000..=0x1FFFFF => 3,
+            0x200000..=0x1FFFFFFF => 4,
+            _ => unreachable!("BUG: value is out of range!"),
+        }
+    }
+}
+
+impl PduDecode<'_> for VarI32 {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        // Ensure we have at least 1 byte available to determine the size of the value
+        ensure_size!(in: src, size: 1);
+
+        let header = src.read_u8();
+        let c: usize = ((header >> 6) & 0x03).into();
+        let is_negative = (header & 0x20) != 0;
+
+        if c == 0 {
+            let val = i32::from(header & 0x1F);
+            return Ok(VarI32(if is_negative { -val } else { val }));
+        }
+
+        ensure_size!(in: src, size: c);
+        let bytes = src.read_slice(c);
+
+        let val1 = header & 0x1F;
+        let mut shift = c * 8;
+        let mut num = i32::from(val1) << shift;
+
+        // Read val2..valN
+        for val in bytes.iter().take(c) {
+            shift -= 8;
+            num |= (i32::from(*val)) << shift;
+        }
+
+        Ok(VarI32(if is_negative { -num } else { num }))
+    }
+}
+
+impl From<VarI32> for i32 {
+    fn from(value: VarI32) -> Self {
+        value.value()
+    }
+}
+
+impl TryFrom<i32> for VarI32 {
+    type Error = PduError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Variable-length encoded u64.
+/// Value range: `[0..0x1FFFFFFFFFFFFFFF]`
+///
+/// NOW-PROTO: NOW_VARU64
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarU64(u64);
+
+impl VarU64 {
+    pub const MIX: u64 = 0x0000000000000000;
+    pub const MAX: u64 = 0x1FFFFFFFFFFFFFFF;
+
+    const NAME: &'static str = "NOW_VARU64";
+
+    pub fn new(value: u64) -> PduResult<Self> {
+        if value > Self::MAX {
+            return Err(invalid_message_err!("value", "too large number"));
+        }
+
+        Ok(VarU64(value))
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0
+    }
+}
+
+impl PduEncode for VarU64 {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+
+        ensure_size!(in: dst, size: encoded_size);
+
+        let mut shift = (encoded_size - 1) * 8;
+        let mut bytes = [0u8; 8];
+
+        for byte in bytes.iter_mut().take(encoded_size) {
+            *byte = ((self.0 >> shift) & 0xFF).try_into().unwrap();
+
+            if shift != 0 {
+                shift -= 8;
+            }
+        }
+
+        let c: u8 = (encoded_size - 1).try_into().unwrap();
+        bytes[0] |= c << 5;
+
+        dst.write_slice(&bytes[..encoded_size]);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self.0 {
+            0x00..=0x1F => 1,
+            0x20..=0x1FFF => 2,
+            0x2000..=0x1FFFFF => 3,
+            0x200000..=0x1FFFFFFF => 4,
+            0x20000000..=0x1FFFFFFFFF => 5,
+            0x2000000000..=0x1FFFFFFFFFFF => 6,
+            0x200000000000..=0x1FFFFFFFFFFFFF => 7,
+            0x20000000000000..=0x1FFFFFFFFFFFFFFF => 8,
+            _ => unreachable!("BUG: value is out of range!"),
+        }
+    }
+}
+
+impl PduDecode<'_> for VarU64 {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        // Ensure we have at least 1 byte available to determine the size of the value
+        ensure_size!(in: src, size: 1);
+
+        let header = src.read_u8();
+        let c: usize = ((header >> 5) & 0x07).into();
+
+        if c == 0 {
+            return Ok(VarU64((header & 0x1F).into()));
+        }
+
+        ensure_size!(in: src, size: c);
+        let bytes = src.read_slice(c);
+
+        let val1 = header & 0x1F;
+        let mut shift = c * 8;
+        let mut num = u64::from(val1) << shift;
+
+        // Read val2..valN
+        for val in bytes.iter().take(c) {
+            shift -= 8;
+            num |= (u64::from(*val)) << shift;
+        }
+
+        Ok(VarU64(num))
+    }
+}
+
+impl From<VarU64> for u64 {
+    fn from(value: VarU64) -> Self {
+        value.value()
+    }
+}
+
+impl TryFrom<u64> for VarU64 {
+    type Error = PduError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+/// Variable-length encoded i64.
+/// Value range: `[-0x0FFFFFFFFFFFFFFF..0x0FFFFFFFFFFFFFFF]`
+///
+/// NOW-PROTO: NOW_VARI64
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct VarI64(i64);
+
+impl VarI64 {
+    const NAME: &'static str = "NOW_VARI64";
+    const MAX: i64 = 0x0FFFFFFFFFFFFFFF;
+
+    pub fn new(value: i64) -> PduResult<Self> {
+        if value.abs() > Self::MAX {
+            return Err(invalid_message_err!("value", "too large number"));
+        }
+
+        Ok(VarI64(value))
+    }
+
+    pub fn value(&self) -> i64 {
+        self.0
+    }
+}
+
+impl PduEncode for VarI64 {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+
+        ensure_size!(in: dst, size: encoded_size);
+
+        let mut shift = (encoded_size - 1) * 8;
+        let mut bytes = [0u8; 8];
+
+        let abs_value = self.0.unsigned_abs();
+
+        for byte in bytes.iter_mut().take(encoded_size) {
+            *byte = ((abs_value >> shift) & 0xFF).try_into().unwrap();
+
+            if shift != 0 {
+                shift -= 8;
+            }
+        }
+
+        let c: u8 = (encoded_size - 1).try_into().unwrap();
+        bytes[0] |= c << 5;
+        if self.0 < 0 {
+            // set sign bit
+            bytes[0] |= 0x10;
+        }
+
+        dst.write_slice(&bytes[..encoded_size]);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self.0.unsigned_abs() {
+            0..=0x0F => 1,
+            0x10..=0x0FFF => 2,
+            0x1000..=0x0FFFFF => 3,
+            0x100000..=0x0FFFFFFF => 4,
+            0x10000000..=0x0FFFFFFFFF => 5,
+            0x1000000000..=0x0FFFFFFFFFFF => 6,
+            0x100000000000..=0x0FFFFFFFFFFFFF => 7,
+            0x10000000000000..=0x0FFFFFFFFFFFFFFF => 8,
+            _ => unreachable!("BUG: value is out of range!"),
+        }
+    }
+}
+
+impl PduDecode<'_> for VarI64 {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        // Ensure we have at least 1 byte available to determine the size of the value
+        ensure_size!(in: src, size: 1);
+
+        let header = src.read_u8();
+        let c: usize = ((header >> 5) & 0x07).into();
+        let is_negative = (header & 0x10) != 0;
+
+        if c == 0 {
+            let val = i64::from(header & 0x0F);
+            return Ok(VarI64(if is_negative { -val } else { val }));
+        }
+
+        ensure_size!(in: src, size: c);
+        let bytes = src.read_slice(c);
+
+        let val1 = header & 0x0F;
+        let mut shift = c * 8;
+        let mut num = i64::from(val1) << shift;
+
+        // Read val2..valN
+        for val in bytes.iter().take(c) {
+            shift -= 8;
+            num |= (i64::from(*val)) << shift;
+        }
+
+        Ok(VarI64(if is_negative { -num } else { num }))
+    }
+}
+
+impl From<VarI64> for i64 {
+    fn from(value: VarI64) -> Self {
+        value.value()
+    }
+}
+
+impl TryFrom<i64> for VarI64 {
+    type Error = PduError;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0x00, &[0x00])]
+    #[case(0x7F, &[0x7F])]
+    #[case(0x80, &[0x80, 0x80])]
+    fn var_u16_roundtrip(#[case] value: u16, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 4];
+        let encoded_size = crate::encode(&VarU16::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<VarU16>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[rstest]
+    #[case(0x00, &[0x00])]
+    #[case(0x3F, &[0x3F])]
+    #[case(0x40, &[0x80, 0x40])]
+    #[case(-0x3F, &[0x7F])]
+    #[case(-0x40, &[0xC0, 0x40])]
+    fn var_i16_roundtrip(#[case] value: i16, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 4];
+        let encoded_size = crate::encode(&VarI16::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<VarI16>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[rstest]
+    #[case(0x00, &[0x00])]
+    #[case(0x3F, &[0x3F])]
+    #[case(0x40, &[0x40, 0x40])]
+    #[case(0x14000, &[0x81, 0x40, 0x00])]
+    #[case(0x3FFFFFFF, &[0xFF, 0xFF, 0xFF, 0xFF])]
+    fn var_u32_roundtrip(#[case] value: u32, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 4];
+        let encoded_size = crate::encode(&VarU32::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<VarU32>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[rstest]
+    #[case(0x00, &[0x00])]
+    #[case(0x1F, &[0x1F])]
+    #[case(0x20, &[0x40, 0x20])]
+    #[case(0x14000, &[0x81, 0x40, 0x00])]
+    #[case(0x1FFFFFFF, &[0xDF, 0xFF, 0xFF, 0xFF])]
+    #[case(-0x1F, &[0x3F])]
+    #[case(-0x1FFFFFFF, &[0xFF, 0xFF, 0xFF, 0xFF])]
+    fn var_i32_roundtrip(#[case] value: i32, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 4];
+        let encoded_size = crate::encode(&VarI32::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<VarI32>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[rstest]
+    #[case(0x00, &[0x00])]
+    #[case(0x1F, &[0x1F])]
+    #[case(0x20, &[0x20, 0x20])]
+    #[case(0x14000, &[0x41, 0x40, 0x00])]
+    #[case(0x1FFFFFFF, &[0x7F, 0xFF, 0xFF, 0xFF])]
+    #[case(0x1FFFFFFFFF, &[0x9F, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(0x1FFFFFFFFFFF, &[0xBF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(0x1FFFFFFFFFFFFF, &[0xDF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(0x1FFFFFFFFFFFFFFF, &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])]
+    fn var_u64_roundtrip(#[case] value: u64, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 8];
+        let encoded_size = crate::encode(&VarU64::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<VarU64>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[rstest]
+    #[case(0x00, &[0x00])]
+    #[case(0x0F, &[0x0F])]
+    #[case(0x10, &[0x20, 0x10])]
+    #[case(0x021400, &[0x42, 0x14, 0x00])]
+    #[case(0x0FFFFFFF, &[0x6F, 0xFF, 0xFF, 0xFF])]
+    #[case(0x0FFFFFFFFF, &[0x8F, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(0x0FFFFFFFFFFF, &[0xAF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(0x0FFFFFFFFFFFFF, &[0xCF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(0x0FFFFFFFFFFFFFFF, &[0xEF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])]
+    #[case(-0x0F, &[0x1F])]
+    #[case(-0x0FFFFFFF, &[0x7F, 0xFF, 0xFF, 0xFF])]
+    fn var_i64_roundtrip(#[case] value: i64, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 8];
+        let encoded_size = crate::encode(&VarI64::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<VarI64>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[test]
+    fn constructed_var_int_too_large() {
+        VarU16::new(0x8000).unwrap_err();
+        VarI16::new(0x4000).unwrap_err();
+        VarI16::new(-0x4000).unwrap_err();
+        VarU32::new(0x40000000).unwrap_err();
+        VarI32::new(0x20000000).unwrap_err();
+        VarI32::new(-0x20000000).unwrap_err();
+        VarU64::new(0x2000000000000000).unwrap_err();
+        VarI64::new(0x1000000000000000).unwrap_err();
+        VarI64::new(-0x1000000000000000).unwrap_err();
+    }
+}

--- a/crates/now-proto-pdu/src/core/status.rs
+++ b/crates/now-proto-pdu/src/core/status.rs
@@ -1,0 +1,166 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    PduDecode, PduEncode, PduError, PduResult,
+};
+
+/// Error or status severity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NowSeverity {
+    /// Informative status
+    ///
+    /// NOW-PROTO: NOW_SEVERITY_INFO
+    Info = 0,
+    /// Warning status
+    ///
+    /// NOW-PROTO: NOW_SEVERITY_WARN
+    Warn = 1,
+    /// Error status (recoverable)
+    ///
+    /// NOW-PROTO: NOW_SEVERITY_ERROR
+    Error = 2,
+    /// Error status (non-recoverable)
+    ///
+    /// NOW-PROTO: NOW_SEVERITY_FATAL
+    Fatal = 3,
+}
+
+impl NowSeverity {
+    const NAME: &'static str = "NOW_STATUS_SEVERITY";
+}
+
+impl TryFrom<u8> for NowSeverity {
+    type Error = PduError;
+
+    fn try_from(value: u8) -> PduResult<Self> {
+        match value {
+            0 => Ok(Self::Info),
+            1 => Ok(Self::Warn),
+            2 => Ok(Self::Error),
+            3 => Ok(Self::Fatal),
+            _ => Err(invalid_message_err!("severity", "invalid value")),
+        }
+    }
+}
+
+/// Error or status code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NowStatusCode(pub u16);
+
+impl NowStatusCode {
+    /// NOW-PROTO: NOW_CODE_SUCCESS
+    pub const SUCCESS: Self = Self(0x0000);
+    /// NOW-PROTO: NOW_CODE_FAILURE
+    pub const FAILURE: Self = Self(0xFFFF);
+    /// NOW-PROTO: NOW_CODE_FILE_NOT_FOUND
+    pub const FILE_NOT_FOUND: Self = Self(0x0002);
+    /// NOW-PROTO: NOW_CODE_ACCESS_DENIED
+    pub const ACCESS_DENIED: Self = Self(0x0005);
+    /// NOW-PROTO: NOW_CODE_BAD_FORMAT
+    pub const BAD_FORMAT: Self = Self(0x000B);
+}
+/// A status code, with a structure similar to HRESULT.
+///
+/// NOW-PROTO: NOW_STATUS
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowStatus {
+    severity: NowSeverity,
+    kind: u8,
+    code: NowStatusCode,
+}
+
+impl NowStatus {
+    const NAME: &'static str = "NOW_STATUS";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(severity: NowSeverity, code: NowStatusCode) -> Self {
+        Self {
+            severity,
+            kind: 0,
+            code,
+        }
+    }
+
+    pub fn with_kind(self, kind: u8) -> PduResult<Self> {
+        if kind > 0x0F {
+            return Err(invalid_message_err!("type", "status type is too large"));
+        }
+
+        Ok(Self { kind, ..self })
+    }
+
+    pub fn severity(&self) -> NowSeverity {
+        self.severity
+    }
+
+    pub fn kind(&self) -> u8 {
+        self.kind
+    }
+
+    pub fn code(&self) -> NowStatusCode {
+        self.code
+    }
+}
+
+impl PduEncode for NowStatus {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        ensure_fixed_part_size!(in: dst);
+
+        // Y, Z, class fields are reserved and must be set to 0.
+        let header_byte = (self.severity as u8) << 6;
+
+        dst.write_u8(header_byte);
+        dst.write_u8(self.kind);
+        dst.write_u16(self.code.0);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+}
+
+impl PduDecode<'_> for NowStatus {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let header_byte = src.read_u8();
+        let severity = (header_byte >> 6) & 0x03;
+        let kind = src.read_u8();
+        let code = src.read_u16();
+
+        Ok(NowStatus {
+            severity: NowSeverity::try_from(severity)?,
+            kind,
+            code: NowStatusCode(code),
+        })
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn now_status_roundtrip() {
+        let status = NowStatus::new(NowSeverity::Error, NowStatusCode::FILE_NOT_FOUND)
+            .with_kind(0x07)
+            .unwrap();
+
+        let mut buf = [0; 4];
+        let mut cursor = WriteCursor::new(&mut buf);
+        status.encode(&mut cursor).unwrap();
+
+        assert_eq!(&buf, &[0x80, 0x07, 0x02, 0x00]);
+
+        let mut cursor = ReadCursor::new(&buf);
+        let decoded = NowStatus::decode(&mut cursor).unwrap();
+
+        assert_eq!(status, decoded);
+    }
+}

--- a/crates/now-proto-pdu/src/core/string.rs
+++ b/crates/now-proto-pdu/src/core/string.rs
@@ -1,0 +1,370 @@
+//! String types
+
+use alloc::string::String;
+
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    PduDecode, PduEncode, PduResult, VarU32,
+};
+
+/// String value up to 2^32 bytes long.
+///
+/// NOW-PROTO: NOW_LRGSTR
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowLrgStr(String);
+
+impl NowLrgStr {
+    pub const MAX_SIZE: usize = u32::MAX as usize;
+
+    const NAME: &'static str = "NOW_LRGSTR";
+    const FIXED_PART_SIZE: usize = 4;
+
+    /// Returns empty string.
+    pub fn empty() -> Self {
+        Self(String::new())
+    }
+
+    /// Creates new `NowLrgStr`. Returns error if string is too big for the protocol.
+    pub fn new(value: impl Into<String>) -> PduResult<Self> {
+        let value = value.into();
+        // IMPORTANT: we need to check for encoded UTF-8 size, not the string length.
+
+        let _: u32 = value
+            .as_bytes()
+            .len()
+            .try_into()
+            .map_err(|_| invalid_message_err!("string value", "too large string"))?;
+
+        Ok(NowLrgStr(value))
+    }
+
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PduEncode for NowLrgStr {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+        ensure_size!(in: dst, size: encoded_size);
+
+        let len: u32 = self.0.len().try_into().expect("BUG: validated in constructor");
+
+        dst.write_u32(len);
+        dst.write_slice(self.0.as_bytes());
+        dst.write_u8(b'\0');
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE  /* u32 size */
+            + self.0.len() /* utf-8 bytes */
+            + 1 /* null termnator */
+    }
+}
+
+impl PduDecode<'_> for NowLrgStr {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let len: usize = cast_length!("len", src.read_u32())?;
+
+        ensure_size!(in: src, size: len);
+        let bytes = src.read_slice(len);
+        ensure_size!(in: src, size: 1);
+        let _null = src.read_u8();
+
+        let string =
+            String::from_utf8(bytes.to_vec()).map_err(|_| invalid_message_err!("string value", "invalid utf-8"))?;
+
+        Ok(NowLrgStr(string))
+    }
+}
+
+impl From<NowLrgStr> for String {
+    fn from(value: NowLrgStr) -> Self {
+        value.0
+    }
+}
+
+/// String value up to 2^31 bytes long (Length has compact variable length encoding).
+///
+/// NOW-PROTO: NOW_VARSTR
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowVarStr(String);
+
+impl NowVarStr {
+    pub const MAX_SIZE: usize = VarU32::MAX as usize;
+
+    const NAME: &'static str = "NOW_VARSTR";
+
+    /// Returns empty string.
+    pub fn empty() -> Self {
+        Self(String::new())
+    }
+
+    /// Creates `NowVarStr` from std string. Returns error if string is too big for the protocol.
+    pub fn new(value: impl Into<String>) -> PduResult<Self> {
+        let value = value.into();
+        // IMPORTANT: we need to check for encoded UTF-8 size, not the string length.
+
+        let _: u32 = value
+            .as_bytes()
+            .len()
+            .try_into()
+            .ok()
+            .and_then(|val| if val <= VarU32::MAX { Some(val) } else { None })
+            .ok_or_else(|| invalid_message_err!("string value", "too large string"))?;
+
+        Ok(NowVarStr(value))
+    }
+
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+impl PduEncode for NowVarStr {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+        ensure_size!(in: dst, size: encoded_size);
+
+        let len: u32 = self.0.len().try_into().expect("BUG: validated in constructor");
+
+        VarU32::new(len)?.encode(dst)?;
+        dst.write_slice(self.0.as_bytes());
+        dst.write_u8(b'\0');
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        VarU32::new(self.0.len().try_into().unwrap()).unwrap().size() /* variable-length size */
+            + self.0.len() /* utf-8 bytes */
+            + 1 /* null termnator */
+    }
+}
+
+impl PduDecode<'_> for NowVarStr {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let len_u32 = VarU32::decode(src)?.value();
+        let len: usize = cast_length!("len", len_u32)?;
+
+        ensure_size!(in: src, size: len);
+        let bytes = src.read_slice(len);
+        ensure_size!(in: src, size: 1);
+        let _null = src.read_u8();
+
+        let string =
+            String::from_utf8(bytes.to_vec()).map_err(|_| invalid_message_err!("string value", "invalid utf-8"))?;
+
+        Ok(NowVarStr(string))
+    }
+}
+
+impl From<NowVarStr> for String {
+    fn from(value: NowVarStr) -> Self {
+        value.0
+    }
+}
+
+const fn restricted_str_name(str_len: u8) -> &'static str {
+    match str_len {
+        15 => "NOW_STRING16",
+        31 => "NOW_STRING32",
+        63 => "NOW_STRING64",
+        127 => "NOW_STRING128",
+        255 => "NOW_STRING256",
+        _ => panic!("BUG: Requested restricted string variant is not defined in the protocol"),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowRestrictedStr<const MAX_LEN: u8>(String);
+
+impl<const MAX_LEN: u8> NowRestrictedStr<MAX_LEN> {
+    pub const MAX_ENCODED_UTF8_LEN: usize = MAX_LEN as usize;
+
+    const NAME: &'static str = restricted_str_name(MAX_LEN);
+    const FIXED_PART_SIZE: usize = 1;
+
+    /// Returns empty string.
+    pub fn empty() -> Self {
+        Self(String::new())
+    }
+
+    /// Creates `NowRestrictedStr` from std string. Returns error if string is too big for the protocol.
+    pub fn new(value: impl Into<String>) -> PduResult<Self> {
+        let value = value.into();
+
+        // IMPORTANT: we need to check for encoded UTF-8 size, not the string length
+        if value.as_bytes().len() > MAX_LEN as usize {
+            return Err(invalid_message_err!("string value", concat!("too large string")));
+        }
+        Ok(NowRestrictedStr(value))
+    }
+
+    pub fn value(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<const MAX_LEN: u8> PduEncode for NowRestrictedStr<MAX_LEN> {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let encoded_size = self.size();
+        ensure_size!(in: dst, size: encoded_size);
+
+        let len: u8 = self.0.len().try_into().expect("BUG: validated in constructor");
+
+        dst.write_u8(len);
+        dst.write_slice(self.0.as_bytes());
+        dst.write_u8(b'\0');
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        Self::FIXED_PART_SIZE  /* u8 size */
+            + self.0.len() /* utf-8 bytes */
+            + 1 /* null termnator */
+    }
+}
+
+impl<const MAX_LEN: u8> PduDecode<'_> for NowRestrictedStr<MAX_LEN> {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let len = src.read_u8();
+        if len > MAX_LEN {
+            return Err(invalid_message_err!("string value", "too large string"));
+        }
+
+        let len_usize = len.into();
+
+        ensure_size!(in: src, size: len_usize);
+        let bytes = src.read_slice(len_usize);
+        ensure_size!(in: src, size: 1);
+        let _null = src.read_u8();
+
+        let string =
+            String::from_utf8(bytes.to_vec()).map_err(|_| invalid_message_err!("string value", "invalid utf-8"))?;
+
+        Ok(NowRestrictedStr(string))
+    }
+}
+
+impl<const N: u8> From<NowRestrictedStr<N>> for String {
+    fn from(value: NowRestrictedStr<N>) -> Self {
+        value.0
+    }
+}
+
+/// String value up to 16 bytes long.
+///
+/// NOW-PROTO: NOW_STRING16
+pub type NowString16 = NowRestrictedStr<15>;
+
+/// String value up to 32 bytes long.
+///
+/// NOW-PROTO: NOW_STRING32
+pub type NowString32 = NowRestrictedStr<31>;
+
+/// String value up to 64 bytes long.
+///
+/// NOW-PROTO: NOW_STRING64
+pub type NowString64 = NowRestrictedStr<63>;
+
+/// String value up to 128 bytes long.
+///
+/// NOW-PROTO: NOW_STRING128
+pub type NowString128 = NowRestrictedStr<127>;
+
+/// String value up to 256 bytes long.
+///
+/// NOW-PROTO: NOW_STRING256
+pub type NowString256 = NowRestrictedStr<255>;
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("hello", &[0x05, 0x00, 0x00, 0x00, b'h', b'e', b'l', b'l', b'o', 0x00])]
+    #[case("", &[0x00, 0x00, 0x00, 0x00, 0x00])]
+    fn now_lrgstr_roundtrip(#[case] value: &str, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 32];
+        let encoded_size = crate::encode(&NowLrgStr::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<NowLrgStr>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[test]
+    fn decoded_now_lrgstr_invalid_utf8() {
+        let encoded = [0x01, 0x00, 0x00, 0x00, 0xFF, 0x00];
+        crate::decode::<NowLrgStr>(&encoded).unwrap_err();
+    }
+
+    #[rstest]
+    #[case("hello", &[0x05, b'h', b'e', b'l', b'l', b'o', 0x00])]
+    #[case("", &[0x00, 0x00])]
+    fn now_varstr_roundtrip(#[case] value: &str, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 32];
+        let encoded_size = crate::encode(&NowVarStr::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<NowVarStr>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[test]
+    fn decoded_now_varstr_invalid_utf8() {
+        let encoded = [0x01, 0xFF, 0x00];
+        crate::decode::<NowLrgStr>(&encoded).unwrap_err();
+    }
+
+    #[rstest]
+    #[case("hello", &[0x05, b'h', b'e', b'l', b'l', b'o', 0x00])]
+    #[case("", &[0x00, 0x00])]
+    fn now_restricted_string_roundtrip(#[case] value: &str, #[case] expected_encoded: &'static [u8]) {
+        let mut encoded_value = [0u8; 32];
+        let encoded_size = crate::encode(&NowString16::new(value).unwrap(), &mut encoded_value).unwrap();
+
+        assert_eq!(encoded_size, expected_encoded.len());
+        assert_eq!(&encoded_value[..encoded_size], expected_encoded);
+
+        let decoded_value = crate::decode::<NowString16>(&encoded_value).unwrap();
+        assert_eq!(decoded_value.0, value);
+    }
+
+    #[test]
+    fn now_restricted_string_too_large_constructed() {
+        let value = "a".repeat(16);
+        NowString16::new(value).unwrap_err();
+    }
+
+    #[test]
+    fn decoded_now_restricted_string_invalid_utf8() {
+        let encoded = [0x01, 0xFF, 0x00];
+        crate::decode::<NowString16>(&encoded).unwrap_err();
+    }
+}

--- a/crates/now-proto-pdu/src/cursor.rs
+++ b/crates/now-proto-pdu/src/cursor.rs
@@ -1,0 +1,310 @@
+use crate::PduResult;
+
+#[derive(Debug)]
+pub struct ReadCursor<'a> {
+    inner: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> ReadCursor<'a> {
+    pub const fn new(bytes: &'a [u8]) -> Self {
+        Self { inner: bytes, pos: 0 }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.inner.len() - self.pos
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub const fn eof(&self) -> bool {
+        self.is_empty()
+    }
+
+    pub fn remaining(&self) -> &[u8] {
+        &self.inner[self.pos..]
+    }
+
+    pub const fn inner(&self) -> &[u8] {
+        self.inner
+    }
+
+    pub const fn pos(&self) -> usize {
+        self.pos
+    }
+
+    pub fn read_array<const N: usize>(&mut self) -> [u8; N] {
+        let bytes = &self.inner[self.pos..self.pos + N];
+        self.pos += N;
+        bytes.try_into().expect("N-elements array")
+    }
+
+    pub fn read_slice(&mut self, n: usize) -> &'a [u8] {
+        let bytes = &self.inner[self.pos..self.pos + n];
+        self.pos += n;
+        bytes
+    }
+
+    pub fn read_u8(&mut self) -> u8 {
+        self.read_array::<1>()[0]
+    }
+
+    pub fn try_read_u8(&mut self, ctx: &'static str) -> PduResult<u8> {
+        ensure_size!(ctx: ctx, in: self, size: 1);
+        Ok(self.read_array::<1>()[0])
+    }
+
+    pub fn read_u16(&mut self) -> u16 {
+        u16::from_le_bytes(self.read_array::<2>())
+    }
+
+    pub fn read_u16_be(&mut self) -> u16 {
+        u16::from_be_bytes(self.read_array::<2>())
+    }
+
+    pub fn try_read_u16(&mut self, ctx: &'static str) -> PduResult<u16> {
+        ensure_size!(ctx: ctx, in: self, size: 2);
+        Ok(u16::from_le_bytes(self.read_array::<2>()))
+    }
+
+    pub fn try_read_u16_be(&mut self, ctx: &'static str) -> PduResult<u16> {
+        ensure_size!(ctx: ctx, in: self, size: 2);
+        Ok(u16::from_be_bytes(self.read_array::<2>()))
+    }
+
+    pub fn read_u32(&mut self) -> u32 {
+        u32::from_le_bytes(self.read_array::<4>())
+    }
+
+    pub fn read_u32_be(&mut self) -> u32 {
+        u32::from_be_bytes(self.read_array::<4>())
+    }
+
+    pub fn try_read_u32(&mut self, ctx: &'static str) -> PduResult<u32> {
+        ensure_size!(ctx: ctx, in: self, size: 4);
+        Ok(u32::from_le_bytes(self.read_array::<4>()))
+    }
+
+    pub fn try_read_u32_be(&mut self, ctx: &'static str) -> PduResult<u32> {
+        ensure_size!(ctx: ctx, in: self, size: 4);
+        Ok(u32::from_be_bytes(self.read_array::<4>()))
+    }
+
+    pub fn read_u64(&mut self) -> u64 {
+        u64::from_le_bytes(self.read_array::<8>())
+    }
+
+    pub fn read_u64_be(&mut self) -> u64 {
+        u64::from_be_bytes(self.read_array::<8>())
+    }
+
+    pub fn try_read_u64(&mut self, ctx: &'static str) -> PduResult<u64> {
+        ensure_size!(ctx: ctx, in: self, size: 8);
+        Ok(u64::from_le_bytes(self.read_array::<8>()))
+    }
+
+    pub fn try_read_u64_be(&mut self, ctx: &'static str) -> PduResult<u64> {
+        ensure_size!(ctx: ctx, in: self, size: 8);
+        Ok(u64::from_be_bytes(self.read_array::<8>()))
+    }
+
+    pub fn peek<const N: usize>(&mut self) -> [u8; N] {
+        self.inner[self.pos..self.pos + N].try_into().expect("N-elements array")
+    }
+
+    pub fn peek_slice(&mut self, n: usize) -> &'a [u8] {
+        &self.inner[self.pos..self.pos + n]
+    }
+
+    pub fn peek_u8(&mut self) -> u8 {
+        self.peek::<1>()[0]
+    }
+
+    pub fn try_peek_u8(&mut self, ctx: &'static str) -> PduResult<u8> {
+        ensure_size!(ctx: ctx, in: self, size: 1);
+        Ok(self.peek::<1>()[0])
+    }
+
+    pub fn peek_u16(&mut self) -> u16 {
+        u16::from_le_bytes(self.peek::<2>())
+    }
+
+    pub fn peek_u16_be(&mut self) -> u16 {
+        u16::from_be_bytes(self.peek::<2>())
+    }
+
+    pub fn try_peek_u16(&mut self, ctx: &'static str) -> PduResult<u16> {
+        ensure_size!(ctx: ctx, in: self, size: 2);
+        Ok(u16::from_le_bytes(self.peek::<2>()))
+    }
+
+    pub fn try_peek_u16_be(&mut self, ctx: &'static str) -> PduResult<u16> {
+        ensure_size!(ctx: ctx, in: self, size: 2);
+        Ok(u16::from_be_bytes(self.peek::<2>()))
+    }
+
+    pub fn peek_u32(&mut self) -> u32 {
+        u32::from_le_bytes(self.peek::<4>())
+    }
+
+    pub fn peek_u32_be(&mut self) -> u32 {
+        u32::from_be_bytes(self.peek::<4>())
+    }
+
+    pub fn try_peek_u32(&mut self, ctx: &'static str) -> PduResult<u32> {
+        ensure_size!(ctx: ctx, in: self, size: 4);
+        Ok(u32::from_le_bytes(self.peek::<4>()))
+    }
+
+    pub fn try_peek_u32_be(&mut self, ctx: &'static str) -> PduResult<u32> {
+        ensure_size!(ctx: ctx, in: self, size: 4);
+        Ok(u32::from_be_bytes(self.peek::<4>()))
+    }
+
+    pub fn peek_u64(&mut self) -> u64 {
+        u64::from_le_bytes(self.peek::<8>())
+    }
+
+    pub fn peek_u64_be(&mut self) -> u64 {
+        u64::from_be_bytes(self.peek::<8>())
+    }
+
+    pub fn try_peek_u64(&mut self, ctx: &'static str) -> PduResult<u64> {
+        ensure_size!(ctx: ctx, in: self, size: 8);
+        Ok(u64::from_le_bytes(self.peek::<8>()))
+    }
+
+    pub fn try_peek_u64_be(&mut self, ctx: &'static str) -> PduResult<u64> {
+        ensure_size!(ctx: ctx, in: self, size: 8);
+        Ok(u64::from_be_bytes(self.peek::<8>()))
+    }
+
+    pub fn advance(&mut self, len: usize) {
+        self.pos += len;
+    }
+
+    pub const fn advanced(&'a self, len: usize) -> ReadCursor<'a> {
+        ReadCursor {
+            inner: self.inner,
+            pos: self.pos + len,
+        }
+    }
+
+    pub fn rewind(&mut self, len: usize) {
+        self.pos -= len;
+    }
+
+    pub const fn rewinded(&'a self, len: usize) -> ReadCursor<'a> {
+        ReadCursor {
+            inner: self.inner,
+            pos: self.pos - len,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WriteCursor<'a> {
+    inner: &'a mut [u8],
+    pos: usize,
+}
+
+impl<'a> WriteCursor<'a> {
+    pub fn new(bytes: &'a mut [u8]) -> Self {
+        Self { inner: bytes, pos: 0 }
+    }
+
+    pub const fn len(&self) -> usize {
+        self.inner.len() - self.pos
+    }
+
+    pub const fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub const fn eof(&self) -> bool {
+        self.is_empty()
+    }
+
+    pub fn remaining(&self) -> &[u8] {
+        &self.inner[self.pos..]
+    }
+
+    pub fn remaining_mut(&mut self) -> &mut [u8] {
+        &mut self.inner[self.pos..]
+    }
+
+    pub const fn inner(&self) -> &[u8] {
+        self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut [u8] {
+        self.inner
+    }
+
+    pub const fn pos(&self) -> usize {
+        self.pos
+    }
+
+    pub fn write_array<const N: usize>(&mut self, array: [u8; N]) {
+        self.inner[self.pos..self.pos + N].copy_from_slice(&array);
+        self.pos += N;
+    }
+
+    pub fn write_slice(&mut self, slice: &[u8]) {
+        let n = slice.len();
+        self.inner[self.pos..self.pos + n].copy_from_slice(slice);
+        self.pos += n;
+    }
+
+    pub fn write_u8(&mut self, value: u8) {
+        self.write_array(value.to_le_bytes())
+    }
+
+    pub fn write_u16(&mut self, value: u16) {
+        self.write_array(value.to_le_bytes())
+    }
+
+    pub fn write_u16_be(&mut self, value: u16) {
+        self.write_array(value.to_be_bytes())
+    }
+
+    pub fn write_u32(&mut self, value: u32) {
+        self.write_array(value.to_le_bytes())
+    }
+
+    pub fn write_u32_be(&mut self, value: u32) {
+        self.write_array(value.to_be_bytes())
+    }
+
+    pub fn write_u64(&mut self, value: u64) {
+        self.write_array(value.to_le_bytes())
+    }
+
+    pub fn write_u64_be(&mut self, value: u64) {
+        self.write_array(value.to_be_bytes())
+    }
+
+    pub fn advance(&mut self, len: usize) {
+        self.pos += len;
+    }
+
+    pub fn advanced(&'a mut self, len: usize) -> WriteCursor<'a> {
+        WriteCursor {
+            inner: self.inner,
+            pos: self.pos + len,
+        }
+    }
+
+    pub fn rewind(&mut self, len: usize) {
+        self.pos -= len;
+    }
+
+    pub fn rewinded(&'a mut self, len: usize) -> WriteCursor<'a> {
+        WriteCursor {
+            inner: self.inner,
+            pos: self.pos - len,
+        }
+    }
+}

--- a/crates/now-proto-pdu/src/error.rs
+++ b/crates/now-proto-pdu/src/error.rs
@@ -1,0 +1,93 @@
+//! This module provides [`PduError`] and [`PduErrorKind`] types based on
+//! reduced functionality IronRDP's `ironrdp-error` module.
+use core::fmt;
+
+#[non_exhaustive]
+#[derive(Clone, Debug)]
+pub enum PduErrorKind {
+    NotEnoughBytes { received: usize, expected: usize },
+    InvalidMessage { field: &'static str, reason: &'static str },
+    UnexpectedMessageKind { class: u8, kind: u8 },
+    Other { description: &'static str },
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PduErrorKind {}
+
+impl fmt::Display for PduErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotEnoughBytes { received, expected } => write!(
+                f,
+                "not enough bytes provided to decode: received {received} bytes, expected {expected} bytes"
+            ),
+            Self::InvalidMessage { field, reason } => {
+                write!(f, "invalid `{field}`: {reason}")
+            }
+            Self::UnexpectedMessageKind { class, kind } => {
+                write!(f, "invalid message kind (CLASS: {class}; KIND: {kind})")
+            }
+            Self::Other { description } => {
+                write!(f, "{description}")
+            }
+        }
+    }
+}
+
+pub trait PduErrorExt {
+    fn not_enough_bytes(context: &'static str, received: usize, expected: usize) -> Self;
+    fn invalid_message(context: &'static str, field: &'static str, reason: &'static str) -> Self;
+    fn unexpected_message_kind(context: &'static str, class: u8, kind: u8) -> Self;
+    fn other(context: &'static str, description: &'static str) -> Self;
+}
+
+impl PduErrorExt for PduError {
+    fn not_enough_bytes(context: &'static str, received: usize, expected: usize) -> Self {
+        Self::new(context, PduErrorKind::NotEnoughBytes { received, expected })
+    }
+
+    fn invalid_message(context: &'static str, field: &'static str, reason: &'static str) -> Self {
+        Self::new(context, PduErrorKind::InvalidMessage { field, reason })
+    }
+
+    fn unexpected_message_kind(context: &'static str, class: u8, kind: u8) -> Self {
+        Self::new(context, PduErrorKind::UnexpectedMessageKind { class, kind })
+    }
+
+    fn other(context: &'static str, description: &'static str) -> Self {
+        Self::new(context, PduErrorKind::Other { description })
+    }
+}
+
+#[derive(Debug)]
+pub struct PduError {
+    context: &'static str,
+    kind: PduErrorKind,
+}
+
+impl PduError {
+    #[cold]
+    pub fn new(context: &'static str, kind: PduErrorKind) -> Self {
+        Self { context, kind }
+    }
+}
+
+impl fmt::Display for PduError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}", self.context, self.kind)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PduError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<PduError> for std::io::Error {
+    fn from(error: PduError) -> Self {
+        std::io::Error::new(std::io::ErrorKind::Other, error)
+    }
+}

--- a/crates/now-proto-pdu/src/exec/abort.rs
+++ b/crates/now-proto-pdu/src/exec/abort.rs
@@ -1,0 +1,89 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowStatus, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_ABORT_MSG message is used to abort a remote execution immediately due to an
+/// unrecoverable error. This message can be sent at any time without an explicit response message.
+/// The session is considered aborted as soon as this message is sent.
+///
+/// NOW-PROTO: NOW_EXEC_ABORT_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecAbortMsg {
+    session_id: u32,
+    status: NowStatus,
+}
+
+impl NowExecAbortMsg {
+    const NAME: &'static str = "NOW_EXEC_ABORT_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, status: NowStatus) -> Self {
+        Self { session_id, status }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn status(&self) -> &NowStatus {
+        &self.status
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.status.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let status = NowStatus::decode(src)?;
+
+        Ok(Self { session_id, status })
+    }
+}
+
+impl PduEncode for NowExecAbortMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::ABORT.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.status.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecAbortMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::ABORT) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecAbortMsg> for NowMessage {
+    fn from(msg: NowExecAbortMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Abort(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/batch.rs
+++ b/crates/now-proto-pdu/src/exec/batch.rs
@@ -1,0 +1,87 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowVarStr, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_BATCH_MSG message is used to execute a remote batch command.
+///
+/// NOW-PROTO: NOW_EXEC_BATCH_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecBatchMsg {
+    session_id: u32,
+    command: NowVarStr,
+}
+
+impl NowExecBatchMsg {
+    const NAME: &'static str = "NOW_EXEC_BATCH_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, command: NowVarStr) -> Self {
+        Self { session_id, command }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn command(&self) -> &NowVarStr {
+        &self.command
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.command.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let command = NowVarStr::decode(src)?;
+
+        Ok(Self { session_id, command })
+    }
+}
+
+impl PduEncode for NowExecBatchMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::BATCH.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.command.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecBatchMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::BATCH) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecBatchMsg> for NowMessage {
+    fn from(msg: NowExecBatchMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Batch(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/cancel_req.rs
+++ b/crates/now-proto-pdu/src/exec/cancel_req.rs
@@ -1,0 +1,80 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_CANCEL_REQ_MSG message is used to cancel a remote execution session.
+///
+/// NOW-PROTO: NOW_EXEC_CANCEL_REQ_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecCancelReqMsg {
+    session_id: u32,
+}
+
+impl NowExecCancelReqMsg {
+    const NAME: &'static str = "NOW_EXEC_CANCEL_REQ_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32) -> Self {
+        Self { session_id }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+
+        Ok(Self { session_id })
+    }
+}
+
+impl PduEncode for NowExecCancelReqMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::CANCEL_REQ.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecCancelReqMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::CANCEL_REQ) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecCancelReqMsg> for NowMessage {
+    fn from(msg: NowExecCancelReqMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::CancelReq(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/cancel_rsp.rs
+++ b/crates/now-proto-pdu/src/exec/cancel_rsp.rs
@@ -1,0 +1,87 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowStatus, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_CANCEL_RSP_MSG message is used to respond to a remote execution cancel request.
+///
+/// NOW_PROTO: NOW_EXEC_CANCEL_RSP_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecCancelRspMsg {
+    session_id: u32,
+    status: NowStatus,
+}
+
+impl NowExecCancelRspMsg {
+    const NAME: &'static str = "NOW_EXEC_CANCEL_RSP_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, status: NowStatus) -> Self {
+        Self { session_id, status }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn status(&self) -> &NowStatus {
+        &self.status
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.status.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let status = NowStatus::decode(src)?;
+
+        Ok(Self { session_id, status })
+    }
+}
+
+impl PduEncode for NowExecCancelRspMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::CANCEL_RSP.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.status.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecCancelRspMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::CANCEL_RSP) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecCancelRspMsg> for NowMessage {
+    fn from(msg: NowExecCancelRspMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::CancelRsp(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/capset.rs
+++ b/crates/now-proto-pdu/src/exec/capset.rs
@@ -1,0 +1,106 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, PduDecode, PduEncode, PduResult,
+};
+use bitflags::bitflags;
+
+bitflags! {
+    /// NOW-PROTO: NOW_EXEC_CAPSET_MSG msgFlags field.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NowExecCapsetFlags: u16 {
+        /// Generic "Run" execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_RUN
+        const STYLE_RUN = 0x0001;
+        /// Generic command execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_CMD
+        const STYLE_CMD = 0x0002;
+        /// CreateProcess() execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_PROCESS
+        const STYLE_PROCESS = 0x0004;
+        /// System shell (.sh) execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_SHELL
+        const STYLE_SHELL = 0x0008;
+        /// Windows batch file (.bat) execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_BATCH
+        const STYLE_BATCH = 0x0010;
+        /// Windows PowerShell (.ps1) execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_WINPS
+        const STYLE_WINPS = 0x0020;
+        /// PowerShell 7 (.ps1) execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_PWSH
+        const STYLE_PWSH = 0x0040;
+        /// Applescript (.scpt) execution style.
+        ///
+        /// NOW-PROTO: NOW_EXEC_STYLE_APPLESCRIPT
+        const STYLE_APPLESCRIPT = 0x0080;
+    }
+}
+
+/// The NOW_EXEC_CAPSET_MSG message is sent to advertise capabilities.
+///
+/// NOW-PROTO: NOW_EXEC_CAPSET_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecCapsetMsg {
+    flags: NowExecCapsetFlags,
+}
+
+impl NowExecCapsetMsg {
+    const NAME: &'static str = "NOW_EXEC_CAPSET_MSG";
+
+    pub fn new(flags: NowExecCapsetFlags) -> Self {
+        Self { flags }
+    }
+
+    pub fn flags(&self) -> NowExecCapsetFlags {
+        self.flags
+    }
+}
+
+impl PduEncode for NowExecCapsetMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: 0,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::CAPSET.0,
+            flags: self.flags.bits(),
+        };
+
+        header.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE
+    }
+}
+
+impl PduDecode<'_> for NowExecCapsetMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::CAPSET) => Ok(Self {
+                flags: NowExecCapsetFlags::from_bits_retain(header.flags),
+            }),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecCapsetMsg> for NowMessage {
+    fn from(msg: NowExecCapsetMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Capset(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/cmd.rs
+++ b/crates/now-proto-pdu/src/exec/cmd.rs
@@ -1,0 +1,1 @@
+// TODO: Not yet defined in specification

--- a/crates/now-proto-pdu/src/exec/data.rs
+++ b/crates/now-proto-pdu/src/exec/data.rs
@@ -1,0 +1,129 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowVarBuf, PduDecode, PduEncode, PduResult,
+};
+use bitflags::bitflags;
+
+bitflags! {
+    /// NOW-PROTO: NOW_EXEC_DATA_MSG flags field.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NowExecDataFlags: u16 {
+        /// This is the first data message.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_DATA_FIRST
+        const FIRST = 0x0001;
+        /// This is the last data message, the command completed execution.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_DATA_LAST
+        const LAST = 0x0002;
+        /// The data is from the standard input.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_DATA_STDIN
+        const STDIN = 0x0004;
+        /// The data is from the standard output.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_DATA_STDOUT
+        const STDOUT = 0x0008;
+        /// The data is from the standard error.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_DATA_STDERR
+        const STDERR = 0x0010;
+    }
+}
+
+/// The NOW_EXEC_DATA_MSG message is used to send input/output data as part of a remote execution.
+///
+/// NOW-PROTO: NOW_EXEC_DATA_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecDataMsg {
+    flags: NowExecDataFlags,
+    session_id: u32,
+    data: NowVarBuf,
+}
+
+impl NowExecDataMsg {
+    const NAME: &'static str = "NOW_EXEC_DATA_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(flags: NowExecDataFlags, session_id: u32, data: NowVarBuf) -> Self {
+        Self {
+            flags,
+            session_id,
+            data,
+        }
+    }
+
+    pub fn flags(&self) -> NowExecDataFlags {
+        self.flags
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn data(&self) -> &NowVarBuf {
+        &self.data
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.data.size()
+    }
+
+    pub(super) fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let flags = NowExecDataFlags::from_bits_retain(header.flags);
+        let session_id = src.read_u32();
+        let data = NowVarBuf::decode(src)?;
+
+        Ok(Self {
+            flags,
+            session_id,
+            data,
+        })
+    }
+}
+
+impl PduEncode for NowExecDataMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::DATA.0,
+            flags: self.flags.bits(),
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.data.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecDataMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::DATA) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecDataMsg> for NowMessage {
+    fn from(msg: NowExecDataMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Data(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/mod.rs
+++ b/crates/now-proto-pdu/src/exec/mod.rs
@@ -1,0 +1,269 @@
+mod abort;
+mod batch;
+mod cancel_req;
+mod cancel_rsp;
+mod capset;
+mod cmd;
+mod data;
+mod process;
+mod pwsh;
+mod result;
+mod run;
+mod shell;
+mod win_ps;
+
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, PduEncode, PduResult,
+};
+
+pub use abort::NowExecAbortMsg;
+pub use batch::NowExecBatchMsg;
+pub use cancel_req::NowExecCancelReqMsg;
+pub use cancel_rsp::NowExecCancelRspMsg;
+pub use capset::{NowExecCapsetFlags, NowExecCapsetMsg};
+pub use data::{NowExecDataFlags, NowExecDataMsg};
+pub use process::NowExecProcessMsg;
+pub use pwsh::NowExecPwshMsg;
+pub use result::NowExecResultMsg;
+pub use run::NowExecRunMsg;
+pub use shell::NowExecShellMsg;
+pub use win_ps::{NowExecWinPsFlags, NowExecWinPsMsg};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NowExecMessage {
+    Capset(NowExecCapsetMsg),
+    Abort(NowExecAbortMsg),
+    CancelReq(NowExecCancelReqMsg),
+    CancelRsp(NowExecCancelRspMsg),
+    Result(NowExecResultMsg),
+    Data(NowExecDataMsg),
+    Run(NowExecRunMsg),
+    // TODO: Define `Cmd` message in specification
+    Process(NowExecProcessMsg),
+    Shell(NowExecShellMsg),
+    Batch(NowExecBatchMsg),
+    WinPs(NowExecWinPsMsg),
+    Pwsh(NowExecPwshMsg),
+}
+
+impl NowExecMessage {
+    const NAME: &'static str = "NOW_EXEC_MSG";
+
+    pub fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        match NowExecMsgKind(header.kind) {
+            NowExecMsgKind::CAPSET => Ok(Self::Capset(NowExecCapsetMsg::new(
+                NowExecCapsetFlags::from_bits_retain(header.flags),
+            ))),
+            NowExecMsgKind::ABORT => Ok(Self::Abort(NowExecAbortMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::CANCEL_REQ => Ok(Self::CancelReq(NowExecCancelReqMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::CANCEL_RSP => Ok(Self::CancelRsp(NowExecCancelRspMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::RESULT => Ok(Self::Result(NowExecResultMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::DATA => Ok(Self::Data(NowExecDataMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::RUN => Ok(Self::Run(NowExecRunMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::PROCESS => Ok(Self::Process(NowExecProcessMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::SHELL => Ok(Self::Shell(NowExecShellMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::BATCH => Ok(Self::Batch(NowExecBatchMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::WINPS => Ok(Self::WinPs(NowExecWinPsMsg::decode_from_body(header, src)?)),
+            NowExecMsgKind::PWSH => Ok(Self::Pwsh(NowExecPwshMsg::decode_from_body(header, src)?)),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl PduEncode for NowExecMessage {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        match self {
+            Self::Capset(msg) => msg.encode(dst),
+            Self::Abort(msg) => msg.encode(dst),
+            Self::CancelReq(msg) => msg.encode(dst),
+            Self::CancelRsp(msg) => msg.encode(dst),
+            Self::Result(msg) => msg.encode(dst),
+            Self::Data(msg) => msg.encode(dst),
+            Self::Run(msg) => msg.encode(dst),
+            Self::Process(msg) => msg.encode(dst),
+            Self::Shell(msg) => msg.encode(dst),
+            Self::Batch(msg) => msg.encode(dst),
+            Self::WinPs(msg) => msg.encode(dst),
+            Self::Pwsh(msg) => msg.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::Capset(msg) => msg.size(),
+            Self::Abort(msg) => msg.size(),
+            Self::CancelReq(msg) => msg.size(),
+            Self::CancelRsp(msg) => msg.size(),
+            Self::Result(msg) => msg.size(),
+            Self::Data(msg) => msg.size(),
+            Self::Run(msg) => msg.size(),
+            Self::Process(msg) => msg.size(),
+            Self::Shell(msg) => msg.size(),
+            Self::Batch(msg) => msg.size(),
+            Self::WinPs(msg) => msg.size(),
+            Self::Pwsh(msg) => msg.size(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NowExecMsgKind(pub u8);
+
+impl NowExecMsgKind {
+    /// NOW-PROTO: NOW_EXEC_CAPSET_MSG_ID
+    pub const CAPSET: Self = Self(0x00);
+    /// NOW-PROTO: NOW_EXEC_ABORT_MSG_ID
+    pub const ABORT: Self = Self(0x01);
+    /// NOW-PROTO: NOW_EXEC_CANCEL_REQ_MSG_ID
+    pub const CANCEL_REQ: Self = Self(0x02);
+    /// NOW-PROTO: NOW_EXEC_CANCEL_RSP_MSG_ID
+    pub const CANCEL_RSP: Self = Self(0x03);
+    /// NOW-PROTO: NOW_EXEC_RESULT_MSG_ID
+    pub const RESULT: Self = Self(0x04);
+    /// NOW-PROTO: NOW_EXEC_DATA_MSG_ID
+    pub const DATA: Self = Self(0x05);
+    /// NOW-PROTO: NOW_EXEC_RUN_MSG_ID
+    pub const RUN: Self = Self(0x10);
+    // /// NOW-PROTO: NOW_EXEC_CMD_MSG_ID
+    // pub const CMD: Self = Self(0x11);
+    /// NOW-PROTO: NOW_EXEC_PROCESS_MSG_ID
+    pub const PROCESS: Self = Self(0x12);
+    /// NOW-PROTO: NOW_EXEC_SHELL_MSG_ID
+    pub const SHELL: Self = Self(0x13);
+    /// NOW-PROTO: NOW_EXEC_BATCH_MSG_ID
+    pub const BATCH: Self = Self(0x14);
+    /// NOW-PROTO: NOW_EXEC_WINPS_MSG_ID
+    pub const WINPS: Self = Self(0x15);
+    /// NOW-PROTO: NOW_EXEC_PWSH_MSG_ID
+    pub const PWSH: Self = Self(0x16);
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::{test_utils::now_msg_roundtrip, NowSeverity, NowStatus, NowStatusCode, NowVarBuf, NowVarStr};
+
+    use expect_test::expect;
+
+    #[test]
+    fn roundtrip_exec_capset() {
+        now_msg_roundtrip(
+            NowExecCapsetMsg::new(NowExecCapsetFlags::all()),
+            expect!["[00, 00, 00, 00, 13, 00, FF, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_abort() {
+        now_msg_roundtrip(
+            NowExecAbortMsg::new(0x12345678, NowStatus::new(NowSeverity::Fatal, NowStatusCode::FAILURE)),
+            expect!["[08, 00, 00, 00, 13, 01, 00, 00, 78, 56, 34, 12, C0, 00, FF, FF]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_cancel_req() {
+        now_msg_roundtrip(
+            NowExecCancelReqMsg::new(0x12345678),
+            expect!["[04, 00, 00, 00, 13, 02, 00, 00, 78, 56, 34, 12]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_cancel_rsp() {
+        now_msg_roundtrip(
+            NowExecCancelRspMsg::new(0x12345678, NowStatus::new(NowSeverity::Error, NowStatusCode::FAILURE)),
+            expect!["[08, 00, 00, 00, 13, 03, 00, 00, 78, 56, 34, 12, 80, 00, FF, FF]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_result() {
+        now_msg_roundtrip(
+            NowExecResultMsg::new(0x12345678, NowStatus::new(NowSeverity::Error, NowStatusCode::FAILURE)),
+            expect!["[08, 00, 00, 00, 13, 04, 00, 00, 78, 56, 34, 12, 80, 00, FF, FF]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_data() {
+        now_msg_roundtrip(
+            NowExecDataMsg::new(
+                NowExecDataFlags::LAST,
+                0x12345678,
+                NowVarBuf::new(vec![0x01, 0x02, 0x03]).unwrap(),
+            ),
+            expect!["[08, 00, 00, 00, 13, 05, 02, 00, 78, 56, 34, 12, 03, 01, 02, 03]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_run() {
+        now_msg_roundtrip(
+            NowExecRunMsg::new(0x1234567, NowVarStr::new("hello".to_string()).unwrap()),
+            expect!["[0B, 00, 00, 00, 13, 10, 00, 00, 67, 45, 23, 01, 05, 68, 65, 6C, 6C, 6F, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_process() {
+        now_msg_roundtrip(
+            NowExecProcessMsg::new(
+                0x12345678,
+                NowVarStr::new("a".to_string()).unwrap(),
+                NowVarStr::new("b".to_string()).unwrap(),
+                NowVarStr::new("c".to_string()).unwrap(),
+            ),
+            expect!["[0D, 00, 00, 00, 13, 12, 00, 00, 78, 56, 34, 12, 01, 61, 00, 01, 62, 00, 01, 63, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_shell() {
+        now_msg_roundtrip(
+            NowExecShellMsg::new(
+                0x12345678,
+                NowVarStr::new("a".to_string()).unwrap(),
+                NowVarStr::new("b".to_string()).unwrap(),
+            ),
+            expect!["[0A, 00, 00, 00, 13, 13, 00, 00, 78, 56, 34, 12, 01, 61, 00, 01, 62, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_batch() {
+        now_msg_roundtrip(
+            NowExecBatchMsg::new(0x12345678, NowVarStr::new("a".to_string()).unwrap()),
+            expect!["[07, 00, 00, 00, 13, 14, 00, 00, 78, 56, 34, 12, 01, 61, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_ps() {
+        now_msg_roundtrip(
+            NowExecWinPsMsg::new(0x12345678, NowVarStr::new("a".to_string()).unwrap())
+                .with_flags(NowExecWinPsFlags::NO_PROFILE)
+                .with_execution_policy(NowVarStr::new("b".to_string()).unwrap())
+                .with_configuration_name(NowVarStr::new("c".to_string()).unwrap()),
+            expect!["[0D, 00, 00, 00, 13, 15, D0, 00, 78, 56, 34, 12, 01, 61, 00, 01, 62, 00, 01, 63, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_exec_pwsh() {
+        now_msg_roundtrip(
+            NowExecPwshMsg::new(0x12345678, NowVarStr::new("a".to_string()).unwrap())
+                .with_flags(NowExecWinPsFlags::NO_PROFILE)
+                .with_execution_policy(NowVarStr::new("b".to_string()).unwrap())
+                .with_configuration_name(NowVarStr::new("c".to_string()).unwrap()),
+            expect!["[0D, 00, 00, 00, 13, 16, D0, 00, 78, 56, 34, 12, 01, 61, 00, 01, 62, 00, 01, 63, 00]"],
+        );
+    }
+}

--- a/crates/now-proto-pdu/src/exec/process.rs
+++ b/crates/now-proto-pdu/src/exec/process.rs
@@ -1,0 +1,111 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowVarStr, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_PROCESS_MSG message is used to send a Windows CreateProcess() request.
+///
+/// NOW-PROTO: NOW_EXEC_PROCESS_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecProcessMsg {
+    session_id: u32,
+    filename: NowVarStr,
+    parameters: NowVarStr,
+    directory: NowVarStr,
+}
+
+impl NowExecProcessMsg {
+    const NAME: &'static str = "NOW_EXEC_PROCESS_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, filename: NowVarStr, parameters: NowVarStr, directory: NowVarStr) -> Self {
+        Self {
+            session_id,
+            filename,
+            parameters,
+            directory,
+        }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn filename(&self) -> &NowVarStr {
+        &self.filename
+    }
+
+    pub fn parameters(&self) -> &NowVarStr {
+        &self.parameters
+    }
+
+    pub fn directory(&self) -> &NowVarStr {
+        &self.directory
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.filename.size() + self.parameters.size() + self.directory.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let filename = NowVarStr::decode(src)?;
+        let parameters = NowVarStr::decode(src)?;
+        let directory = NowVarStr::decode(src)?;
+
+        Ok(Self {
+            session_id,
+            filename,
+            parameters,
+            directory,
+        })
+    }
+}
+
+impl PduEncode for NowExecProcessMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::PROCESS.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.filename.encode(dst)?;
+        self.parameters.encode(dst)?;
+        self.directory.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecProcessMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::PROCESS) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecProcessMsg> for NowMessage {
+    fn from(msg: NowExecProcessMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Process(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/pwsh.rs
+++ b/crates/now-proto-pdu/src/exec/pwsh.rs
@@ -1,0 +1,145 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowExecWinPsFlags, NowHeader, NowMessage, NowMessageClass, NowVarStr, PduDecode,
+    PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_PWSH_MSG message is used to execute a remote PowerShell 7 (pwsh) command.
+///
+/// NOW-PROTO: NOW_EXEC_PWSH_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecPwshMsg {
+    flags: NowExecWinPsFlags,
+    session_id: u32,
+    command: NowVarStr,
+    execution_policy: NowVarStr,
+    configuration_name: NowVarStr,
+}
+
+impl NowExecPwshMsg {
+    const NAME: &'static str = "NOW_EXEC_PWSH_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, command: NowVarStr) -> Self {
+        Self {
+            session_id,
+            command,
+            flags: NowExecWinPsFlags::empty(),
+            execution_policy: NowVarStr::empty(),
+            configuration_name: NowVarStr::empty(),
+        }
+    }
+
+    pub fn with_flags(mut self, flags: NowExecWinPsFlags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    pub fn with_execution_policy(mut self, execution_policy: NowVarStr) -> Self {
+        self.execution_policy = execution_policy;
+        self.flags |= NowExecWinPsFlags::EXECUTION_POLICY;
+        self
+    }
+
+    pub fn with_configuration_name(mut self, configuration_name: NowVarStr) -> Self {
+        self.configuration_name = configuration_name;
+        self.flags |= NowExecWinPsFlags::CONFIGURATION_NAME;
+        self
+    }
+
+    pub fn flags(&self) -> NowExecWinPsFlags {
+        self.flags
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn command(&self) -> &NowVarStr {
+        &self.command
+    }
+
+    pub fn execution_policy(&self) -> Option<&NowVarStr> {
+        if self.flags.contains(NowExecWinPsFlags::EXECUTION_POLICY) {
+            Some(&self.execution_policy)
+        } else {
+            None
+        }
+    }
+
+    pub fn configuration_name(&self) -> Option<&NowVarStr> {
+        if self.flags.contains(NowExecWinPsFlags::CONFIGURATION_NAME) {
+            Some(&self.configuration_name)
+        } else {
+            None
+        }
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.command.size() + self.execution_policy.size() + self.configuration_name.size()
+    }
+
+    pub(super) fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let flags = NowExecWinPsFlags::from_bits_retain(header.flags);
+        let session_id = src.read_u32();
+        let command = NowVarStr::decode(src)?;
+        let execution_policy = NowVarStr::decode(src)?;
+        let configuration_name = NowVarStr::decode(src)?;
+
+        Ok(Self {
+            flags,
+            session_id,
+            command,
+            execution_policy,
+            configuration_name,
+        })
+    }
+}
+
+impl PduEncode for NowExecPwshMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::PWSH.0,
+            flags: self.flags.bits(),
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.command.encode(dst)?;
+        self.execution_policy.encode(dst)?;
+        self.configuration_name.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecPwshMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::PWSH) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecPwshMsg> for NowMessage {
+    fn from(msg: NowExecPwshMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Pwsh(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/result.rs
+++ b/crates/now-proto-pdu/src/exec/result.rs
@@ -1,0 +1,87 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowStatus, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_RESULT_MSG message is used to return the result of an execution request.
+///
+/// NOW_PROTO: NOW_EXEC_RESULT_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecResultMsg {
+    session_id: u32,
+    status: NowStatus,
+}
+
+impl NowExecResultMsg {
+    const NAME: &'static str = "NOW_EXEC_RESULT_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, status: NowStatus) -> Self {
+        Self { session_id, status }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn status(&self) -> &NowStatus {
+        &self.status
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.status.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let status = NowStatus::decode(src)?;
+
+        Ok(Self { session_id, status })
+    }
+}
+
+impl PduEncode for NowExecResultMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::RESULT.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.status.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecResultMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::RESULT) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecResultMsg> for NowMessage {
+    fn from(msg: NowExecResultMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Result(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/run.rs
+++ b/crates/now-proto-pdu/src/exec/run.rs
@@ -1,0 +1,90 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowVarStr, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_RUN_MSG message is used to send a run request. This request type maps to starting
+/// a program by using the “Run” menu on operating systems (the Start Menu on Windows, the Dock on
+/// macOS etc.). The execution of programs started with NOW_EXEC_RUN_MSG is not followed and does
+/// not send back the output.
+///
+/// NOW_PROTO: NOW_EXEC_RUN_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecRunMsg {
+    session_id: u32,
+    command: NowVarStr,
+}
+
+impl NowExecRunMsg {
+    const NAME: &'static str = "NOW_EXEC_RUN_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, command: NowVarStr) -> Self {
+        Self { session_id, command }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn command(&self) -> &NowVarStr {
+        &self.command
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.command.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let command = NowVarStr::decode(src)?;
+
+        Ok(Self { session_id, command })
+    }
+}
+
+impl PduEncode for NowExecRunMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::RUN.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.command.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecRunMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::RUN) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecRunMsg> for NowMessage {
+    fn from(msg: NowExecRunMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Run(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/shell.rs
+++ b/crates/now-proto-pdu/src/exec/shell.rs
@@ -1,0 +1,102 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowVarStr, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_EXEC_SHELL_MSG message is used to execute a remote shell command.
+///
+/// NOW-PROTO: NOW_EXEC_SHELL_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecShellMsg {
+    session_id: u32,
+    command: NowVarStr,
+    shell: NowVarStr,
+}
+
+impl NowExecShellMsg {
+    const NAME: &'static str = "NOW_EXEC_SHELL_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, command: NowVarStr, shell: NowVarStr) -> Self {
+        Self {
+            session_id,
+            command,
+            shell,
+        }
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn command(&self) -> &NowVarStr {
+        &self.command
+    }
+
+    pub fn shell(&self) -> &NowVarStr {
+        &self.shell
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.command.size() + self.shell.size()
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let session_id = src.read_u32();
+        let command = NowVarStr::decode(src)?;
+        let shell = NowVarStr::decode(src)?;
+
+        Ok(Self {
+            session_id,
+            command,
+            shell,
+        })
+    }
+}
+
+impl PduEncode for NowExecShellMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::SHELL.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.command.encode(dst)?;
+        self.shell.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecShellMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::SHELL) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecShellMsg> for NowMessage {
+    fn from(msg: NowExecShellMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::Shell(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/exec/win_ps.rs
+++ b/crates/now-proto-pdu/src/exec/win_ps.rs
@@ -1,0 +1,186 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowExecMsgKind, NowHeader, NowMessage, NowMessageClass, NowVarStr, PduDecode, PduEncode, PduResult,
+};
+use bitflags::bitflags;
+
+bitflags! {
+    /// NOW-PROTO: NOW_EXEC_WINPS_MSG msgFlags field.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NowExecWinPsFlags: u16 {
+        /// PowerShell -NoLogo option.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_NO_LOGO
+        const NO_LOGO = 0x0001;
+        /// PowerShell -NoExit option.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_NO_EXIT
+        const NO_EXIT = 0x0002;
+        /// PowerShell -Sta option.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_STA
+        const STA = 0x0004;
+        /// PowerShell -Mta option
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_MTA
+        const MTA = 0x0008;
+        /// PowerShell -NoProfile option.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_NO_PROFILE
+        const NO_PROFILE = 0x0010;
+        /// PowerShell -NonInteractive option.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_NON_INTERACTIVE
+        const NON_INTERACTIVE = 0x0020;
+        /// The PowerShell -ExecutionPolicy parameter is specified with value in
+        /// executionPolicy field.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_EXECUTION_POLICY
+        const EXECUTION_POLICY = 0x0040;
+        /// The PowerShell -ConfigurationName parameter is specified with value in
+        /// configurationName field.
+        ///
+        /// NOW-PROTO: NOW_EXEC_FLAG_PS_CONFIGURATION_NAME
+        const CONFIGURATION_NAME = 0x0080;
+    }
+}
+
+/// The NOW_EXEC_WINPS_MSG message is used to execute a remote Windows PowerShell (powershell.exe) command.
+///
+/// NOW-PROTO: NOW_EXEC_WINPS_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowExecWinPsMsg {
+    flags: NowExecWinPsFlags,
+    session_id: u32,
+    command: NowVarStr,
+    execution_policy: NowVarStr,
+    configuration_name: NowVarStr,
+}
+
+impl NowExecWinPsMsg {
+    const NAME: &'static str = "NOW_EXEC_WINPS_MSG";
+    const FIXED_PART_SIZE: usize = 4;
+
+    pub fn new(session_id: u32, command: NowVarStr) -> Self {
+        Self {
+            session_id,
+            command,
+            flags: NowExecWinPsFlags::empty(),
+            execution_policy: NowVarStr::empty(),
+            configuration_name: NowVarStr::empty(),
+        }
+    }
+
+    pub fn with_flags(mut self, flags: NowExecWinPsFlags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    pub fn with_execution_policy(mut self, execution_policy: NowVarStr) -> Self {
+        self.execution_policy = execution_policy;
+        self.flags |= NowExecWinPsFlags::EXECUTION_POLICY;
+        self
+    }
+
+    pub fn with_configuration_name(mut self, configuration_name: NowVarStr) -> Self {
+        self.configuration_name = configuration_name;
+        self.flags |= NowExecWinPsFlags::CONFIGURATION_NAME;
+        self
+    }
+
+    pub fn flags(&self) -> NowExecWinPsFlags {
+        self.flags
+    }
+
+    pub fn session_id(&self) -> u32 {
+        self.session_id
+    }
+
+    pub fn command(&self) -> &NowVarStr {
+        &self.command
+    }
+
+    pub fn execution_policy(&self) -> Option<&NowVarStr> {
+        if self.flags.contains(NowExecWinPsFlags::EXECUTION_POLICY) {
+            Some(&self.execution_policy)
+        } else {
+            None
+        }
+    }
+
+    pub fn configuration_name(&self) -> Option<&NowVarStr> {
+        if self.flags.contains(NowExecWinPsFlags::CONFIGURATION_NAME) {
+            Some(&self.configuration_name)
+        } else {
+            None
+        }
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.command.size() + self.execution_policy.size() + self.configuration_name.size()
+    }
+
+    pub(super) fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let flags = NowExecWinPsFlags::from_bits_retain(header.flags);
+        let session_id = src.read_u32();
+        let command = NowVarStr::decode(src)?;
+        let execution_policy = NowVarStr::decode(src)?;
+        let configuration_name = NowVarStr::decode(src)?;
+
+        Ok(Self {
+            flags,
+            session_id,
+            command,
+            execution_policy,
+            configuration_name,
+        })
+    }
+}
+
+impl PduEncode for NowExecWinPsMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::EXEC,
+            kind: NowExecMsgKind::WINPS.0,
+            flags: self.flags.bits(),
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.session_id);
+        self.command.encode(dst)?;
+        self.execution_policy.encode(dst)?;
+        self.configuration_name.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowExecWinPsMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowExecMsgKind(header.kind)) {
+            (NowMessageClass::EXEC, NowExecMsgKind::WINPS) => Self::decode_from_body(header, src),
+            _ => Err(invalid_message_err!("type", "invalid message type")),
+        }
+    }
+}
+
+impl From<NowExecWinPsMsg> for NowMessage {
+    fn from(msg: NowExecWinPsMsg) -> Self {
+        NowMessage::Exec(NowExecMessage::WinPs(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/lib.rs
+++ b/crates/now-proto-pdu/src/lib.rs
@@ -1,0 +1,120 @@
+//! This crate provides implementation of [NOW_PROTO] protocol.
+//!
+//! [NOW_PROTO]: ../../../docs/NOW-spec.md
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[macro_use]
+mod macros;
+
+#[cfg(all(test, feature = "std"))]
+mod test_utils;
+
+mod core;
+mod exec;
+mod message;
+mod session;
+mod system;
+
+mod cursor;
+mod error;
+
+pub use error::{PduError, PduErrorExt, PduErrorKind};
+pub type PduResult<T> = Result<T, PduError>;
+
+pub use core::*;
+pub use exec::*;
+pub use message::*;
+pub use session::*;
+pub use system::*;
+
+use cursor::{ReadCursor, WriteCursor};
+
+/// PDU that can be encoded into its binary form.
+///
+/// The resulting binary payload is a fully encoded PDU that may be sent to the peer.
+///
+/// This trait is object-safe and may be used in a dynamic context.
+pub trait PduEncode {
+    /// Encodes this PDU in-place using the provided `WriteCursor`.
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()>;
+
+    /// Returns the associated PDU name associated.
+    fn name(&self) -> &'static str;
+
+    /// Computes the size in bytes for this PDU.
+    fn size(&self) -> usize;
+}
+
+assert_obj_safe!(PduEncode);
+
+/// Encodes the given PDU in-place into the provided buffer and returns the number of bytes written.
+pub fn encode<T: PduEncode>(pdu: &T, dst: &mut [u8]) -> PduResult<usize> {
+    let mut cursor = WriteCursor::new(dst);
+    encode_cursor(pdu, &mut cursor)?;
+    Ok(cursor.pos())
+}
+
+/// Same as `encode_pdu` but resizes the buffer when it is too small to fit the PDU.
+pub fn encode_buf<T: PduEncode>(pdu: &T, buf: &mut alloc::vec::Vec<u8>) -> PduResult<usize> {
+    let pdu_size = pdu.size();
+
+    if buf.len() < pdu_size {
+        buf.resize(pdu_size, 0);
+    }
+
+    encode(pdu, buf)
+}
+
+/// Encodes the given PDU in-place using the provided `WriteCursor`.
+pub fn encode_cursor<T: PduEncode>(pdu: &T, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+    pdu.encode(dst)
+}
+
+/// Gets the name of this PDU.
+pub fn name<T: PduEncode>(pdu: &T) -> &'static str {
+    pdu.name()
+}
+
+/// Computes the size in bytes for this PDU.
+pub fn size<T: PduEncode>(pdu: &T) -> usize {
+    pdu.size()
+}
+
+/// PDU that can be decoded from a binary input.
+///
+/// The binary payload must be a full PDU, not some subset of it.
+pub trait PduDecode<'de>: Sized {
+    fn decode(src: &mut ReadCursor<'de>) -> PduResult<Self>;
+}
+
+pub fn decode<'de, T: PduDecode<'de>>(src: &'de [u8]) -> PduResult<T> {
+    let mut cursor = ReadCursor::new(src);
+    T::decode(&mut cursor)
+}
+
+pub fn decode_cursor<'de, T: PduDecode<'de>>(src: &mut ReadCursor<'de>) -> PduResult<T> {
+    T::decode(src)
+}
+
+/// Similar to `PduDecode` but unconditionally returns an owned type.
+pub trait PduDecodeOwned: Sized {
+    fn decode_owned(src: &mut ReadCursor<'_>) -> PduResult<Self>;
+}
+
+pub fn decode_owned<T: PduDecodeOwned>(src: &[u8]) -> PduResult<T> {
+    let mut cursor = ReadCursor::new(src);
+    T::decode_owned(&mut cursor)
+}
+
+pub fn decode_owned_cursor<T: PduDecodeOwned>(src: &mut ReadCursor<'_>) -> PduResult<T> {
+    T::decode_owned(src)
+}
+
+/// Trait used to produce an owned version of a given PDU.
+pub trait IntoOwnedPdu: Sized {
+    type Owned: 'static;
+
+    fn into_owned_pdu(self) -> Self::Owned;
+}

--- a/crates/now-proto-pdu/src/macros.rs
+++ b/crates/now-proto-pdu/src/macros.rs
@@ -1,0 +1,184 @@
+//! Helper macros for PDU encoding and decoding
+//!
+//! Some are exported and available to external crates
+
+/// Creates a `PduError` with `NotEnoughBytes` kind
+///
+/// Shorthand for
+/// ```text
+/// <PduError as PduErrorExt>::not_enough_bytes(context, received, expected)
+/// ```
+/// and
+/// ```text
+/// <PduError as PduErrorExt>::not_enough_bytes(Self::NAME, received, expected)
+/// ```
+#[macro_export]
+macro_rules! not_enough_bytes_err {
+    ( $context:expr, $received:expr , $expected:expr $(,)? ) => {{
+        <$crate::PduError as $crate::PduErrorExt>::not_enough_bytes($context, $received, $expected)
+    }};
+    ( $received:expr , $expected:expr $(,)? ) => {{
+        not_enough_bytes_err!(Self::NAME, $received, $expected)
+    }};
+}
+
+/// Creates a `PduError` with `InvalidMessage` kind
+///
+/// Shorthand for
+/// ```text
+/// <PduError as PduErrorExt>::invalid_message(context, field, reason)
+/// ```
+/// and
+/// ```text
+/// <PduError as PduErrorExt>::invalid_message(Self::NAME, field, reason)
+/// ```
+#[macro_export]
+macro_rules! invalid_message_err {
+    ( $context:expr, $field:expr , $reason:expr $(,)? ) => {{
+        <$crate::PduError as $crate::PduErrorExt>::invalid_message($context, $field, $reason)
+    }};
+    ( $field:expr , $reason:expr $(,)? ) => {{
+        invalid_message_err!(Self::NAME, $field, $reason)
+    }};
+}
+
+/// Creates a `PduError` with `UnexpectedMessageType` kind
+///
+/// Shorthand for
+/// ```text
+/// <PduError as PduErrorExt>::unexpected_message_type(context, got)
+/// ```
+/// and
+/// ```text
+/// <PduError as PduErrorExt>::unexpected_message_type(Self::NAME, got)
+/// ```
+#[macro_export]
+macro_rules! unexpected_message_kind_err {
+    ( $context:expr, class: $class:expr, kind: $kind:expr $(,)? ) => {{
+        <$crate::PduError as $crate::PduErrorExt>::unexpected_message_kind($context, $class, $kind)
+    }};
+    ( class: $class:expr, kind: $kind:expr $(,)? ) => {{
+        unexpected_message_kind_err!(Self::NAME, class: $class, kind: $kind)
+    }};
+}
+
+/// Creates a `PduError` with `Other` kind
+///
+/// Shorthand for
+/// ```text
+/// <PduError as PduErrorExt>::other(context, description)
+/// ```
+/// and
+/// ```text
+/// <PduError as PduErrorExt>::other(Self::NAME, description)
+/// ```
+#[macro_export]
+macro_rules! other_err {
+    ( $context:expr, $description:expr $(,)? ) => {{
+        <$crate::PduError as $crate::PduErrorExt>::other($context, $description)
+    }};
+    ( $description:expr $(,)? ) => {{
+        other_err!(Self::NAME, $description)
+    }};
+}
+
+#[macro_export]
+macro_rules! ensure_size {
+    (ctx: $ctx:expr, in: $buf:ident, size: $expected:expr) => {{
+        let received = $buf.len();
+        let expected = $expected;
+        if !(received >= expected) {
+            return Err(<$crate::PduError as $crate::PduErrorExt>::not_enough_bytes($ctx, received, expected));
+        }
+    }};
+    (in: $buf:ident, size: $expected:expr) => {{
+        $crate::ensure_size!(ctx: Self::NAME, in: $buf, size: $expected)
+    }};
+}
+
+#[macro_export]
+macro_rules! ensure_fixed_part_size {
+    (in: $buf:ident) => {{
+        $crate::ensure_size!(ctx: Self::NAME, in: $buf, size: Self::FIXED_PART_SIZE)
+    }};
+}
+
+#[macro_export]
+macro_rules! cast_length {
+    ($ctx:expr, $field:expr, $len:expr) => {{
+        $len.try_into()
+            .map_err(|_| <$crate::PduError as $crate::PduErrorExt>::invalid_message($ctx, $field, "too many elements"))
+    }};
+    ($field:expr, $len:expr) => {{
+        $crate::cast_length!(Self::NAME, $field, $len)
+    }};
+}
+
+/// Asserts that the traits support dynamic dispatch.
+///
+/// From <https://docs.rs/static_assertions/latest/src/static_assertions/assert_obj_safe.rs.html#72-76>
+#[macro_export]
+macro_rules! assert_obj_safe {
+    ($($xs:path),+ $(,)?) => {
+        $(const _: Option<&dyn $xs> = None;)+
+    };
+}
+
+/// Implements additional traits for a plain old data structure (POD).
+#[macro_export]
+macro_rules! impl_pdu_pod {
+    ($pdu_ty:ty) => {
+        impl $crate::IntoOwnedPdu for $pdu_ty {
+            type Owned = Self;
+
+            fn into_owned_pdu(self) -> Self::Owned {
+                self
+            }
+        }
+
+        impl $crate::PduDecodeOwned for $pdu_ty {
+            fn decode_owned(src: &mut $crate::cursor::ReadCursor<'_>) -> $crate::PduResult<Self> {
+                <Self as $crate::PduDecode>::decode(src)
+            }
+        }
+    };
+}
+
+/// Implements additional traits for a borrowing PDU and defines a static-bounded owned version.
+#[macro_export]
+macro_rules! impl_pdu_borrowing {
+    ($pdu_ty:ident, $owned_ty:ident) => {
+        pub type $owned_ty = $pdu_ty<'static>;
+
+        impl $crate::PduDecodeOwned for $owned_ty {
+            fn decode_owned(src: &mut $crate::cursor::ReadCursor<'_>) -> $crate::PduResult<Self> {
+                let pdu = <$pdu_ty as $crate::PduDecode>::decode(src)?;
+                Ok($crate::IntoOwnedPdu::into_owned_pdu(pdu))
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! try_read_optional {
+    ($e:expr, $ret:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(ref e) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                return Ok($ret);
+            }
+            Err(e) => return Err(From::from(e)),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! try_write_optional {
+    ($val:expr, $f:expr) => {
+        if let Some(ref val) = $val {
+            $f(val)?
+        } else {
+            return Ok(());
+        }
+    };
+}

--- a/crates/now-proto-pdu/src/message.rs
+++ b/crates/now-proto-pdu/src/message.rs
@@ -1,0 +1,54 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowExecMessage, NowHeader, NowMessageClass, NowSessionMessage, NowSystemMessage, PduDecode, PduEncode, PduResult,
+};
+
+/// Wrapper type for messages transferred over the NOW-PROTO communication channel.
+///
+/// NOW-PROTO: NOW_*_MSG messages
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NowMessage {
+    System(NowSystemMessage),
+    Session(NowSessionMessage),
+    Exec(NowExecMessage),
+}
+
+impl NowMessage {
+    const NAME: &'static str = "NOW_MSG";
+}
+
+impl PduEncode for NowMessage {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        match self {
+            Self::System(msg) => msg.encode(dst),
+            Self::Session(msg) => msg.encode(dst),
+            Self::Exec(msg) => msg.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::System(msg) => msg.size(),
+            Self::Session(msg) => msg.size(),
+            Self::Exec(msg) => msg.size(),
+        }
+    }
+}
+
+impl PduDecode<'_> for NowMessage {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match NowMessageClass(header.class.0) {
+            NowMessageClass::SYSTEM => Ok(Self::System(NowSystemMessage::decode_from_body(header, src)?)),
+            NowMessageClass::SESSION => Ok(Self::Session(NowSessionMessage::decode_from_body(header, src)?)),
+            NowMessageClass::EXEC => Ok(Self::Exec(NowExecMessage::decode_from_body(header, src)?)),
+            // Handle unknown class; Unknown kind is handled by underlying message type.
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}

--- a/crates/now-proto-pdu/src/session/lock.rs
+++ b/crates/now-proto-pdu/src/session/lock.rs
@@ -1,0 +1,55 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, NowMessage, NowMessageClass, NowSessionMessage, NowSessionMessageKind, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_SESSION_LOCK_MSG is used to request locking the user session.
+///
+/// NOW_PROTO: NOW_SESSION_LOCK_MSG
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct NowSessionLockMsg;
+
+impl NowSessionLockMsg {
+    const NAME: &'static str = "NOW_SESSION_LOCK_MSG";
+}
+
+impl PduEncode for NowSessionLockMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: 0,
+            class: NowMessageClass::SESSION,
+            kind: NowSessionMessageKind::LOCK.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE
+    }
+}
+
+impl PduDecode<'_> for NowSessionLockMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowSessionMessageKind(header.kind)) {
+            (NowMessageClass::SESSION, NowSessionMessageKind::LOCK) => Ok(Self::default()),
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}
+
+impl From<NowSessionLockMsg> for NowMessage {
+    fn from(val: NowSessionLockMsg) -> Self {
+        NowMessage::Session(NowSessionMessage::Lock(val))
+    }
+}

--- a/crates/now-proto-pdu/src/session/logoff.rs
+++ b/crates/now-proto-pdu/src/session/logoff.rs
@@ -1,0 +1,55 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, NowMessage, NowMessageClass, NowSessionMessage, NowSessionMessageKind, PduDecode, PduEncode, PduResult,
+};
+
+/// The NOW_SESSION_LOGOFF_MSG is used to request a user session logoff.
+///
+/// NOW_PROTO: NOW_SESSION_LOGOFF_MSG
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub struct NowSessionLogoffMsg;
+
+impl NowSessionLogoffMsg {
+    const NAME: &'static str = "NOW_SESSION_LOGOFF_MSG";
+}
+
+impl PduEncode for NowSessionLogoffMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: 0,
+            class: NowMessageClass::SESSION,
+            kind: NowSessionMessageKind::LOGOFF.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE
+    }
+}
+
+impl PduDecode<'_> for NowSessionLogoffMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowSessionMessageKind(header.kind)) {
+            (NowMessageClass::SESSION, NowSessionMessageKind::LOGOFF) => Ok(Self::default()),
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}
+
+impl From<NowSessionLogoffMsg> for NowMessage {
+    fn from(msg: NowSessionLogoffMsg) -> Self {
+        NowMessage::Session(NowSessionMessage::Logoff(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/session/mod.rs
+++ b/crates/now-proto-pdu/src/session/mod.rs
@@ -1,0 +1,126 @@
+mod lock;
+mod logoff;
+mod msg_box_req;
+mod msg_box_rsp;
+
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, PduEncode, PduResult,
+};
+
+pub use lock::NowSessionLockMsg;
+pub use logoff::NowSessionLogoffMsg;
+pub use msg_box_req::{NowMessageBoxStyle, NowSessionMsgBoxReqMsg};
+pub use msg_box_rsp::{NowMsgBoxResponse, NowSessionMsgBoxRspMsg};
+
+/// Wrapper for the `NOW_SESSION_MSG_CLASS_ID` message class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NowSessionMessageKind(pub u8);
+
+impl NowSessionMessageKind {
+    /// NOW-PROTO: NOW_SESSION_LOCK_MSG_ID
+    pub const LOCK: Self = Self(0x01);
+    /// NOW-PROTO: NOW_SESSION_LOGOFF_MSG_ID
+    pub const LOGOFF: Self = Self(0x02);
+    /// NOW-PROTO: NOW_SESSION_MSGBOX_REQ_MSG_ID
+    pub const MSGBOX_REQ: Self = Self(0x03);
+    /// NOW-PROTO: NOW_SESSION_MSGBOX_RSP_MSG_ID
+    pub const MSGBOX_RSP: Self = Self(0x04);
+}
+
+// Wrapper for the `NOW_SESSION_MSG_CLASS_ID` message class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NowSessionMessage {
+    Lock(NowSessionLockMsg),
+    Logoff(NowSessionLogoffMsg),
+    MsgBoxReq(NowSessionMsgBoxReqMsg),
+    MsgBoxRsp(NowSessionMsgBoxRspMsg),
+}
+
+impl NowSessionMessage {
+    const NAME: &'static str = "NOW_SESSION_MSG";
+
+    pub fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        match NowSessionMessageKind(header.kind) {
+            NowSessionMessageKind::LOCK => Ok(Self::Lock(NowSessionLockMsg::default())),
+            NowSessionMessageKind::LOGOFF => Ok(Self::Logoff(NowSessionLogoffMsg::default())),
+            NowSessionMessageKind::MSGBOX_REQ => {
+                Ok(Self::MsgBoxReq(NowSessionMsgBoxReqMsg::decode_from_body(header, src)?))
+            }
+            NowSessionMessageKind::MSGBOX_RSP => {
+                Ok(Self::MsgBoxRsp(NowSessionMsgBoxRspMsg::decode_from_body(header, src)?))
+            }
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}
+
+impl PduEncode for NowSessionMessage {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        match self {
+            Self::Lock(msg) => msg.encode(dst),
+            Self::Logoff(msg) => msg.encode(dst),
+            Self::MsgBoxReq(msg) => msg.encode(dst),
+            Self::MsgBoxRsp(msg) => msg.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::Lock(msg) => msg.size(),
+            Self::Logoff(msg) => msg.size(),
+            Self::MsgBoxReq(msg) => msg.size(),
+            Self::MsgBoxRsp(msg) => msg.size(),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::{test_utils::now_msg_roundtrip, NowVarStr};
+
+    use expect_test::expect;
+    #[test]
+    fn roundtrip_session_lock() {
+        now_msg_roundtrip(
+            NowSessionLockMsg::default(),
+            expect!["[00, 00, 00, 00, 12, 01, 00, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtrip_session_logoff() {
+        now_msg_roundtrip(
+            NowSessionLogoffMsg::default(),
+            expect!["[00, 00, 00, 00, 12, 02, 00, 00]"],
+        );
+    }
+
+    #[test]
+    fn roundtip_session_msgbox_req() {
+        now_msg_roundtrip(
+            NowSessionMsgBoxReqMsg::new(
+                0x76543210,
+                NowVarStr::new("hello".to_string()).unwrap(),
+            ).with_response().with_style(NowMessageBoxStyle::ABORT_RETRY_IGNORE)
+            .with_title(NowVarStr::new("world".to_string()).unwrap())
+            .with_timeout(3),
+            expect!["[1A, 00, 00, 00, 12, 03, 0F, 00, 10, 32, 54, 76, 02, 00, 00, 00, 03, 00, 00, 00, 05, 77, 6F, 72, 6C, 64, 00, 05, 68, 65, 6C, 6C, 6F, 00]"]
+        );
+    }
+
+    #[test]
+    fn roundtrip_session_msgbox_rsp() {
+        now_msg_roundtrip(
+            NowSessionMsgBoxRspMsg::new(0x01234567, NowMsgBoxResponse::RETRY),
+            expect!["[08, 00, 00, 00, 12, 04, 00, 00, 67, 45, 23, 01, 04, 00, 00, 00]"],
+        );
+    }
+}

--- a/crates/now-proto-pdu/src/session/msg_box_req.rs
+++ b/crates/now-proto-pdu/src/session/msg_box_req.rs
@@ -1,0 +1,217 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, NowMessage, NowMessageClass, NowSessionMessage, NowSessionMessageKind, NowVarStr, PduDecode, PduEncode,
+    PduResult,
+};
+use bitflags::bitflags;
+
+/// Message box style; Directly maps to the WinAPI MessageBox function message box style field.
+///
+/// NOW_PROTO: `style` field from NOW_SESSION_MESSAGE_BOX_REQ_MSG
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NowMessageBoxStyle(u32);
+
+impl NowMessageBoxStyle {
+    pub const OK: Self = Self(0x00000000);
+    pub const OK_CANCEL: Self = Self(0x00000001);
+    pub const ABORT_RETRY_IGNORE: Self = Self(0x00000002);
+    pub const YES_NO_CANCEL: Self = Self(0x00000003);
+    pub const YES_NO: Self = Self(0x00000004);
+    pub const RETRY_CANCEL: Self = Self(0x00000005);
+    pub const CANCEL_TRY_CONTINUE: Self = Self(0x00000006);
+    pub const HELP: Self = Self(0x00004000);
+
+    pub fn new(style: u32) -> Self {
+        Self(style)
+    }
+
+    pub fn value(&self) -> u32 {
+        self.0
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NowSessionMessageBoxFlags: u16 {
+        /// The title field contains non-default value.
+        ///
+        /// NOW_PROTO: NOW_SESSION_MSGBOX_FLAG_TITLE
+        const TITLE = 0x0001;
+
+        /// The style field contains non-default value.
+        ///
+        /// NOW_PROTO: NOW_SESSION_MSGBOX_FLAG_STYLE
+        const STYLE = 0x0002;
+
+        /// The timeout field contains non-default value.
+        ///
+        /// NOW_PROTO: NOW_SESSION_MSGBOX_FLAG_TIMEOUT
+        const TIMEOUT = 0x0004;
+
+        /// A response message is expected (don't fire and forget)
+        ///
+        /// NOW_PROTO: NOW_SESSION_MSGBOX_FLAG_RESPONSE
+        const RESPONSE = 0x0008;
+    }
+}
+
+/// The NOW_SESSION_MSGBOX_REQ_MSG is used to show a message box in the user session, similar to
+/// what the [WTSSendMessage function](https://learn.microsoft.com/en-us/windows/win32/api/wtsapi32/nf-wtsapi32-wtssendmessagew)
+/// does.
+///
+/// NOW_PROTO: NOW_SESSION_MSGBOX_REQ_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowSessionMsgBoxReqMsg {
+    flags: NowSessionMessageBoxFlags,
+    request_id: u32,
+    style: NowMessageBoxStyle,
+    timeout: u32,
+    title: NowVarStr,
+    message: NowVarStr,
+}
+
+impl NowSessionMsgBoxReqMsg {
+    const NAME: &'static str = "NOW_SESSION_MSGBOX_REQ_MSG";
+    const FIXED_PART_SIZE: usize = 12;
+
+    pub fn new(request_id: u32, message: NowVarStr) -> Self {
+        Self {
+            flags: NowSessionMessageBoxFlags::empty(),
+            request_id,
+            style: NowMessageBoxStyle::OK,
+            timeout: 0,
+            title: NowVarStr::new(String::new()).unwrap(),
+            message,
+        }
+    }
+
+    pub fn with_title(mut self, title: NowVarStr) -> Self {
+        self.flags |= NowSessionMessageBoxFlags::TITLE;
+        self.title = title;
+        self
+    }
+
+    pub fn with_style(mut self, style: NowMessageBoxStyle) -> Self {
+        self.flags |= NowSessionMessageBoxFlags::STYLE;
+        self.style = style;
+        self
+    }
+
+    pub fn with_timeout(mut self, timeout: u32) -> Self {
+        self.flags |= NowSessionMessageBoxFlags::TIMEOUT;
+        self.timeout = timeout;
+        self
+    }
+
+    pub fn with_response(mut self) -> Self {
+        self.flags |= NowSessionMessageBoxFlags::RESPONSE;
+        self
+    }
+
+    pub fn request_id(&self) -> u32 {
+        self.request_id
+    }
+
+    pub fn style(&self) -> NowMessageBoxStyle {
+        if self.flags.contains(NowSessionMessageBoxFlags::STYLE) {
+            self.style
+        } else {
+            NowMessageBoxStyle::OK
+        }
+    }
+
+    pub fn timeout(&self) -> Option<u32> {
+        if self.flags.contains(NowSessionMessageBoxFlags::TIMEOUT) && self.timeout > 0 {
+            Some(self.timeout)
+        } else {
+            None
+        }
+    }
+
+    pub fn title(&self) -> Option<&NowVarStr> {
+        if self.flags.contains(NowSessionMessageBoxFlags::TITLE) {
+            Some(&self.title)
+        } else {
+            None
+        }
+    }
+
+    pub fn message(&self) -> &NowVarStr {
+        &self.message
+    }
+
+    pub fn is_response_expected(&self) -> bool {
+        self.flags.contains(NowSessionMessageBoxFlags::RESPONSE)
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.title.size() + self.message.size()
+    }
+
+    pub(super) fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let flags = NowSessionMessageBoxFlags::from_bits_retain(header.flags);
+        let request_id = src.read_u32();
+        let style = NowMessageBoxStyle(src.read_u32());
+        let timeout = src.read_u32();
+        let title = NowVarStr::decode(src)?;
+        let message = NowVarStr::decode(src)?;
+
+        Ok(Self {
+            flags,
+            request_id,
+            style,
+            timeout,
+            title,
+            message,
+        })
+    }
+}
+
+impl PduEncode for NowSessionMsgBoxReqMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::SESSION,
+            kind: NowSessionMessageKind::MSGBOX_REQ.0,
+            flags: self.flags.bits(),
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.request_id);
+        dst.write_u32(self.style.value());
+        dst.write_u32(self.timeout);
+        self.title.encode(dst)?;
+        self.message.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowSessionMsgBoxReqMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowSessionMessageKind(header.kind)) {
+            (NowMessageClass::SESSION, NowSessionMessageKind::MSGBOX_REQ) => Self::decode_from_body(header, src),
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}
+
+impl From<NowSessionMsgBoxReqMsg> for NowMessage {
+    fn from(val: NowSessionMsgBoxReqMsg) -> Self {
+        NowMessage::Session(NowSessionMessage::MsgBoxReq(val))
+    }
+}

--- a/crates/now-proto-pdu/src/session/msg_box_rsp.rs
+++ b/crates/now-proto-pdu/src/session/msg_box_rsp.rs
@@ -1,0 +1,145 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, NowMessage, NowMessageClass, NowSessionMessage, NowSessionMessageKind, PduDecode, PduEncode, PduResult,
+};
+
+/// Message box response; Directly maps to the WinAPI MessageBox function response.
+///
+/// NOW_PROTO: `response` field from NOW_SESSION_MESSAGE_BOX_RSP_MSG
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NowMsgBoxResponse(u32);
+
+impl NowMsgBoxResponse {
+    /// OK
+    ///
+    /// NOW_PROTO: IDOK
+    pub const OK: Self = Self(1);
+    /// Cancel
+    ///
+    /// NOW_PROTO: IDCANCEL
+    pub const CANCEL: Self = Self(2);
+    /// Abort
+    ///
+    /// NOW_PROTO: IDABORT
+    pub const ABORT: Self = Self(3);
+    /// Retry
+    ///
+    /// NOW_PROTO: IDRETRY
+    pub const RETRY: Self = Self(4);
+    /// Ignore
+    ///
+    /// NOW_PROTO: IDIGNORE
+    pub const IGNORE: Self = Self(5);
+    /// Yes
+    ///
+    /// NOW_PROTO: IDYES
+    pub const YES: Self = Self(6);
+    /// No
+    ///
+    /// NOW_PROTO: IDNO
+    pub const NO: Self = Self(7);
+    /// Try Again
+    ///
+    /// NOW_PROTO: IDTRYAGAIN
+    pub const TRY_AGAIN: Self = Self(10);
+    /// Continue
+    ///
+    /// NOW_PROTO: IDCONTINUE
+    pub const CONTINUE: Self = Self(11);
+    /// Timeout
+    ///
+    /// NOW_PROTO: IDTIMEOUT
+    pub const TIMEOUT: Self = Self(32000);
+
+    pub fn new(response: u32) -> Self {
+        Self(response)
+    }
+
+    pub fn value(&self) -> u32 {
+        self.0
+    }
+}
+
+/// The NOW_SESSION_MSGBOX_RSP_MSG is a message sent in response to NOW_SESSION_MSGBOX_REQ_MSG if
+/// the NOW_MSGBOX_FLAG_RESPONSE has been set, and contains the result from the message box dialog.
+///
+/// NOW_PROTO: NOW_SESSION_MSGBOX_RSP_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowSessionMsgBoxRspMsg {
+    request_id: u32,
+    response: NowMsgBoxResponse,
+}
+
+impl NowSessionMsgBoxRspMsg {
+    const NAME: &'static str = "NOW_SESSION_MSGBOX_RSP_MSG";
+    const FIXED_PART_SIZE: usize = 8;
+
+    pub fn new(request_id: u32, response: NowMsgBoxResponse) -> Self {
+        Self { request_id, response }
+    }
+
+    pub fn request_id(&self) -> u32 {
+        self.request_id
+    }
+
+    pub fn response(&self) -> NowMsgBoxResponse {
+        self.response
+    }
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE
+    }
+
+    pub(super) fn decode_from_body(_header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let request_id = src.read_u32();
+        let response = NowMsgBoxResponse(src.read_u32());
+
+        Ok(Self { request_id, response })
+    }
+}
+
+impl PduEncode for NowSessionMsgBoxRspMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::SESSION,
+            kind: NowSessionMessageKind::MSGBOX_RSP.0,
+            flags: 0,
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.request_id);
+        dst.write_u32(self.response.value());
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl PduDecode<'_> for NowSessionMsgBoxRspMsg {
+    fn decode(src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        let header = NowHeader::decode(src)?;
+
+        match (header.class, NowSessionMessageKind(header.kind)) {
+            (NowMessageClass::SESSION, NowSessionMessageKind::MSGBOX_RSP) => Self::decode_from_body(header, src),
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}
+
+impl From<NowSessionMsgBoxRspMsg> for NowMessage {
+    fn from(val: NowSessionMsgBoxRspMsg) -> Self {
+        NowMessage::Session(NowSessionMessage::MsgBoxRsp(val))
+    }
+}

--- a/crates/now-proto-pdu/src/system/mod.rs
+++ b/crates/now-proto-pdu/src/system/mod.rs
@@ -1,0 +1,81 @@
+mod shutdown;
+
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    NowHeader, PduEncode, PduResult,
+};
+
+pub use shutdown::{NowSystemShutdownFlags, NowSystemShutdownMsg};
+
+// Wrapper for the `NOW_SYSTEM_MSG_CLASS_ID` message class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NowSystemMessage {
+    Shutdown(NowSystemShutdownMsg),
+}
+
+impl NowSystemMessage {
+    const NAME: &'static str = "NOW_SYSTEM_MSG";
+
+    pub fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        match NowSystemMessageKind(header.kind) {
+            NowSystemMessageKind::SHUTDOWN => Ok(Self::Shutdown(NowSystemShutdownMsg::decode_from_body(header, src)?)),
+            _ => Err(unexpected_message_kind_err!(class: header.class.0, kind: header.kind)),
+        }
+    }
+}
+
+impl PduEncode for NowSystemMessage {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        match self {
+            Self::Shutdown(msg) => msg.encode(dst),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            Self::Shutdown(msg) => msg.size(),
+        }
+    }
+}
+
+/// NOW-PROTO: NOW_SYSTEM_INFO_*_ID
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct NowSystemMessageKind(u8);
+
+impl NowSystemMessageKind {
+    // TODO: NOW_SYSTEM_INFO_REQ_ID/NOW_SYSTEM_INFO_RSP_ID when will be added to the protocol
+    // specification.
+
+    // /// NOW-PROTO: NOW_SYSTEM_INFO_REQ_ID
+    // pub const INFO_REQ: Self = Self(0x01);
+    // /// NOW-PROTO: NOW_SYSTEM_INFO_RSP_ID
+    // pub const INFO_RSP: Self = Self(0x02);
+    /// NOW-PROTO: NOW_SYSTEM_SHUTDOWN_ID
+    pub const SHUTDOWN: Self = Self(0x03);
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::*;
+    use crate::{test_utils::now_msg_roundtrip, NowVarStr};
+
+    use expect_test::expect;
+
+    #[test]
+    fn roundtip_system_shutdown() {
+        now_msg_roundtrip(
+            NowSystemShutdownMsg {
+                flags: NowSystemShutdownFlags::FORCE,
+                message: NowVarStr::new("hello".to_string()).unwrap(),
+                timeout: 0x12345678,
+            },
+            expect!["[0B, 00, 00, 00, 11, 03, 01, 00, 78, 56, 34, 12, 05, 68, 65, 6C, 6C, 6F, 00]"],
+        );
+    }
+}

--- a/crates/now-proto-pdu/src/system/shutdown.rs
+++ b/crates/now-proto-pdu/src/system/shutdown.rs
@@ -1,0 +1,88 @@
+use crate::{
+    cursor::{ReadCursor, WriteCursor},
+    system::NowSystemMessageKind,
+    NowHeader, NowMessage, NowMessageClass, NowSystemMessage, NowVarStr, PduDecode as _, PduEncode, PduResult,
+};
+use bitflags::bitflags;
+
+bitflags! {
+    /// NOW_PROTO: NOW_SYSTEM_SHUTDOWN_FLAG_* constants.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct NowSystemShutdownFlags: u16 {
+        /// Force shutdown
+        ///
+        /// NOW-PROTO: NOW_SHUTDOWN_FLAG_FORCE
+        const FORCE = 0x0001;
+        /// Reboot after shutdown
+        ///
+        /// NOW-PROTO: NOW_SHUTDOWN_FLAG_REBOOT
+        const REBOOT = 0x0002;
+    }
+}
+
+/// The NOW_SYSTEM_SHUTDOWN_MSG structure is used to request a system shutdown.
+///
+/// NOW_PROTO: NOW_SYSTEM_SHUTDOWN_MSG
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NowSystemShutdownMsg {
+    pub flags: NowSystemShutdownFlags,
+    /// This system shutdown timeout, in seconds.
+    pub timeout: u32,
+    /// Optional shutdown message.
+    pub message: NowVarStr,
+}
+
+impl NowSystemShutdownMsg {
+    const NAME: &'static str = "NOW_SYSTEM_SHUTDOWN_MSG";
+    const FIXED_PART_SIZE: usize = 4 /* u32 timeout */;
+
+    fn body_size(&self) -> usize {
+        Self::FIXED_PART_SIZE + self.message.size()
+    }
+
+    pub fn decode_from_body(header: NowHeader, src: &mut ReadCursor<'_>) -> PduResult<Self> {
+        ensure_fixed_part_size!(in: src);
+
+        let timeout = src.read_u32();
+        let message = NowVarStr::decode(src)?;
+
+        Ok(Self {
+            flags: NowSystemShutdownFlags::from_bits_retain(header.flags),
+            timeout,
+            message,
+        })
+    }
+}
+
+impl PduEncode for NowSystemShutdownMsg {
+    fn encode(&self, dst: &mut WriteCursor<'_>) -> PduResult<()> {
+        let header = NowHeader {
+            size: cast_length!("size", self.body_size())?,
+            class: NowMessageClass::SYSTEM,
+            kind: NowSystemMessageKind::SHUTDOWN.0,
+            flags: self.flags.bits(),
+        };
+
+        header.encode(dst)?;
+
+        ensure_fixed_part_size!(in: dst);
+        dst.write_u32(self.timeout);
+        self.message.encode(dst)?;
+
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn size(&self) -> usize {
+        NowHeader::FIXED_PART_SIZE + self.body_size()
+    }
+}
+
+impl From<NowSystemShutdownMsg> for NowMessage {
+    fn from(msg: NowSystemShutdownMsg) -> Self {
+        NowMessage::System(NowSystemMessage::Shutdown(msg))
+    }
+}

--- a/crates/now-proto-pdu/src/test_utils.rs
+++ b/crates/now-proto-pdu/src/test_utils.rs
@@ -1,0 +1,18 @@
+//! Various test utilities
+use crate::{cursor::ReadCursor, NowMessage, PduDecode as _};
+use alloc::vec::Vec;
+use expect_test::Expect;
+
+pub(crate) fn now_msg_roundtrip(msg: impl Into<NowMessage>, expected_bytes: Expect) {
+    let msg = msg.into();
+
+    let mut buf = Vec::new();
+    let _ = crate::encode_buf(&msg, &mut buf).unwrap();
+
+    expected_bytes.assert_eq(&format!("{:02X?}", buf));
+
+    let mut cursor = ReadCursor::new(&buf);
+    let decoded = NowMessage::decode(&mut cursor).unwrap();
+
+    assert_eq!(msg, decoded);
+}

--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -18,6 +18,7 @@ ctrlc = "3.1"
 devolutions-agent-shared = { path = "../crates/devolutions-agent-shared" }
 devolutions-gateway-task = { path = "../crates/devolutions-gateway-task" }
 devolutions-log = { path = "../crates/devolutions-log" }
+now-proto-pdu = { path = "../crates/now-proto-pdu" }
 futures = "0.3"
 hex = "0.4"
 notify-debouncer-mini = "0.4.1"


### PR DESCRIPTION
This PR implements `NOW-PROTO` protocol according to the current draft specification.

Additionally, I made some fixes/changes to the specification in https://github.com/Devolutions/devolutions-gateway/pull/913 , please review these changes first before reviewing this PR.

- Pdu parsing/error handling were copied from IronRDP, but code was and simplified/functionality reduced in some places.
- `#[no_std]` is supported with `alloc`, crate itself do not have any dependencies on other workspace members, therefore it could be used as a standalone library for other projects besides devolutions-agent
- bitfields/enums are not strict when parsing, while providing access to unknown flags/variant -- this should improve backwards-compatibility for the protocol in future.
- Some structs are currently missing due to non-specified strucutre in specification (e.g. CMD exec command and System info 
PDUs)
- All structures are covered by simple unit tests, but it would be great to add fuzzing in future

Blocked by #913