### PR TITLE
fix(agent): add "EnableUnstable" debug option

### DIFF
--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -321,11 +321,16 @@ pub mod dto {
         /// Directives string in the same form as the RUST_LOG environment variable
         #[serde(skip_serializing_if = "Option::is_none")]
         pub log_directives: Option<String>,
+
         /// Skip MSI installation in updater module
         ///
         /// Useful for debugging updater logic without actually changing the system.
         #[serde(default)]
         pub skip_msi_install: bool,
+
+        /// Enable unstable features which may break at any point
+        #[serde(default)]
+        pub enable_unstable: bool,
     }
 
     /// Manual Default trait implementation just to make sure default values are deliberates
@@ -335,6 +340,7 @@ pub mod dto {
             Self {
                 log_directives: None,
                 skip_msi_install: false,
+                enable_unstable: false,
             }
         }
     }

--- a/devolutions-agent/src/service.rs
+++ b/devolutions-agent/src/service.rs
@@ -185,7 +185,7 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<Tasks> {
         tasks.register(UpdaterTask::new(conf_handle.clone()));
     }
 
-    if conf.remote_desktop.enabled {
+    if conf.debug.enable_unstable && conf.remote_desktop.enabled {
         tasks.register(RemoteDesktopTask::new(conf_handle));
     }
 

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -1089,7 +1089,7 @@ pub mod dto {
         /// Path to the XMF shared library (Cadeau) for runtime loading.
         pub lib_xmf_path: Option<Utf8PathBuf>,
 
-        /// Enable unstable API which may break at any point
+        /// Enable unstable features which may break at any point
         #[serde(default)]
         pub enable_unstable: bool,
     }


### PR DESCRIPTION
This option will be used to enable unstable features which may break at any point. The first feature to be put behind this option is the remote desktop module.