### PR TITLE
ci: Windows ARM builds for Devolutions Agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,18 @@ jobs:
           $GatewayMatrix = ConvertTo-JSON $Jobs -Compress
           echo "gateway-build-matrix=$GatewayMatrix" >> $Env:GITHUB_OUTPUT
 
+          $Jobs = @()
+
+          $Platforms | ForEach-Object {
+              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'linux' { 'ubuntu-20.04' } }
+              foreach ($Arch in $Archs) {
+                  $Jobs += @{
+                      arch = $Arch
+                      os = $_
+                      runner = $Runner }
+              }
+          }
+
           $AgentMatrix = ConvertTo-JSON $Jobs -Compress
           echo "agent-build-matrix=$AgentMatrix" >> $Env:GITHUB_OUTPUT
 
@@ -538,9 +550,6 @@ jobs:
             $DAgentPedmShellExtMsix = Join-Path $TargetOutputPath "DevolutionsPedmShellExt.msix"
             echo "dagent-pedm-shell-ext-msix=$DAgentPedmShellExtMsix" >> $Env:GITHUB_OUTPUT
 
-            $DAgentPedmHook = Join-Path $TargetOutputPath "devolutions_pedm_hook.dll"
-            echo "dagent-pedm-hook=$DAgentPedmHook" >> $Env:GITHUB_OUTPUT
-
             $DAgentSessionExecutable = Join-Path $TargetOutputPath "DevolutionsSession.exe"
             echo "dagent-session-executable=$DAgentSessionExecutable" >> $Env:GITHUB_OUTPUT
           }
@@ -590,6 +599,12 @@ jobs:
           # We need to add the NASM binary folder to the PATH manually.
           Write-Output "$Env:ProgramFiles\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Configure Windows (arm) runner
+        if: runner.os == 'Windows' && matrix.arch == 'arm64'
+        shell: pwsh
+        run: |
+          rustup target add aarch64-pc-windows-msvc
+
       - name: Add msbuild to PATH
         if: matrix.os == 'windows'
         uses: microsoft/setup-msbuild@v2
@@ -603,7 +618,6 @@ jobs:
         run: |
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DAGENT_PEDM_DESKTOP_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-pedm-desktop-executable }}"
-            $Env:DAGENT_PEDM_HOOK = "${{ steps.load-variables.outputs.dagent-pedm-hook }}"
             $Env:DAGENT_PEDM_SHELL_EXT_DLL = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-dll }}"
             $Env:DAGENT_PEDM_SHELL_EXT_MSIX = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-msix }}"
             $Env:DAGENT_SESSION_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-session-executable }}"
@@ -621,7 +635,6 @@ jobs:
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DAGENT_PACKAGE = "${{ steps.load-variables.outputs.dagent-package }}"
             $Env:DAGENT_PEDM_DESKTOP_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-pedm-desktop-executable }}"
-            $Env:DAGENT_PEDM_HOOK = "${{ steps.load-variables.outputs.dagent-pedm-hook }}"
             $Env:DAGENT_PEDM_SHELL_EXT_DLL = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-dll }}"
             $Env:DAGENT_PEDM_SHELL_EXT_MSIX = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-msix }}"
             $Env:DAGENT_SESSION_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-session-executable }}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -228,7 +228,7 @@ jobs:
           $IncludePattern = switch ('${{ matrix.project }}') {
             'devolutions-gateway' { 'DevolutionsGateway_*.exe' }
             'devolutions-agent' { 'DevolutionsAgent_*.exe', 'DevolutionsPedmShellExt.dll',
-              'DevolutionsPedmShellExt.msix', 'DevolutionsPedmDesktop.exe', 'devolutions_pedm_hook.dll' }
+              'DevolutionsPedmShellExt.msix', 'DevolutionsPedmDesktop.exe' }
             'jetsocat' { 'jetsocat_*' }
           }
           $ExcludePattern = "*.pdb"
@@ -325,7 +325,6 @@ jobs:
           $Env:DAGENT_PEDM_DESKTOP_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmDesktop.exe' | Select -First 1
           $Env:DAGENT_PEDM_SHELL_EXT_DLL = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.dll' | Select -First 1
           $Env:DAGENT_PEDM_SHELL_EXT_MSIX = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.msix' | Select -First 1
-          $Env:DAGENT_PEDM_HOOK = Get-ChildItem -Path $PackageRoot -Recurse -Include 'devolutions_pedm_hook.dll' | Select -First 1
           $Env:DAGENT_SESSION_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsSession.exe' | Select -First 1
 
           ./ci/tlk.ps1 package -Product agent -PackageOption generate

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -343,7 +343,6 @@ class TlkRecipe
                 $agentPackages = @([TlkPackage]::new("devolutions-agent", "devolutions-agent", $false))
 
                 if ($this.Target.IsWindows()) {
-                    $agentPackages += [TlkPackage]::new("devolutions-pedm-hook", "crates/devolutions-pedm-hook", $true)
                     $agentPackages += [TlkPackage]::new("devolutions-pedm-shell-ext", "crates/devolutions-pedm-shell-ext", $true)
                     $agentPackages += [TlkPackage]::new("devolutions-session", "devolutions-session", $false)
                 }
@@ -428,8 +427,6 @@ class TlkRecipe
                 "agent" {
                     if ($CargoPackage.Name -Eq "devolutions-agent" -And (Test-Path Env:DAGENT_EXECUTABLE)) {
                         $Env:DAGENT_EXECUTABLE
-                    } elseif ($CargoPackage.Name -Eq "devolutions-pedm-hook" -And (Test-Path Env:DAGENT_PEDM_HOOK)) {
-                        $Env:DAGENT_PEDM_HOOK
                     } elseif ($CargoPackage.Name -Eq "devolutions-pedm-shell-ext" -And (Test-Path Env:DAGENT_PEDM_SHELL_EXT_DLL)) {
                         $Env:DAGENT_PEDM_SHELL_EXT_DLL
                     } elseif ($CargoPackage.Name -Eq "devolutions-session" -And (Test-Path Env:DAGENT_SESSION_EXECUTABLE)) {

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -113,8 +113,6 @@ internal class Program
         return path;
     }
 
-    private static string DevolutionsPedmHook => ResolveArtifact("DAGENT_PEDM_HOOK", "The PEDM hook was not found");
-
     private static string DevolutionsPedmShellExtDll => ResolveArtifact("DAGENT_PEDM_SHELL_EXT_DLL", "The PEDM shell extension DLL was not found");
 
     private static string DevolutionsPedmShellExtMsix => ResolveArtifact("DAGENT_PEDM_SHELL_EXT_MSIX", "The PEDM shell extension MSIX was not found");
@@ -281,7 +279,6 @@ internal class Program
                             StopOn = SvcEvent.InstallUninstall,
                         },
                     },
-                    new (Includes.PEDM_FEATURE, DevolutionsPedmHook),
                     new (Includes.PEDM_FEATURE, DevolutionsPedmShellExtDll),
                     new (Includes.PEDM_FEATURE, DevolutionsPedmShellExtMsix),
                     new (Includes.SESSION_FEATURE, DevolutionsSession)


### PR DESCRIPTION
UAC integration for PEDM is not needed currently; but the hook DLL is built and packaged. 

Removing the hook DLL from the build system allows us to build Devolutions Agent for ARM64 on Windows (it has a reference that is not ARM64 compatible).