### PR TITLE
build(webapp): angular 18 changed build output path, update config to remove it

### DIFF
--- a/webapp/angular.json
+++ b/webapp/angular.json
@@ -14,7 +14,8 @@
           "options": {
             "baseHref": "/jet/webapp/client/",
             "outputPath": {
-              "base": "client"
+              "base": "client",
+              "browser": ""
             },
             "preserveSymlinks": true,
             "index": "src/client/index.html",


### PR DESCRIPTION
Angular 18 build output now have `browser` and `server` sub path under build output directory. We don't want it, updated settings to remove this difference

reference: https://github.com/angular/angular-cli/issues/26304