### PR TITLE
fix(dgw): set dwShareMode for recording files on Windows

### DIFF
--- a/devolutions-gateway/src/recording.rs
+++ b/devolutions-gateway/src/recording.rs
@@ -94,14 +94,20 @@ where
 
         debug!(path = %recording_file, "Opening file");
 
-        let res = match fs::OpenOptions::new()
-            .read(false)
-            .write(true)
-            .truncate(true)
-            .create(true)
-            .open(&recording_file)
-            .await
+        let mut open_options = fs::OpenOptions::new();
+
+        open_options.read(false).write(true).truncate(true).create(true);
+
+        #[cfg(windows)]
         {
+            use std::os::windows::fs::OpenOptionsExt as _;
+
+            const FILE_SHARE_READ: u32 = 1;
+
+            open_options.share_mode(FILE_SHARE_READ);
+        }
+
+        let res = match open_options.open(&recording_file).await {
             Ok(file) => {
                 let mut file = BufWriter::new(file);
 


### PR DESCRIPTION
On Windows, the default default share_mode set when opening a new file is `FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE`.

We now overrides the share_mode and set it to `FILE_SHARE_READ`.

This makes the recording process more robust by ensuring no other process can write or delete the files while the Devolutions Gateway is actively writing it.