### PR TITLE
fix(agent): make UpdaterConf::enabled required when deserializing

### DIFF
--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -185,21 +185,16 @@ pub fn load_conf_file_or_generate_new() -> anyhow::Result<dto::ConfFile> {
 pub mod dto {
     use super::*;
 
-    const fn default_bool<const V: bool>() -> bool {
-        V
-    }
-
     #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "PascalCase")]
     pub struct UpdaterConf {
-        /// Enable updater module (enabled by default)
-        #[serde(default = "default_bool::<true>")]
+        /// Enable updater module
         pub enabled: bool,
     }
 
     impl Default for UpdaterConf {
         fn default() -> Self {
-            Self { enabled: true }
+            Self { enabled: false }
         }
     }
 
@@ -324,8 +319,9 @@ pub mod dto {
         /// Directives string in the same form as the RUST_LOG environment variable
         #[serde(skip_serializing_if = "Option::is_none")]
         pub log_directives: Option<String>,
-        /// Skip MSI installation in updater module. Useful for debugging updater logic
-        /// without actually changing the system.
+        /// Skip MSI installation in updater module
+        ///
+        /// Useful for debugging updater logic without actually changing the system.
         #[serde(default)]
         pub skip_msi_install: bool,
     }


### PR DESCRIPTION
Instead of special-casing the "Enabled" property of the updater module config, we require it when deserializing from JSON, and if the config of the updater is completely removed, we assume that it’s not enabled.

We keep the updater enabled in the default config file.

Future modules will be enabled by default when generating a fresh config file as well, but we won’t enable them by default implicitly when installing a newer version of the executable. It’s easier to predict how the agent will behave for both us and the user.

The default config file is:
```json
{
  "Updater": {
    "Enabled": true
  }
}
```
This PR is not changing that.