### PR TITLE
fix(jetsocat): enable support for TLS 1.2

### DIFF
--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -65,7 +65,7 @@ tracing = "0.1"
 
 # Async, futures…
 tokio = { version = "1.38", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot", "fs"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["std", "logging", "tls12", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json"] }
 futures = "0.3"
 async-trait = "0.1"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -65,7 +65,7 @@ tracing = "0.1"
 
 # Async, futures…
 tokio = { version = "1.38", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot", "fs"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["std", "logging", "tls12", "ring"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json"] }
 futures = "0.3"
 async-trait = "0.1"

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -58,7 +58,7 @@ sysinfo = { version = "0.30", default-features = false }
 # doctor
 tinyjson = "2.5" # Small JSON library; used to avoid including a bigger like serde-json
 native-tls = { version = "0.2", optional = true } # Same dependency as tokio-tungstenite
-rustls = { version = "0.23", optional = true, default-features = false, features = ["ring"] } # Same dependency as tokio-tungstenite
+rustls = { version = "0.23", optional = true, default-features = false, features = ["tls12", "std", "ring", "logging"] } # Same dependency as tokio-tungstenite
 rustls-native-certs = { version = "0.8", optional = true } # Same dependency as tokio-tungstenite
 openssl-probe = "0.1" # Same dependency as rustls-native-certs
 rustls-pemfile = "2.2" # Same dependency as rustls-native-certs


### PR DESCRIPTION
https://github.com/Devolutions/devolutions-gateway/pull/1038 caused TLS 1.2 to be disabled. It was previously enabled by one of our dependencies, but things changed down there.