### PR TITLE
fix(dgw): allow any header to be set in browser JavaScript HTTP requests

### DIFF
--- a/devolutions-gateway/src/middleware/cors.rs
+++ b/devolutions-gateway/src/middleware/cors.rs
@@ -4,7 +4,7 @@ use tower_http::cors::CorsLayer;
 pub fn make_middleware() -> CorsLayer {
     CorsLayer::new()
         .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::PATCH])
-        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE])
+        .allow_headers([tower_http::cors::Any, header::AUTHORIZATION])
         .allow_origin(tower_http::cors::Any)
         .max_age(std::time::Duration::from_secs(7200))
         .allow_credentials(false)

--- a/devolutions-gateway/src/middleware/cors.rs
+++ b/devolutions-gateway/src/middleware/cors.rs
@@ -1,11 +1,10 @@
-use axum::http::{header, Method};
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{self, AllowHeaders, CorsLayer};
 
 pub fn make_middleware() -> CorsLayer {
     CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE, Method::PATCH])
-        .allow_headers([tower_http::cors::Any, header::AUTHORIZATION])
-        .allow_origin(tower_http::cors::Any)
+        .allow_methods(cors::Any)
+        .allow_headers(AllowHeaders::mirror_request())
+        .allow_origin(cors::Any)
         .max_age(std::time::Duration::from_secs(7200))
         .allow_credentials(false)
 }


### PR DESCRIPTION
We don’t expose any header particularly sensitive from the Devolutions Gateway, and the future HTTP bridge will always require a token which is only issued on a per need basis. In fact, in such cases we actually want to allow virtually any header to be used for web-based integration of various web services (e.g.: VMware dashboard).
The restriction imposed by the token requirement is strong enough.