### PR TITLE
ci: fix release workflow for containers

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -115,6 +115,18 @@ jobs:
           $Version = Get-Content VERSION -TotalCount 1
           echo "version=$Version" >> $Env:GITHUB_OUTPUT
 
+      - name: Download Cadeau
+        shell: pwsh
+        run: |
+          ./ci/download-cadeau.ps1 -Platform 'win' -Architecture 'x64'
+          ./ci/download-cadeau.ps1 -Platform 'linux' -Architecture 'x64'
+
+      - name: Upload native libs
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-libs
+          path: native-libs/
+
   codesign:
     name: Codesign
     runs-on: ${{ matrix.runner }}
@@ -244,10 +256,12 @@ jobs:
         if: matrix.os == 'windows' && (matrix.project == 'devolutions-gateway' || matrix.project == 'devolutions-agent')
         uses: microsoft/setup-msbuild@v2
 
-      - name: Download Cadeau
+      - name: Download native libs
         if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'
         shell: pwsh
-        run: ./ci/download-cadeau.ps1 -Platform 'win' -Architecture 'x64'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run download ${{ needs.preflight.outputs.run }} -n native-libs --repo $Env:GITHUB_REPOSITORY
 
       - name: Regenerate Gateway MSI
         if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -261,7 +261,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ needs.preflight.outputs.run }} -n native-libs --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n native-libs -D "./native-libs/"
 
       - name: Regenerate Gateway MSI
         if: matrix.project == 'devolutions-gateway' && matrix.os == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -n docker -n devolutions-gateway --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -n docker -n devolutions-gateway -n native-libs --repo $Env:GITHUB_REPOSITORY
 
       ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
@@ -167,12 +167,6 @@ jobs:
 
           $PowerShellArchive = Get-ChildItem -Recurse -Filter "Devolutionsgateway-ps-*.zip" | Select-Object -First 1
           Expand-Archive $PowerShellArchive -DestinationPath "$PkgDir"
-
-      - name: Download Cadeau
-        shell: pwsh
-        run: |
-          $Platform = @{'windows'='win'; 'linux'='linux'}['${{ matrix.os }}']
-          ./ci/download-cadeau.ps1 -Platform $Platform -Architecture 'x64'
 
       - name: Build container
         id: build-container


### PR DESCRIPTION
We are not checking out the repository in the release workflow.
Because of that, the `download-cadeau.ps1` file is not found.
The cleanest fix appears to follow how thing are already done
and to upload a new artifact containing the native libraries.