### PR TITLE
perf(jetsocat,dgw): remove to_vec calls from JMUX implementation

### DIFF
--- a/crates/jmux-generators/src/lib.rs
+++ b/crates/jmux-generators/src/lib.rs
@@ -46,7 +46,8 @@ pub fn message_window_adjust() -> impl Strategy<Value = Message> {
 }
 
 pub fn message_data() -> impl Strategy<Value = Message> {
-    (distant_channel_id(), vec(any::<u8>(), 0..512)).prop_map(|(distant_id, data)| Message::data(distant_id, data))
+    (distant_channel_id(), vec(any::<u8>(), 0..512))
+        .prop_map(|(distant_id, data)| Message::data(distant_id, Bytes::from(data)))
 }
 
 pub fn message_eof() -> impl Strategy<Value = Message> {

--- a/crates/jmux-proto/src/lib.rs
+++ b/crates/jmux-proto/src/lib.rs
@@ -235,7 +235,7 @@ impl Message {
         Self::WindowAdjust(ChannelWindowAdjust::new(distant_id, window_adjustment))
     }
 
-    pub fn data(id: DistantChannelId, data: Vec<u8>) -> Self {
+    pub fn data(id: DistantChannelId, data: Bytes) -> Self {
         Self::Data(ChannelData::new(id, data))
     }
 
@@ -654,7 +654,7 @@ impl ChannelWindowAdjust {
 #[derive(PartialEq, Eq)]
 pub struct ChannelData {
     pub recipient_channel_id: u32,
-    pub transfer_data: Vec<u8>,
+    pub transfer_data: Bytes,
 }
 
 // We don't want to print `transfer_data` content (usually too big)
@@ -671,7 +671,7 @@ impl ChannelData {
     pub const NAME: &'static str = "CHANNEL DATA";
     pub const FIXED_PART_SIZE: usize = 4 /*recipientChannelId*/;
 
-    pub fn new(id: DistantChannelId, data: Vec<u8>) -> Self {
+    pub fn new(id: DistantChannelId, data: Bytes) -> Self {
         ChannelData {
             recipient_channel_id: u32::from(id),
             transfer_data: data,
@@ -684,14 +684,14 @@ impl ChannelData {
 
     pub fn encode(&self, buf: &mut BytesMut) {
         buf.put_u32(self.recipient_channel_id);
-        buf.put(self.transfer_data.as_slice());
+        buf.put(self.transfer_data.slice(..));
     }
 
     pub fn decode(mut buf: Bytes) -> Result<Self, Error> {
         ensure_size!(fixed Self in buf);
         Ok(Self {
             recipient_channel_id: buf.get_u32(),
-            transfer_data: buf.to_vec(),
+            transfer_data: buf,
         })
     }
 }

--- a/crates/jmux-proto/src/lib.rs
+++ b/crates/jmux-proto/src/lib.rs
@@ -1,8 +1,11 @@
 //! [Specification document](https://github.com/Devolutions/devolutions-gateway/blob/master/crates/jmux-proto/spec/JMUX_Spec.md)
 
-use bytes::{Buf as _, BufMut as _, Bytes, BytesMut};
+use bytes::{Buf as _, BufMut as _};
 use core::fmt;
 use smol_str::SmolStr;
+
+// We re-export these types, because they are used in the public API.
+pub use bytes::{Bytes, BytesMut};
 
 /// Distant identifier for a channel
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]

--- a/crates/jmux-proto/tests/message.rs
+++ b/crates/jmux-proto/tests/message.rs
@@ -152,7 +152,7 @@ pub fn channel_window_adjust() {
 #[test]
 pub fn error_on_oversized_packet() {
     let mut buf = BytesMut::new();
-    let err = Message::data(DistantChannelId::from(1), vec![0; u16::MAX as usize])
+    let err = Message::data(DistantChannelId::from(1), vec![0; u16::MAX as usize].into())
         .encode(&mut buf)
         .err()
         .unwrap();
@@ -171,7 +171,7 @@ pub fn channel_data() {
 
     let msg_example = ChannelData {
         recipient_channel_id: 1,
-        transfer_data: vec![11, 12, 13, 14],
+        transfer_data: vec![11, 12, 13, 14].into(),
     };
 
     check_encode_decode(Message::Data(msg_example), raw_msg);


### PR DESCRIPTION
By removing a few `to_vec()` calls and reusing the `Bytes` buffer as-is, perfomance of JMUX proxy is increased by ~62.3%.

Performance was measured using `iperf` on local network.

JMUX proxy performance before this patch:

> 0.0000-10.0493 sec  8.21 GBytes  7.02 Gbits/sec

JMUX proxy performance after this patch:

> 0.0000-19.0245 sec  25.2 GBytes  11.4 Gbits/sec

This is still 78.6% slower than jetsocat regular TCP port forwarding.