### PR TITLE
feat(jetsocat): Windows named pipes and Unix sockets

### DIFF
--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -36,7 +36,7 @@ seahorse = "2.2"
 humantime = "2.1"
 
 # async
-tokio = { version = "1.38", features = ["io-std", "io-util", "net", "fs", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
+tokio = { version = "1.38", features = ["io-std", "io-util", "net", "fs", "signal", "time", "rt", "sync", "process", "rt-multi-thread", "macros"] }
 tokio-tungstenite = "0.21"
 futures-util = "0.3"
 transport = { path = "../crates/transport" }

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -527,7 +527,9 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
         "np" => {
             #[cfg(windows)]
             {
-                Ok(PipeMode::NamedPipe { name: value.to_owned() })
+                Ok(PipeMode::NamedPipe {
+                    name: value.replace('/', '\\'),
+                })
             }
             #[cfg(unix)]
             {
@@ -539,7 +541,9 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
         "np-listen" => {
             #[cfg(windows)]
             {
-                Ok(PipeMode::NamedPipeListen { name: value.to_owned() })
+                Ok(PipeMode::NamedPipeListen {
+                    name: value.replace('/', '\\'),
+                })
             }
             #[cfg(unix)]
             {

--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -528,7 +528,7 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
             #[cfg(windows)]
             {
                 Ok(PipeMode::NamedPipe {
-                    name: value.replace('/', '\\'),
+                    name: format!("\\\\{}", value.replace('/', "\\")),
                 })
             }
             #[cfg(unix)]
@@ -542,7 +542,7 @@ fn parse_pipe_mode(arg: String) -> anyhow::Result<PipeMode> {
             #[cfg(windows)]
             {
                 Ok(PipeMode::NamedPipeListen {
-                    name: value.replace('/', '\\'),
+                    name: format!("\\\\{}", value.replace('/', "\\")),
                 })
             }
             #[cfg(unix)]

--- a/jetsocat/src/pipe.rs
+++ b/jetsocat/src/pipe.rs
@@ -303,14 +303,15 @@ pub async fn open_pipe(mode: PipeMode, proxy_cfg: Option<ProxyConfig>) -> Result
             use std::time::Duration;
             use tokio::net::windows::named_pipe::ClientOptions;
             use tokio::time;
-            use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
 
-            info!(path = %path.display(), "Open named pipe...");
+            const ERROR_PIPE_BUSY: i32 = 231;
+
+            info!(%name, "Open named pipe...");
 
             let named_pipe = loop {
                 match ClientOptions::new().open(&name) {
                     Ok(named_pipe) => break named_pipe,
-                    Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => (),
+                    Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY) => (),
                     Err(e) => return Err(anyhow::Error::new(e).context("named pipe open")),
                 }
 

--- a/jetsocat/src/pipe.rs
+++ b/jetsocat/src/pipe.rs
@@ -332,7 +332,7 @@ pub async fn open_pipe(mode: PipeMode, proxy_cfg: Option<ProxyConfig>) -> Result
 
             info!(%name, "Create named pipe...");
 
-            let mut named_pipe = ServerOptions::new()
+            let named_pipe = ServerOptions::new()
                 .first_pipe_instance(true)
                 .create(&name)
                 .context("create named pipe")?;


### PR DESCRIPTION
This PR adds support for Windows named pipes and Unix sockets to Jetsocat.