### PR TITLE
perf(jetsocat,dgw): reuse buffer in JMUX sender task

### DIFF
--- a/crates/jmux-proto/src/lib.rs
+++ b/crates/jmux-proto/src/lib.rs
@@ -160,7 +160,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::PacketOversized { packet_size, max } => {
-                write!(f, "Packet oversized: max is {max}, got {packet_size}")
+                write!(f, "packet oversized: max is {max}, got {packet_size}")
             }
             Error::NotEnoughBytes {
                 name,
@@ -168,13 +168,13 @@ impl fmt::Display for Error {
                 expected,
             } => write!(
                 f,
-                "Not enough bytes provided to decode {name}: received {received} bytes, expected {expected} bytes"
+                "not enough bytes provided to decode {name}: received {received} bytes, expected {expected} bytes"
             ),
             Error::InvalidPacket { name, field, reason } => {
-                write!(f, "Invalid `{field}` in {name}: {reason}")
+                write!(f, "invalid `{field}` in {name}: {reason}")
             }
             Error::InvalidDestinationUrl { value, reason } => {
-                write!(f, "Invalid destination URL `{value}`: {reason}")
+                write!(f, "invalid destination URL `{value}`: {reason}")
             }
         }
     }

--- a/crates/jmux-proto/tests/message.rs
+++ b/crates/jmux-proto/tests/message.rs
@@ -35,7 +35,7 @@ fn message_type_try_err_on_invalid_bytes() {
 fn header_decode_buffer_too_short_err() {
     let err = Header::decode(Bytes::from_static(&[])).err().unwrap();
     assert_eq!(
-        "Not enough bytes provided to decode HEADER: received 0 bytes, expected 4 bytes",
+        "not enough bytes provided to decode HEADER: received 0 bytes, expected 4 bytes",
         err.to_string()
     );
 }
@@ -156,7 +156,7 @@ pub fn error_on_oversized_packet() {
         .encode(&mut buf)
         .err()
         .unwrap();
-    assert_eq!("Packet oversized: max is 65535, got 65543", err.to_string());
+    assert_eq!("packet oversized: max is 65535, got 65543", err.to_string());
 }
 
 #[test]


### PR DESCRIPTION
We’re spending a lot of time dealing with `Bytes` and `BytesMut` in the JMUX sender task.

![image](https://github.com/user-attachments/assets/5ed7b423-8898-44f2-bc5c-afd79344fdf0)

This patch is getting rid of the leftmost drop. We can actually reuse the `BytesMut` buffer between writes and greatly reduces allocation / de-allocation.

Performance is increased by ~26.3%.

Before this patch:

> 0.0000-19.0245 sec 25.2 GBytes 11.4 Gbits/sec

After this patch:

> 0.0000-17.1307 sec  28.8 GBytes  14.4 Gbits/sec