### PR TITLE
fix(dgw): properly set the recording policy for RDP via web

### DIFF
--- a/crates/devolutions-gateway-generators/src/lib.rs
+++ b/crates/devolutions-gateway-generators/src/lib.rs
@@ -203,11 +203,14 @@ pub fn any_association_claims(now: i64, validity_duration: i64) -> impl Strategy
 
 pub fn session_info_fwd_only() -> impl Strategy<Value = SessionInfo> {
     (uuid_typed(), application_protocol(), target_addr()).prop_map(|(id, application_protocol, destination_host)| {
-        SessionInfo::new(
-            id,
-            application_protocol,
-            ConnectionModeDetails::Fwd { destination_host },
-        )
+        SessionInfo::builder()
+            .association_id(id)
+            .application_protocol(application_protocol)
+            .details(ConnectionModeDetails::Fwd { destination_host })
+            .recording_policy(token::RecordingPolicy::None)
+            .filtering_policy(false)
+            .time_to_live(token::SessionTtl::Unlimited)
+            .build()
     })
 }
 

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -181,16 +181,16 @@ where
 
             info!("WebSocket-TLS forwarding");
 
-            let info = SessionInfo::new(
-                claims.jet_aid,
-                claims.jet_ap,
-                ConnectionModeDetails::Fwd {
+            let info = SessionInfo::builder()
+                .association_id(claims.jet_aid)
+                .application_protocol(claims.jet_ap)
+                .details(ConnectionModeDetails::Fwd {
                     destination_host: selected_target.clone(),
-                },
-            )
-            .with_ttl(claims.jet_ttl)
-            .with_recording_policy(claims.jet_rec)
-            .with_filtering_policy(claims.jet_flt);
+                })
+                .time_to_live(claims.jet_ttl)
+                .recording_policy(claims.jet_rec)
+                .filtering_policy(claims.jet_flt)
+                .build();
 
             Proxy::builder()
                 .conf(conf)
@@ -209,16 +209,16 @@ where
         } else {
             info!("WebSocket-TCP forwarding");
 
-            let info = SessionInfo::new(
-                claims.jet_aid,
-                claims.jet_ap,
-                ConnectionModeDetails::Fwd {
+            let info = SessionInfo::builder()
+                .association_id(claims.jet_aid)
+                .application_protocol(claims.jet_ap)
+                .details(ConnectionModeDetails::Fwd {
                     destination_host: selected_target.clone(),
-                },
-            )
-            .with_ttl(claims.jet_ttl)
-            .with_recording_policy(claims.jet_rec)
-            .with_filtering_policy(claims.jet_flt);
+                })
+                .time_to_live(claims.jet_ttl)
+                .recording_policy(claims.jet_rec)
+                .filtering_policy(claims.jet_flt)
+                .build();
 
             Proxy::builder()
                 .conf(conf)

--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -93,16 +93,16 @@ where
                     .await
                     .context("failed to write leftover bytes")?;
 
-                let info = SessionInfo::new(
-                    claims.jet_aid,
-                    claims.jet_ap,
-                    ConnectionModeDetails::Fwd {
+                let info = SessionInfo::builder()
+                    .association_id(claims.jet_aid)
+                    .application_protocol(claims.jet_ap)
+                    .details(ConnectionModeDetails::Fwd {
                         destination_host: selected_target.clone(),
-                    },
-                )
-                .with_ttl(claims.jet_ttl)
-                .with_recording_policy(claims.jet_rec)
-                .with_filtering_policy(claims.jet_flt);
+                    })
+                    .time_to_live(claims.jet_ttl)
+                    .recording_policy(claims.jet_rec)
+                    .filtering_policy(claims.jet_flt)
+                    .build();
 
                 Proxy::builder()
                     .conf(conf)

--- a/devolutions-gateway/src/jmux.rs
+++ b/devolutions-gateway/src/jmux.rs
@@ -49,15 +49,15 @@ pub async fn handle(
 
     let session_id = claims.jet_aid;
 
-    let info = SessionInfo::new(
-        session_id,
-        claims.jet_ap,
-        ConnectionModeDetails::Fwd {
+    let info = SessionInfo::builder()
+        .association_id(session_id)
+        .application_protocol(claims.jet_ap)
+        .details(ConnectionModeDetails::Fwd {
             destination_host: main_destination_host,
-        },
-    )
-    .with_ttl(claims.jet_ttl)
-    .with_recording_policy(claims.jet_rec);
+        })
+        .time_to_live(claims.jet_ttl)
+        .recording_policy(claims.jet_rec)
+        .build();
 
     let notify_kill = Arc::new(Notify::new());
 

--- a/devolutions-gateway/src/rdp_extension.rs
+++ b/devolutions-gateway/src/rdp_extension.rs
@@ -305,14 +305,15 @@ pub async fn handle(
 
     // Start actual RDP session
 
-    let info = SessionInfo::new(
-        claims.jet_aid,
-        claims.jet_ap,
-        ConnectionModeDetails::Fwd {
+    let info = SessionInfo::builder()
+        .association_id(claims.jet_aid)
+        .application_protocol(claims.jet_ap)
+        .details(ConnectionModeDetails::Fwd {
             destination_host: destination.clone(),
-        },
-    )
-    .with_ttl(claims.jet_ttl);
+        })
+        .time_to_live(claims.jet_ttl)
+        .recording_policy(claims.jet_rec)
+        .build();
 
     info!("RDP-TLS forwarding");
 


### PR DESCRIPTION
To prevent future regressions, it is ensured that we properly set the policy everywhere by checking at compile-time that a value is set.