### PR TITLE
build(deps): bump mdns-sd from 0.10.5 to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.10.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8031297470465389c1349c399b927505d0cc4503be7a997c3541765bca82b4d"
+checksum = "807457e493076539ff8f202806f9dc2eaa9f13f69701da7ed38eec7a9afd1616"
 dependencies = [
  "flume",
  "if-addrs",

--- a/crates/network-scanner/Cargo.toml
+++ b/crates/network-scanner/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 crossbeam = { version = "0.8", features = ["crossbeam-channel"] }
 dns-lookup = "2.0"
-mdns-sd = "0.11.0"
+mdns-sd = "0.11"
 network-interface = "1.1"
 network-scanner-net = { path = "../network-scanner-net" }
 network-scanner-proto = { path = "../network-scanner-proto" }

--- a/crates/network-scanner/Cargo.toml
+++ b/crates/network-scanner/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 crossbeam = { version = "0.8", features = ["crossbeam-channel"] }
 dns-lookup = "2.0"
-mdns-sd = "0.10"
+mdns-sd = "0.11.0"
 network-interface = "1.1"
 network-scanner-net = { path = "../network-scanner-net" }
 network-scanner-proto = { path = "../network-scanner-proto" }


### PR DESCRIPTION
looks like we are not affected by it's API change, we didn't use this funciton specified in its changelog