### PR TITLE
ci: skip upload of agent windows-arm64 artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,7 @@ jobs:
           ./ci/tlk.ps1 package -Product agent -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
 
       - name: Upload artifacts
+        if: matrix.arch != 'arm64'
         uses: actions/upload-artifact@v4
         with:
           name: devolutions-agent-${{ matrix.os }}-${{ matrix.arch }}


### PR DESCRIPTION
Temporarily skip uploads of Devolutions Agent artifacts on Windows ARM64.

There are further considerations here:

- Some artifacts are architecture specific but not currently named accordingly (DevolutionSession, DevolutionsPedmShellExt)
- The same is true for the msix package (DevolutionsPedmShellExt.msix). It's actually not currently clear to me if this is architecture specific, or should contain binaries for all architectures
- Some artifacts are "universal" (.NET Framework) and shouldn't be uploaded twice (DevolutionsPedmDesktop)

We can address these issues in source, the main point for now is that we are building ARM64 projects and can catch build breaks and etc 