### PR TITLE
feat(agent): initial Remote Desktop server module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,45 +111,18 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
-dependencies = [
- "asn1-rs-derive 0.4.0",
- "asn1-rs-impl 0.1.0",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror",
-]
-
-[[package]]
-name = "asn1-rs"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
 dependencies = [
- "asn1-rs-derive 0.5.0",
- "asn1-rs-impl 0.2.0",
+ "asn1-rs-derive",
+ "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror",
  "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -161,18 +134,7 @@ dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
  "syn 2.0.49",
- "synstructure 0.13.1",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]
@@ -282,6 +244,33 @@ dependencies = [
  "generational-arena",
  "parking_lot",
  "slotmap",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
 ]
 
 [[package]]
@@ -431,6 +420,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.4.2",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2 1.0.78",
+ "quote 1.0.35",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.49",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +565,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -573,6 +586,15 @@ dependencies = [
  "timer",
  "widestring 0.4.3",
  "winapi",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -609,6 +631,26 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -845,24 +887,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
-dependencies = [
- "asn1-rs 0.5.2",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs 0.6.1",
+ "asn1-rs",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -913,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "devolutions-agent"
-version = "2024.1.2"
+version = "2024.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -926,9 +955,13 @@ dependencies = [
  "embed-resource",
  "futures",
  "hex",
+ "ironrdp",
  "notify-debouncer-mini",
  "parking_lot",
+ "rand",
  "reqwest",
+ "rustls 0.23.7",
+ "rustls-pemfile 2.1.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -937,10 +970,12 @@ dependencies = [
  "tap",
  "thiserror",
  "tokio",
+ "tokio-rustls 0.26.0",
  "tracing",
  "uuid",
  "windows 0.57.0",
  "winreg 0.52.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1136,6 +1171,12 @@ dependencies = [
  "socket2",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecdsa"
@@ -1338,6 +1379,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1621,6 +1668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,23 +1936,133 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "ironrdp"
+version = "0.5.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "ironrdp-acceptor",
+ "ironrdp-server",
+]
+
+[[package]]
+name = "ironrdp-acceptor"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "ironrdp-async",
+ "ironrdp-connector",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-ainput"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bitflags 2.4.2",
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "num-derive",
+ "num-traits",
+]
+
+[[package]]
+name = "ironrdp-async"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bytes",
+ "ironrdp-connector",
+ "ironrdp-pdu",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-cliprdr"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bitflags 2.4.2",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-connector"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "ironrdp-error",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "rand_core",
+ "sspi 0.11.1",
+ "tracing",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "ironrdp-displaycontrol"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "ironrdp-dvc",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-dvc"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "slab",
+ "tracing",
+]
+
+[[package]]
 name = "ironrdp-error"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=4844e77b7f65024d85ba74b1824013eda6eb32b2#4844e77b7f65024d85ba74b1824013eda6eb32b2"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+
+[[package]]
+name = "ironrdp-graphics"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bit_field",
+ "bitflags 2.4.2",
+ "bitvec",
+ "byteorder",
+ "ironrdp-error",
+ "ironrdp-pdu",
+ "lazy_static",
+ "num-derive",
+ "num-traits",
+ "thiserror",
+]
 
 [[package]]
 name = "ironrdp-pdu"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=4844e77b7f65024d85ba74b1824013eda6eb32b2#4844e77b7f65024d85ba74b1824013eda6eb32b2"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "bit_field",
  "bitflags 2.4.2",
  "byteorder",
- "der-parser 8.2.0",
+ "der-parser",
  "ironrdp-error",
  "md-5",
  "num-bigint",
- "num-derive 0.3.3",
+ "num-derive",
  "num-integer",
  "num-traits",
  "pkcs1",
@@ -1909,9 +2075,70 @@ dependencies = [
 [[package]]
 name = "ironrdp-rdcleanpath"
 version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=4844e77b7f65024d85ba74b1824013eda6eb32b2#4844e77b7f65024d85ba74b1824013eda6eb32b2"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "der",
+]
+
+[[package]]
+name = "ironrdp-rdpsnd"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bitflags 2.4.2",
+ "ironrdp-pdu",
+ "ironrdp-svc",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-server"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "ironrdp-acceptor",
+ "ironrdp-ainput",
+ "ironrdp-cliprdr",
+ "ironrdp-displaycontrol",
+ "ironrdp-dvc",
+ "ironrdp-graphics",
+ "ironrdp-pdu",
+ "ironrdp-rdpsnd",
+ "ironrdp-svc",
+ "ironrdp-tokio",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-svc"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bitflags 2.4.2",
+ "ironrdp-pdu",
+]
+
+[[package]]
+name = "ironrdp-tokio"
+version = "0.1.0"
+source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+dependencies = [
+ "bytes",
+ "ironrdp-async",
+ "tokio",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1935,7 +2162,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sspi",
+ "sspi 0.12.0",
  "tempfile",
  "tokio-rustls 0.24.1",
  "ureq",
@@ -2005,6 +2232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,10 +2288,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "libm"
@@ -2213,6 +2465,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "mock-net"
@@ -2550,17 +2808,6 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
@@ -2643,7 +2890,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
 dependencies = [
- "asn1-rs 0.6.1",
+ "asn1-rs",
 ]
 
 [[package]]
@@ -3138,6 +3385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2 1.0.78",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,7 +3433,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3725,6 +3982,8 @@ version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebbbdb961df0ad3f2652da8f3fdc4b36122f568f968f45ad3316f26c025c677b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring 0.17.7",
  "rustls-pki-types",
@@ -3799,6 +4058,7 @@ version = "0.102.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.7",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -4056,6 +4316,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4150,6 +4416,49 @@ dependencies = [
 
 [[package]]
 name = "sspi"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d31fab47d9290be28a8d027c8428756826f1d4fe1e5ba0f51d24f52c568e21"
+dependencies = [
+ "async-dnssd",
+ "async-recursion",
+ "bitflags 2.4.2",
+ "byteorder",
+ "cfg-if",
+ "crypto-mac",
+ "futures",
+ "hmac",
+ "lazy_static",
+ "md-5",
+ "md4",
+ "num-bigint-dig",
+ "num-derive",
+ "num-traits",
+ "oid",
+ "picky",
+ "picky-asn1 0.8.0",
+ "picky-asn1-der 0.4.1",
+ "picky-asn1-x509 0.12.0",
+ "picky-krb 0.8.0",
+ "rand",
+ "serde",
+ "serde_derive",
+ "sha1",
+ "sha2",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "winapi",
+ "windows 0.51.1",
+ "windows-sys 0.48.0",
+ "winreg 0.51.0",
+ "zeroize",
+]
+
+[[package]]
+name = "sspi"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579d8ebd38b21e9fc957788e6230dee92d7ff0bb236aec0fceaf8b203bd0b6e3"
@@ -4166,7 +4475,7 @@ dependencies = [
  "md-5",
  "md4",
  "num-bigint-dig",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "oid",
  "picky",
@@ -4205,7 +4514,7 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -4241,18 +4550,6 @@ name = "sync_wrapper"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384595c11a4e2969895cad5a8c4029115f5ab956a9e5ef4de79d11a426e5f20c"
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2 1.0.78",
- "quote 1.0.35",
- "syn 1.0.109",
- "unicode-xid 0.2.4",
-]
 
 [[package]]
 name = "synstructure"
@@ -4849,12 +5146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,6 +5411,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -5568,9 +5871,9 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs 0.6.1",
+ "asn1-rs",
  "data-encoding",
- "der-parser 9.0.0",
+ "der-parser",
  "lazy_static",
  "nom",
  "oid-registry",

--- a/crates/devolutions-agent-shared/src/date_version.rs
+++ b/crates/devolutions-agent-shared/src/date_version.rs
@@ -1,4 +1,5 @@
-use std::{fmt, str::FromStr};
+use std::fmt;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-agent"
-version = "2024.1.2"
+version = "2024.2.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Devolutions Inc. <infos@devolutions.net>"]
@@ -32,6 +32,20 @@ tap = "1.0"
 thiserror = "1"
 tracing = "0.1"
 uuid = { version = "1.5", features = ["v4"] }
+rand = "0.8" # FIXME(@CBenoit): maybe we don’t need this crate
+zeroize = { version = "1.7", features = ["derive"] }
+tokio-rustls = "0.26"
+rustls = "0.23"
+rustls-pemfile = "2.1" # FIXME(@CBenoit): maybe we don’t need this crate
+
+[dependencies.ironrdp]
+git = "https://github.com/Devolutions/IronRDP"
+rev = "2e1a9ac88e38e7d92d893007bc25d0a05c365861"
+default-features = false
+features = [
+    "server",
+    "acceptor",
+]
 
 [dependencies.tokio]
 version = "1.37"
@@ -44,7 +58,7 @@ features = [
     "macros",
     "parking_lot",
     "fs",
-    "process"
+    "process",
 ]
 
 [target.'cfg(windows)'.dependencies]
@@ -59,7 +73,7 @@ features = [
     "Win32_System_Threading",
     "Win32_Security_Cryptography",
     "Win32_Security_Authorization",
-    "Win32_System_ApplicationInstallationAndServicing"
+    "Win32_System_ApplicationInstallationAndServicing",
 ]
 
 [target.'cfg(windows)'.build-dependencies]

--- a/devolutions-agent/src/lib.rs
+++ b/devolutions-agent/src/lib.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate tracing;
+
+pub mod config;
+mod log;
+mod remote_desktop;
+pub mod service;
+
+#[cfg(windows)]
+mod updater;

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -1,21 +1,14 @@
 #[macro_use]
 extern crate tracing;
 
-mod config;
-mod log;
-mod service;
-
-#[cfg(windows)]
-mod updater;
-
 use std::env;
 use std::sync::mpsc;
 
 use ceviche::controller::*;
 use ceviche::{Service, ServiceEvent};
 
-use config::ConfHandle;
-use service::AgentService;
+use devolutions_agent::config::ConfHandle;
+use devolutions_agent::service::{AgentService, DESCRIPTION, DISPLAY_NAME, SERVICE_NAME};
 
 const BAD_CONFIG_ERR_CODE: u32 = 1;
 const START_FAILED_ERR_CODE: u32 = 2;
@@ -43,7 +36,7 @@ fn agent_service_main(
     };
 
     match service.start() {
-        Ok(()) => info!("{} service started", service::SERVICE_NAME),
+        Ok(()) => info!("{} service started", SERVICE_NAME),
         Err(error) => {
             error!(error = format!("{error:#}"), "Failed to start");
             return START_FAILED_ERR_CODE;
@@ -61,7 +54,7 @@ fn agent_service_main(
         }
     }
 
-    info!("{} service stopping", service::SERVICE_NAME);
+    info!("{} service stopping", SERVICE_NAME);
 
     0
 }
@@ -69,7 +62,7 @@ fn agent_service_main(
 Service!("agent", agent_service_main);
 
 fn main() {
-    let mut controller = Controller::new(service::SERVICE_NAME, service::DISPLAY_NAME, service::DESCRIPTION);
+    let mut controller = Controller::new(SERVICE_NAME, DISPLAY_NAME, DESCRIPTION);
 
     if let Some(cmd) = env::args().nth(1) {
         match cmd.as_str() {
@@ -106,7 +99,7 @@ fn main() {
             }
             "config" => {
                 let subcommand = env::args().nth(2).expect("missing config subcommand");
-                if let Err(e) = config::handle_cli(subcommand.as_str()) {
+                if let Err(e) = devolutions_agent::config::handle_cli(subcommand.as_str()) {
                     eprintln!("[ERROR] Agent configuration failed: {}", e);
                 }
             }

--- a/devolutions-agent/src/remote_desktop/graphics.rs
+++ b/devolutions-agent/src/remote_desktop/graphics.rs
@@ -1,0 +1,68 @@
+use std::num::NonZeroU16;
+use std::time::Duration;
+
+use ironrdp::server::{
+    BitmapUpdate, DesktopSize, DisplayUpdate, PixelFormat, PixelOrder, RdpServerDisplay, RdpServerDisplayUpdates,
+};
+
+const WIDTH: u16 = 1024;
+const HEIGHT: u16 = 1024;
+
+pub struct DisplayHandler;
+
+impl DisplayHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait::async_trait]
+impl RdpServerDisplay for DisplayHandler {
+    async fn size(&mut self) -> DesktopSize {
+        DesktopSize {
+            width: WIDTH,
+            height: HEIGHT,
+        }
+    }
+
+    async fn updates(&mut self) -> anyhow::Result<Box<dyn RdpServerDisplayUpdates>> {
+        Ok(Box::new(DisplayUpdates))
+    }
+}
+
+struct DisplayUpdates;
+
+#[async_trait::async_trait]
+impl RdpServerDisplayUpdates for DisplayUpdates {
+    async fn next_update(&mut self) -> Option<DisplayUpdate> {
+        use rand::Rng as _;
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut rng = rand::rngs::OsRng;
+
+        let top: u16 = rng.gen_range(0..HEIGHT);
+        let height = NonZeroU16::new(rng.gen_range(1..=HEIGHT - top)).unwrap();
+        let left: u16 = rng.gen_range(0..WIDTH);
+        let width = NonZeroU16::new(rng.gen_range(1..=WIDTH - left)).unwrap();
+
+        let data: Vec<u8> = std::iter::repeat([rng.gen(), rng.gen(), rng.gen(), 255])
+            .take(usize::from(width.get()) * usize::from(height.get()))
+            .flatten()
+            .collect();
+
+        trace!(left, top, width, height, "BitmapUpdate");
+
+        let bitmap = BitmapUpdate {
+            top,
+            left,
+            width,
+            height,
+            format: PixelFormat::BgrA32,
+            order: PixelOrder::TopToBottom,
+            data,
+        };
+
+        Some(DisplayUpdate::Bitmap(bitmap))
+    }
+}

--- a/devolutions-agent/src/remote_desktop/input.rs
+++ b/devolutions-agent/src/remote_desktop/input.rs
@@ -1,0 +1,20 @@
+use ironrdp::server::{KeyboardEvent, MouseEvent, RdpServerInputHandler};
+
+#[derive(Clone, Debug)]
+pub struct InputHandler;
+
+impl InputHandler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl RdpServerInputHandler for InputHandler {
+    fn keyboard(&mut self, event: KeyboardEvent) {
+        trace!(?event, "keyboard");
+    }
+
+    fn mouse(&mut self, event: MouseEvent) {
+        trace!(?event, "mouse");
+    }
+}

--- a/devolutions-agent/src/remote_desktop/mod.rs
+++ b/devolutions-agent/src/remote_desktop/mod.rs
@@ -1,0 +1,100 @@
+mod graphics;
+mod input;
+mod tls;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use devolutions_gateway_task::{ShutdownSignal, Task};
+use ironrdp::server::RdpServer;
+use tokio::sync::oneshot;
+
+use crate::config::ConfHandle;
+
+pub struct RemoteDesktopTask {
+    conf_handle: ConfHandle,
+}
+
+impl RemoteDesktopTask {
+    pub fn new(conf_handle: ConfHandle) -> Self {
+        Self { conf_handle }
+    }
+}
+
+#[async_trait]
+impl Task for RemoteDesktopTask {
+    type Output = anyhow::Result<()>;
+
+    const NAME: &'static str = "remote desktop";
+
+    async fn run(self, shutdown_signal: ShutdownSignal) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+
+        std::thread::spawn(move || {
+            // FIXME(@CBenoit): make RdpServer implement `Send`
+
+            let res = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("couldn’t build tokio runtime")
+                .and_then(|rt| rt.block_on(recording_server_task(self.conf_handle, shutdown_signal)));
+
+            let _ = tx.send(res);
+        });
+
+        rx.await
+            .context("couldn’t retrieve result from remote desktop server task")?
+    }
+}
+
+#[instrument(skip_all)]
+async fn recording_server_task(conf_handle: ConfHandle, mut shutdown_signal: ShutdownSignal) -> anyhow::Result<()> {
+    let conf = conf_handle.get_conf();
+
+    let input_handler = input::InputHandler::new();
+    let display_handler = graphics::DisplayHandler::new();
+
+    let tls_acceptor = conf
+        .remote_desktop
+        .certificate
+        .as_ref()
+        .zip(conf.remote_desktop.private_key.as_ref())
+        .map(|(cert, key)| tls::acceptor(cert, key))
+        .transpose()
+        .context("failed to create TLS acceptor")?;
+
+    let bind_address = conf
+        .remote_desktop
+        .bind_addresses
+        .first() // FIXME(@CBenoit): proper support for multiple bind addresses
+        .context("no bind address configured")?;
+
+    let server = RdpServer::builder().with_addr(bind_address.clone());
+
+    let server = if let Some(tls_acceptor) = tls_acceptor {
+        server.with_tls(tls_acceptor)
+    } else {
+        server.with_no_security()
+    };
+
+    let mut server = server
+        .with_input_handler(input_handler)
+        .with_display_handler(display_handler)
+        .build();
+
+    info!(%bind_address, "Remote Desktop Server ready");
+
+    tokio::select! {
+        res = server.run() => {
+            res.context("remote server failure")?;
+        },
+        _ = shutdown_signal.wait() => {
+            // FIXME(@CBenoit): add graceful shutdown of the RDP server and look into TLS close_notify
+            // See: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
+            trace!("Received shutdown signal");
+        },
+    }
+
+    debug!("Task terminated");
+
+    Ok(())
+}

--- a/devolutions-agent/src/remote_desktop/tls.rs
+++ b/devolutions-agent/src/remote_desktop/tls.rs
@@ -1,0 +1,31 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::Arc;
+
+use anyhow::Context as _;
+use camino::Utf8Path;
+use rustls::ServerConfig;
+use tokio_rustls::TlsAcceptor;
+
+pub fn acceptor(cert_path: &Utf8Path, key_path: &Utf8Path) -> anyhow::Result<TlsAcceptor> {
+    let cert_file = File::open(cert_path).with_context(|| format!("failed to open {cert_path}"))?;
+    let cert = rustls_pemfile::certs(&mut BufReader::new(cert_file))
+        .next()
+        .context("no certificate")??;
+
+    let key_file = File::open(key_path).with_context(|| format!("failed to open {key_path}"))?;
+    let key = rustls_pemfile::pkcs8_private_keys(&mut BufReader::new(key_file))
+        .next()
+        .context("no private key")?
+        .map(rustls::pki_types::PrivateKeyDer::from)?;
+
+    let mut server_config = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert], key)
+        .context("bad certificate/key")?;
+
+    // This adds support for the SSLKEYLOGFILE env variable (https://wiki.wireshark.org/TLS#using-the-pre-master-secret)
+    server_config.key_log = Arc::new(rustls::KeyLogFile::new());
+
+    Ok(TlsAcceptor::from(Arc::new(server_config)))
+}

--- a/devolutions-agent/src/service.rs
+++ b/devolutions-agent/src/service.rs
@@ -1,8 +1,10 @@
 use tokio::runtime::{self, Runtime};
 
+use crate::config::ConfHandle;
+use crate::log::AgentLog;
+use crate::remote_desktop::RemoteDesktopTask;
 #[cfg(windows)]
 use crate::updater::UpdaterTask;
-use crate::{config::ConfHandle, log::AgentLog};
 use anyhow::Context;
 use devolutions_gateway_task::{ChildTask, ShutdownHandle, ShutdownSignal};
 use devolutions_log::{self, LogDeleterTask, LoggerGuard};
@@ -177,6 +179,10 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<Tasks> {
     let mut tasks = Tasks::new();
 
     tasks.register(LogDeleterTask::<AgentLog>::new(conf.log_file.clone()));
+
+    if conf.remote_desktop.enabled {
+        tasks.register(RemoteDesktopTask::new(conf_handle.clone()));
+    }
 
     #[cfg(windows)]
     if conf.updater.enabled {

--- a/devolutions-agent/src/updater/io.rs
+++ b/devolutions-agent/src/updater/io.rs
@@ -1,9 +1,9 @@
 //! IO utilities for the updater logic
 
-use camino::Utf8Path;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use futures::TryFutureExt;
-use tokio::{fs::File, io::AsyncWriteExt};
+use tokio::fs::File;
+use tokio::io::AsyncWriteExt;
 
 use crate::updater::UpdaterError;
 

--- a/devolutions-agent/src/updater/mod.rs
+++ b/devolutions-agent/src/updater/mod.rs
@@ -17,8 +17,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use notify_debouncer_mini::notify::RecursiveMode;
 use tokio::fs;
 
-use devolutions_agent_shared::{get_updater_file_path, DateVersion};
-use devolutions_agent_shared::{UpdateJson, VersionSpecification};
+use devolutions_agent_shared::{get_updater_file_path, DateVersion, UpdateJson, VersionSpecification};
 use devolutions_gateway_task::{ShutdownSignal, Task};
 
 use crate::config::ConfHandle;

--- a/devolutions-agent/src/updater/productinfo/db.rs
+++ b/devolutions-agent/src/updater/productinfo/db.rs
@@ -1,6 +1,7 @@
 //! Devolutions product information (https://devolutions.net/productinfo.htm) parser
 
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
+use std::str::FromStr;
 
 use crate::updater::UpdaterError;
 

--- a/devolutions-agent/src/updater/security.rs
+++ b/devolutions-agent/src/updater/security.rs
@@ -21,8 +21,7 @@ pub fn set_file_dacl(file_path: &Utf8Path, acl: &str) -> Result<(), UpdaterError
     use windows::Win32::Security::Authorization::{
         ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW, SDDL_REVISION_1, SE_FILE_OBJECT,
     };
-    use windows::Win32::Security::PSECURITY_DESCRIPTOR;
-    use windows::Win32::Security::{GetSecurityDescriptorDacl, ACL, DACL_SECURITY_INFORMATION};
+    use windows::Win32::Security::{GetSecurityDescriptorDacl, ACL, DACL_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR};
 
     struct OwnedPSecurityDescriptor(PSECURITY_DESCRIPTOR);
 

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -21,8 +21,8 @@ jmux-proxy = { path = "../crates/jmux-proxy" }
 devolutions-agent-shared = { path = "../crates/devolutions-agent-shared" }
 devolutions-gateway-task = { path = "../crates/devolutions-gateway-task" }
 devolutions-log = { path = "../crates/devolutions-log" }
-ironrdp-pdu = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "4844e77b7f65024d85ba74b1824013eda6eb32b2" }
-ironrdp-rdcleanpath = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "4844e77b7f65024d85ba74b1824013eda6eb32b2" }
+ironrdp-pdu = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "2e1a9ac88e38e7d92d893007bc25d0a05c365861", features = ["std"] }
+ironrdp-rdcleanpath = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "2e1a9ac88e38e7d92d893007bc25d0a05c365861" }
 ceviche = "0.6"
 picky-krb = "0.9"
 network-scanner = { version = "0.0.0", path = "../crates/network-scanner" }

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -965,7 +965,7 @@ pub mod dto {
         pub sogar: Option<SogarConf>,
 
         /// (Unstable) Unsafe debug options for developers
-        #[serde(default, rename = "__debug__", skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "__debug__", skip_serializing_if = "Option::is_none")]
         pub debug: Option<DebugConf>,
 
         // Other unofficial options.


### PR DESCRIPTION
# Demo

https://github.com/user-attachments/assets/55ee3fc5-32f0-42dd-9396-f6345f60a491

# Config examples

## Just enabling the module

```json
{
  "RemoteDesktop": {
    "Enabled": true
  }
}
```

## Enabling TLS

```json
{
  "RemoteDesktop": {
    "Enabled": true,
    "Certificate": "rdpserver.crt",
    "PrivateKey": "rdpserver.key"
  }
}
```

## Changing the default port

```json
{
  "RemoteDesktop": {
    "Enabled": true,
    "Port": 9999
  }
}
```

# Limitations / future work

- The server only sends garbage rectangles, no real interaction is happening yet.
- There is currently no user authentification. Any username / password is accepted.
- `RdpServer` should implement `Send`.
- `RdpServer` should support multiple listener (bind) addresses.
- `RdpServer` should support graceful shutdown.