### PR TITLE
ci: prepare for aws-lc-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
 
         - name: Tests
           shell: pwsh
-          run: ./ci/tlk.ps1 test -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+          env:
+            AWS_LC_SYS_NO_ASM: true
+          run: ./ci/tlk.ps1 test -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile 'dev'
 
   jetsocat:
     name: jetsocat [${{ matrix.os }} ${{ matrix.arch }}]
@@ -169,6 +171,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -o Acquire::Retries=3 install python3-wget python3-setuptools
+
+          # We need a newer version of GCC because aws-lc-rs rejects versions affected
+          # by this bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
+          # These lines can be safely removed once we switch to ubuntu-22.04 runner.
+          sudo apt install gcc-10
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 60
 
       - name: Configure Linux (arm) runner
         if: matrix.os == 'linux' && matrix.arch == 'arm64'
@@ -503,14 +511,21 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
           echo "STRIP_EXECUTABLE=aarch64-linux-gnu-strip" >> $GITHUB_ENV
 
-      # WiX is installed on Windows runners but not in the PATH
       - name: Configure Windows runner
         if: matrix.os == 'windows'
         run: |
           # https://github.com/actions/runner-images/issues/9667
           choco uninstall wixtoolset
           choco install wixtoolset --version 3.14.0 --allow-downgrade --force
-          echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          # WiX is installed on Windows runners but not in the PATH
+          Write-Output "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+          # NASM is required by aws-lc-rs (used as rustls crypto backend)
+          choco install nasm
+
+          # We need to add the NASM binary folder to the PATH manually.
+          Write-Output "$Env:ProgramFiles\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Build
         shell: pwsh
@@ -623,7 +638,7 @@ jobs:
 
   upload-git-log:
     name: Upload git-log output
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/master' }}
     needs:
       - success

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -912,7 +912,7 @@ function Invoke-TlkStep {
 		[string] $Platform,
 		[ValidateSet('x86','x86_64','arm64')]
 		[string] $Architecture,
-        [ValidateSet('release', 'production')]
+        [ValidateSet('dev', 'release', 'production')]
         [string] $CargoProfile,
         [ValidateSet('gateway', 'agent', 'jetsocat')]
         [string] $Product


### PR DESCRIPTION
This patch is preparing the CI for newer rustls which is using aws-lc-rs as the default crypto backend.

- Install a newer version of gcc for Linux. aws-lc-rs is rejecting some versions of gcc, including the one packaged by default with Ubuntu 20.04. It’s important because of this bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95189
- Install NASM when building with release / production profiles.
- Run tests using the dev profile. The tlk.ps1 script only allowed release and production profiles, but there is no reason to run the tests using these profiles.