### PR TITLE
feat(dgw): dynamically load XMF native lib on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
+name = "cadeau"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba4af571bf872af2caaed2d274439dd542db94b75cfeaa85863f674105cf1a0"
+dependencies = [
+ "xmf-sys",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1014,7 @@ dependencies = [
  "axum-extra",
  "backoff",
  "bytes",
+ "cadeau",
  "camino",
  "ceviche",
  "cfg-if",
@@ -1144,6 +1154,15 @@ name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading",
+]
 
 [[package]]
 name = "dlopen"
@@ -5936,6 +5955,15 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "xmf-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17dade9447321f393019b9ced5f73c15b868d2613f736c34f648354d7641ce4"
+dependencies = [
+ "dlib",
 ]
 
 [[package]]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -83,9 +83,12 @@ utoipa = { version = "4.2", default-features = false, features = ["uuid", "time"
 # Safe pin projection
 pin-project-lite = "0.2"
 
-# Native plugins
+# Native plugins (QUESTION: now that we have Cadeau integrated, should we remove this feature?)
 dlopen = "0.1"
 dlopen_derive = "0.1"
+
+# Video processing for session recording
+cadeau = { version = "0.3", features = ["dlopen"] }
 
 # Dependencies required for PCAP support (QUESTION: should we keep that built-in?)
 pcap-file = "2.0"

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -1080,6 +1080,9 @@ pub mod dto {
         /// Providing this option will cause the PCAP interceptor to be attached to each stream.
         pub capture_path: Option<Utf8PathBuf>,
 
+        /// Path to the XMF shared library (Cadeau) for runtime loading.
+        pub lib_xmf_path: Option<Utf8PathBuf>,
+
         /// Enable unstable API which may break at any point
         #[serde(default)]
         pub enable_unstable: bool,
@@ -1095,6 +1098,7 @@ pub mod dto {
                 override_kdc: None,
                 log_directives: None,
                 capture_path: None,
+                lib_xmf_path: None,
                 enable_unstable: false,
             }
         }


### PR DESCRIPTION
By default, we look for the library at `/usr/lib/libxmf.so` on Linux, and `xmf.dll` alongside the executable on Windows.

Developers may specify a different path to xmf.dll / libxmf.so using `lib_xmf_path` debug option:

```rust
{
  "__debug__": {
    "lib_xmf_path": "/usr/local/lib/libxmf.so"
  }
}
```