### PR TITLE
feat(dgw): initial implementation for /jet/fwd/http endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "rustls 0.23.15",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio 1.41.0",
  "tokio-rustls",
@@ -2404,7 +2404,7 @@ dependencies = [
  "proxy-types",
  "proxy_cfg",
  "rustls 0.23.15",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "seahorse",
  "sysinfo",
@@ -4035,7 +4035,7 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "quinn",
  "rustls 0.23.15",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4264,19 +4264,6 @@ dependencies = [
  "rustls 0.23.15",
  "sha2",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -5121,7 +5108,7 @@ dependencies = [
  "log",
  "native-tls",
  "rustls 0.23.15",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio 1.41.0",
  "tokio-native-tls",
@@ -5467,7 +5454,6 @@ dependencies = [
  "native-tls",
  "rand",
  "rustls 0.23.15",
- "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "sha1",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "tokio 1.41.0",
  "tokio-rustls",
  "tokio-test",
+ "tokio-tungstenite",
  "tower 0.5.1",
  "tower-http",
  "tracing",
@@ -4043,10 +4044,12 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio 1.41.0",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -5742,6 +5745,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "rustls 0.23.15",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio 1.41.0",
  "tokio-rustls",
@@ -2404,7 +2404,7 @@ dependencies = [
  "proxy-types",
  "proxy_cfg",
  "rustls 0.23.15",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "seahorse",
  "sysinfo",
@@ -4035,7 +4035,7 @@ dependencies = [
  "pin-project-lite 0.2.14",
  "quinn",
  "rustls 0.23.15",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4264,6 +4264,19 @@ dependencies = [
  "rustls 0.23.15",
  "sha2",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5108,7 +5121,7 @@ dependencies = [
  "log",
  "native-tls",
  "rustls 0.23.15",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio 1.41.0",
  "tokio-native-tls",
@@ -5454,6 +5467,7 @@ dependencies = [
  "native-tls",
  "rand",
  "rustls 0.23.15",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "sha1",
  "thiserror",

--- a/crates/devolutions-gateway-generators/src/lib.rs
+++ b/crates/devolutions-gateway-generators/src/lib.rs
@@ -234,18 +234,31 @@ pub fn any_scope_claims(now: i64, validity_duration: i64) -> impl Strategy<Value
 #[derive(Debug, Clone, Serialize)]
 pub struct BridgeClaims {
     pub target_host: TargetAddr,
+    pub jet_aid: Uuid,
+    pub jet_ap: ApplicationProtocol,
+    pub jet_rec: RecordingPolicy,
     pub nbf: i64,
     pub exp: i64,
     pub jti: Uuid,
 }
 
 pub fn any_bridge_claims(now: i64, validity_duration: i64) -> impl Strategy<Value = BridgeClaims> {
-    (target_addr(), uuid_typed()).prop_map(move |(target_host, jti)| BridgeClaims {
-        target_host,
-        jti,
-        nbf: now,
-        exp: now + validity_duration,
-    })
+    (
+        target_addr(),
+        uuid_typed(),
+        application_protocol(),
+        recording_policy(),
+        uuid_typed(),
+    )
+        .prop_map(move |(target_host, jet_aid, jet_ap, jet_rec, jti)| BridgeClaims {
+            target_host,
+            jet_aid,
+            jet_ap,
+            jet_rec,
+            nbf: now,
+            exp: now + validity_duration,
+            jti,
+        })
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -77,9 +77,8 @@ hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "ws", "query", "tracing", "tower-log"] }
 axum-extra = { version = "0.9", features = ["query", "async-read-body", "typed-header"] }
 tower-http = { version = "0.5", features = ["cors", "fs"] }
-# Should be the same version as `axum` (we perform error downcasting for better error reporting)
-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
-tokio-tungstenite = "0.24" # Should use the same version of tungstenite as `axum`
+tungstenite = "0.24" # Should be the same version as `axum` (we perform error downcasting for better error reporting)
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] } # Should use the same version of tungstenite as `axum`
 http-body-util = "0.1"
 
 # OpenAPI generator

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -65,7 +65,7 @@ tracing = "0.1"
 # Async, futures…
 tokio = { version = "1.41", features = ["signal", "net", "io-util", "time", "rt", "rt-multi-thread", "sync", "macros", "parking_lot", "fs"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "stream"] }
 futures = "0.3"
 async-trait = "0.1"
 tower = { version = "0.5", features = ["timeout"] }
@@ -78,6 +78,8 @@ axum = { version = "0.7", default-features = false, features = ["http1", "json",
 axum-extra = { version = "0.9", features = ["query", "async-read-body", "typed-header"] }
 tower-http = { version = "0.5", features = ["cors", "fs"] }
 tungstenite = "0.24" # Should be the same version as `axum` (we perform error downcasting for better error reporting)
+tokio-tungstenite = "0.24" # Should use the same version of tungstenite as `axum`
+http-body-util = "0.1"
 
 # OpenAPI generator
 utoipa = { version = "4.2", default-features = false, features = ["uuid", "time"], optional = true }

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -77,7 +77,8 @@ hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "json", "ws", "query", "tracing", "tower-log"] }
 axum-extra = { version = "0.9", features = ["query", "async-read-body", "typed-header"] }
 tower-http = { version = "0.5", features = ["cors", "fs"] }
-tungstenite = "0.24" # Should be the same version as `axum` (we perform error downcasting for better error reporting)
+# Should be the same version as `axum` (we perform error downcasting for better error reporting)
+tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
 tokio-tungstenite = "0.24" # Should use the same version of tungstenite as `axum`
 http-body-util = "0.1"
 

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -1,19 +1,19 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use anyhow::Context as _;
+use anyhow::Context;
 use axum::extract::ws::WebSocket;
 use axum::extract::{self, ConnectInfo, State, WebSocketUpgrade};
 use axum::response::Response;
-use axum::routing::get;
+use axum::routing::{self, get};
 use axum::Router;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tracing::{field, Instrument as _};
+use tracing::{field, Instrument};
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 use crate::config::Conf;
-use crate::extract::AssociationToken;
+use crate::extract::{AssociationToken, BridgeToken};
 use crate::http::HttpError;
 use crate::proxy::Proxy;
 use crate::session::{ConnectionModeDetails, SessionInfo, SessionMessageSender};
@@ -22,10 +22,27 @@ use crate::token::{ApplicationProtocol, AssociationTokenClaims, ConnectionMode, 
 use crate::{utils, DgwState};
 
 pub fn make_router<S>(state: DgwState) -> Router<S> {
-    Router::new()
+    use routing::MethodFilter;
+
+    let router = Router::new()
         .route("/tcp/:id", get(fwd_tcp))
-        .route("/tls/:id", get(fwd_tls))
-        .with_state(state)
+        .route("/tls/:id", get(fwd_tls));
+
+    let router = if state.conf_handle.get_conf().debug.enable_unstable {
+        let method_filter = MethodFilter::DELETE
+            .or(MethodFilter::GET)
+            .or(MethodFilter::HEAD)
+            .or(MethodFilter::PATCH)
+            .or(MethodFilter::POST)
+            .or(MethodFilter::PUT)
+            .or(MethodFilter::TRACE);
+
+        router.route("/http/:id", routing::on(method_filter, fwd_http))
+    } else {
+        router
+    };
+
+    router.with_state(state)
 }
 
 async fn fwd_tcp(
@@ -235,5 +252,270 @@ where
                 .await
                 .context("encountered a failure during plain tcp traffic proxying")
         }
+    }
+}
+
+async fn fwd_http(
+    State(state): State<DgwState>,
+    BridgeToken(claims): BridgeToken,
+    extract::Path(session_id): extract::Path<Uuid>,
+    ConnectInfo(source_addr): ConnectInfo<SocketAddr>,
+    mut request: axum::http::Request<axum::body::Body>,
+) -> Result<Response, HttpError> {
+    use axum::extract::FromRequestParts as _; // from_request_parts
+    use axum::http::header;
+    use axum::http::Response;
+    use core::str::FromStr;
+    use http_body_util::BodyExt as _; // into_data_stream
+    use std::sync::LazyLock;
+    use tokio_tungstenite::connect_async;
+
+    // Default HTTP client for typical usage.
+    static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+
+    // Dangerous HTTP client, only to be used when absolutely necessary.
+    // E.g.: VMware services are often using untrusted self-signed certificates.
+    static DANGEROUS_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+        reqwest::Client::builder()
+            .danger_accept_invalid_hostnames(true)
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("parameters known to be valid only")
+    });
+
+    const REQUEST_TARGET_PARAM: Parameter<String> =
+        Parameter::new("Dgw-Request-Target", |params| params.request_target.take());
+
+    const DANGEROUS_TLS_PARAM: Parameter<bool> =
+        Parameter::new("Dgw-Dangerous-Tls", |params| params.dangerous_tls.take());
+
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct QueryParams {
+        request_target: Option<String>,
+        dangerous_tls: Option<bool>, // QUESTION: Maybe we should bake this parameter into the Bridge token.
+    }
+
+    if session_id != claims.jet_aid {
+        return Err(HttpError::forbidden().msg("wrong session ID"));
+    }
+
+    // 1. Extract the requested target.
+
+    let query = request.uri().query().unwrap_or_default();
+    let mut query_params = serde_urlencoded::from_str::<QueryParams>(query)
+        .map_err(HttpError::bad_request().with_msg("invalid query params").err())?;
+
+    let dangerous_tls = DANGEROUS_TLS_PARAM
+        .extract_opt(&mut query_params, request.headers_mut())?
+        .unwrap_or(false);
+
+    // <METHOD> <TARGET>
+    let request_target = REQUEST_TARGET_PARAM.extract(&mut query_params, request.headers_mut())?;
+
+    debug!(%request_target, %dangerous_tls, "HTTP forwarding request");
+
+    // 2. Compute the target URI from the Request-Target parameter and the token claim.
+
+    // <TARGET>
+    let request_target = request_target
+        .split(' ')
+        .next_back()
+        .expect("split always returns at least one element");
+
+    let target_uri = claims.target_host.to_uri_with_path_and_query(request_target).map_err(
+        HttpError::bad_request()
+            .with_msg("Request-Target header has an invalid value")
+            .err(),
+    )?;
+
+    // 3. Modify the request with the target server information.
+
+    *request.uri_mut() = target_uri;
+
+    let host_value =
+        header::HeaderValue::from_str(claims.target_host.host()).map_err(HttpError::bad_request().err())?;
+    request.headers_mut().insert(header::HOST, host_value);
+
+    // 4. Forward the request.
+
+    let response = if matches!(request.uri().scheme_str(), Some("ws" | "wss")) {
+        // 4.a Perform the WebSocket upgrade.
+
+        // We are discarding the original body. There is no HTTP body when performing a WebSocket upgrade.
+        let (mut parts, _) = request.into_parts();
+
+        let client_ws = WebSocketUpgrade::from_request_parts(&mut parts, &state).await.map_err(
+            HttpError::bad_request()
+                .with_msg("failed to initiate the websocket upgrade")
+                .err(),
+        )?;
+
+        // 4.b Open a WebSocket connection to the target.
+
+        let request = axum::http::Request::from_parts(parts, ());
+        let request_uri = request.uri().clone();
+
+        let (server_ws, server_ws_response) = connect_async(request).await.map_err(
+            HttpError::bad_gateway()
+                .with_msg("WebSocket connection to target server")
+                .err(),
+        )?;
+        let server_stream = tokio_tungstenite_websocket_compat(server_ws);
+
+        debug!(?server_ws_response, "Connected to target server");
+
+        // 4.c Start WebSocket forwarding.
+
+        let span = tracing::Span::current();
+        let conf = state.conf_handle.get_conf();
+        let sessions = state.sessions;
+        let subscriber_tx = state.subscriber_tx;
+
+        client_ws.on_upgrade(move |client_ws| {
+            let client_stream = crate::ws::websocket_compat(client_ws);
+            let client_addr = source_addr;
+
+            async move {
+                info!(target = %request_uri, "WebSocket-WebSocket forwarding");
+
+                let info = SessionInfo::builder()
+                    .association_id(claims.jet_aid)
+                    .application_protocol(claims.jet_ap)
+                    .details(ConnectionModeDetails::Fwd {
+                        destination_host: claims.target_host,
+                    })
+                    .time_to_live(claims.jet_ttl)
+                    .recording_policy(claims.jet_rec)
+                    .build();
+
+                let result = Proxy::builder()
+                    .conf(conf)
+                    .session_info(info)
+                    .address_a(client_addr)
+                    .transport_a(client_stream)
+                    .address_b("8.8.8.8:8888".parse().expect("valid hardcoded value")) // NOTE: We don’t really use this address for anything else other than pcap recording, so it’s fine to use a placeholder for now.
+                    .transport_b(server_stream)
+                    .sessions(sessions)
+                    .subscriber_tx(subscriber_tx)
+                    .build()
+                    .select_dissector_and_forward()
+                    .instrument(span.clone())
+                    .await
+                    .context("encountered a failure during WebSocket traffic proxying");
+
+                if let Err(error) = result {
+                    span.in_scope(|| {
+                        error!(error = format!("{error:#}"), "WebSocket forwarding failure");
+                    });
+                }
+            }
+        })
+    } else {
+        // 4.a Plain HTTP request forwarding using reqwest.
+
+        let (parts, body) = request.into_parts();
+        let body = reqwest::Body::wrap_stream(body.into_data_stream());
+        let request = axum::http::Request::from_parts(parts, body);
+        let request = reqwest::Request::try_from(request).map_err(HttpError::internal().err())?;
+
+        debug!(?request);
+
+        info!(target = %request.url(), "Forward HTTP request");
+
+        let client = if dangerous_tls { &*DANGEROUS_CLIENT } else { &*CLIENT };
+
+        let response = client.execute(request).await.map_err(HttpError::bad_gateway().err())?;
+
+        if let Err(error) = response.error_for_status_ref() {
+            info!(%error, host = claims.target_host.host(), "Service responded with an failure HTTP status code");
+        }
+
+        // 4.b Convert the response into the expected type and return it.
+
+        let response = Response::from(response);
+        let (parts, body) = response.into_parts();
+        let body = axum::body::Body::from_stream(body.into_data_stream());
+        Response::from_parts(parts, body)
+    };
+
+    return Ok(response);
+
+    // * Helpers //
+
+    struct Parameter<T>
+    where
+        T: FromStr,
+    {
+        header_name: &'static str,
+        query_params_extractor: fn(&mut QueryParams) -> Option<T>,
+    }
+
+    impl<T> Parameter<T>
+    where
+        T: FromStr,
+        T::Err: core::fmt::Display,
+    {
+        const fn new(header_name: &'static str, query_params_extractor: fn(&mut QueryParams) -> Option<T>) -> Self {
+            Self {
+                header_name,
+                query_params_extractor,
+            }
+        }
+
+        fn extract_opt(
+            &self,
+            query_params: &mut QueryParams,
+            headers: &mut axum::http::HeaderMap,
+        ) -> Result<Option<T>, HttpError> {
+            let value = if let Some(value) = (self.query_params_extractor)(query_params) {
+                value
+            } else if let Some(value) = headers.remove(self.header_name) {
+                let value = value
+                    .to_str()
+                    .with_context(|| format!("invalid UTF-16 value for header {}", self.header_name))
+                    .map_err(HttpError::bad_request().err())?;
+                T::from_str(value)
+                    .map_err(|e| format!("failed to parse header {}: {}", self.header_name, e))
+                    .map_err(HttpError::bad_request().err())?
+            } else {
+                return Ok(None);
+            };
+
+            Ok(Some(value))
+        }
+
+        fn extract(&self, query_params: &mut QueryParams, headers: &mut axum::http::HeaderMap) -> Result<T, HttpError> {
+            let value = self.extract_opt(query_params, headers)?;
+            let value = value
+                .with_context(|| format!("query param or header missing for {}", self.header_name))
+                .map_err(HttpError::bad_request().err())?;
+            Ok(value)
+        }
+    }
+
+    fn tokio_tungstenite_websocket_compat<S>(stream: S) -> impl AsyncRead + AsyncWrite + Unpin + Send + 'static
+    where
+        S: futures::Stream<Item = Result<tungstenite::Message, tungstenite::Error>>
+            + futures::Sink<tungstenite::Message, Error = tungstenite::Error>
+            + Unpin
+            + Send
+            + 'static,
+    {
+        use futures::{SinkExt as _, StreamExt as _};
+
+        let compat = stream
+            .map(|item| {
+                item.map(|msg| match msg {
+                    tungstenite::Message::Text(s) => transport::WsMessage::Payload(s.into_bytes()),
+                    tungstenite::Message::Binary(data) => transport::WsMessage::Payload(data),
+                    tungstenite::Message::Ping(_) | tungstenite::Message::Pong(_) => transport::WsMessage::Ignored,
+                    tungstenite::Message::Close(_) => transport::WsMessage::Close,
+                    tungstenite::Message::Frame(_) => unreachable!("raw frames are never returned when reading"),
+                })
+            })
+            .with(|item| core::future::ready(Ok::<_, tungstenite::Error>(tungstenite::Message::Binary(item))));
+
+        transport::WsStream::new(compat)
     }
 }

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -409,12 +409,15 @@ async fn fwd_http(
                     .recording_policy(claims.jet_rec)
                     .build();
 
+                // NOTE: We don’t really use this address for anything else other than pcap recording, so it’s fine to use a placeholder for now.
+                let server_addr = "8.8.8.8:8888".parse().expect("valid hardcoded value");
+
                 let result = Proxy::builder()
                     .conf(conf)
                     .session_info(info)
                     .address_a(client_addr)
                     .transport_a(client_stream)
-                    .address_b("8.8.8.8:8888".parse().expect("valid hardcoded value")) // NOTE: We don’t really use this address for anything else other than pcap recording, so it’s fine to use a placeholder for now.
+                    .address_b(server_addr)
                     .transport_b(server_stream)
                     .sessions(sessions)
                     .subscriber_tx(subscriber_tx)
@@ -461,7 +464,7 @@ async fn fwd_http(
 
     return Ok(response);
 
-    // * Helpers //
+    // -- local helpers -- //
 
     struct Parameter<T>
     where

--- a/devolutions-gateway/src/extract.rs
+++ b/devolutions-gateway/src/extract.rs
@@ -5,8 +5,8 @@ use axum::Extension;
 
 use crate::http::HttpError;
 use crate::token::{
-    AccessScope, AccessTokenClaims, AssociationTokenClaims, JmuxTokenClaims, JrecTokenClaims, JrlTokenClaims,
-    ScopeTokenClaims, WebAppTokenClaims,
+    AccessScope, AccessTokenClaims, AssociationTokenClaims, BridgeTokenClaims, JmuxTokenClaims, JrecTokenClaims,
+    JrlTokenClaims, ScopeTokenClaims, WebAppTokenClaims,
 };
 
 #[derive(Clone)]
@@ -347,6 +347,25 @@ where
             Ok(Self)
         } else {
             Err(HttpError::forbidden().msg("token not allowed (expected NETSCAN)"))
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct BridgeToken(pub BridgeTokenClaims);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for BridgeToken
+where
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        if let AccessTokenClaims::Bridge(claims) = AccessToken::from_request_parts(parts, state).await?.0 {
+            Ok(Self(claims))
+        } else {
+            Err(HttpError::forbidden().msg("token not allowed (expected BRIDGE)"))
         }
     }
 }

--- a/devolutions-gateway/src/main.rs
+++ b/devolutions-gateway/src/main.rs
@@ -8,12 +8,12 @@ use rustls_cng as _;
 use utoipa as _;
 use {
     argon2 as _, async_trait as _, axum as _, axum_extra as _, backoff as _, bytes as _, camino as _,
-    devolutions_agent_shared as _, dlopen as _, dlopen_derive as _, etherparse as _, hostname as _, hyper as _,
-    hyper_util as _, ironrdp_pdu as _, ironrdp_rdcleanpath as _, jmux_proxy as _, multibase as _, network_scanner as _,
-    ngrok as _, nonempty as _, pcap_file as _, picky as _, picky_krb as _, pin_project_lite as _, portpicker as _,
-    reqwest as _, serde as _, serde_urlencoded as _, smol_str as _, sysinfo as _, thiserror as _, time as _,
-    tokio_rustls as _, tower as _, tower_http as _, transport as _, tungstenite as _, typed_builder as _, url as _,
-    uuid as _, zeroize as _,
+    devolutions_agent_shared as _, dlopen as _, dlopen_derive as _, etherparse as _, hostname as _,
+    http_body_util as _, hyper as _, hyper_util as _, ironrdp_pdu as _, ironrdp_rdcleanpath as _, jmux_proxy as _,
+    multibase as _, network_scanner as _, ngrok as _, nonempty as _, pcap_file as _, picky as _, picky_krb as _,
+    pin_project_lite as _, portpicker as _, reqwest as _, serde as _, serde_urlencoded as _, smol_str as _,
+    sysinfo as _, thiserror as _, time as _, tokio_rustls as _, tokio_tungstenite as _, tower as _, tower_http as _,
+    transport as _, tungstenite as _, typed_builder as _, url as _, uuid as _, zeroize as _,
 };
 
 // Used by tests.

--- a/devolutions-gateway/src/middleware/auth.rs
+++ b/devolutions-gateway/src/middleware/auth.rs
@@ -98,6 +98,7 @@ pub async fn auth_middleware(
     next: Next,
 ) -> Result<Response, HttpError> {
     #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
     struct TokenQueryParam<'a> {
         token: &'a str,
     }

--- a/devolutions-gateway/src/proxy.rs
+++ b/devolutions-gateway/src/proxy.rs
@@ -54,7 +54,7 @@ where
             let format = time::format_description::parse("[year]-[month]-[day]-[hour]-[minute]-[second]")
                 .expect("valid hardcoded format");
             let date = time::OffsetDateTime::now_utc().format(&format)?;
-            let pcap_filename = format!("{date}_from_{}_to_{}.pcap", self.address_a, self.address_b,);
+            let pcap_filename = format!("{date}_from_{}_to_{}.pcap", self.address_a, self.address_b);
             let pcap_path = capture_path.join(pcap_filename);
 
             let (client_inspector, server_inspector) =

--- a/devolutions-gateway/src/target_addr.rs
+++ b/devolutions-gateway/src/target_addr.rs
@@ -138,6 +138,13 @@ impl TargetAddr {
 
         &self.serialization.as_str()[(lo, hi)]
     }
+
+    pub fn to_uri_with_path_and_query(
+        &self,
+        path_and_query: &str,
+    ) -> Result<axum::http::Uri, axum::http::uri::InvalidUri> {
+        format!("{}{}", self.serialization, path_and_query).parse()
+    }
 }
 
 fn target_addr_parse_impl(

--- a/devolutions-gateway/src/tls.rs
+++ b/devolutions-gateway/src/tls.rs
@@ -272,12 +272,12 @@ pub mod sanity {
     }
 }
 
-mod danger {
+pub mod danger {
     use tokio_rustls::rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
     use tokio_rustls::rustls::{pki_types, DigitallySignedStruct, Error, SignatureScheme};
 
     #[derive(Debug)]
-    pub(super) struct NoCertificateVerification;
+    pub struct NoCertificateVerification;
 
     impl ServerCertVerifier for NoCertificateVerification {
         fn verify_server_cert(

--- a/devolutions-gateway/tests/token_security.proptest-regressions
+++ b/devolutions-gateway/tests/token_security.proptest-regressions
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 28144969b0e528f8251db5e960c28e7d7d5572e01acb4803442794da1a6fd2c0 # shrinks to scope_dw_id = None, use_subkey = false, claims = Bridge(BridgeClaims { target_host: TargetAddr { serialization: "tcp://bhvyrbkl.xwj:5960", scheme_end: 3, host_start: 6, host_end: 18, host_internal: Domain, port: 5960 }, nbf: 1730393500, exp: 1730403292, jti: 92768525-5113-2224-4867-980717311108 })
+cc eaae5af628a2c2b4f970865703c2a1df20e64dc0ff4f82e45661539092121e12 # shrinks to same_ip = false, claims = Bridge(BridgeClaims { target_host: TargetAddr { serialization: "tcp://vbmwyphds.lu:1810", scheme_end: 3, host_start: 6, host_end: 18, host_internal: Domain, port: 1810 }, nbf: 1730393500, exp: 1730405465, jti: 75353433-7931-5293-0704-962950113675 })
+cc fefa2894e11ed08b2eaf3966dfb5913f941a364149f4ad2854a7d4899bea1834 # shrinks to items = [RevocableItem { claim_to_revoke: None, claims: Object {"exp": Number(1730403958), "jti": String("02498981-4258-6884-1970-328704169839"), "nbf": Number(1730393500), "target_host": String("tcp://cxg.sm:147")}, token: "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6IkJSSURHRSJ9.eyJ0YXJnZXRfaG9zdCI6InRjcDovL2N4Zy5zbToxNDciLCJuYmYiOjE3MzAzOTM1MDAsImV4cCI6MTczMDQwMzk1OCwianRpIjoiMDI0OTg5ODEtNDI1OC02ODg0LTE5NzAtMzI4NzA0MTY5ODM5In0.EceCpsMRvSjsE4vmlH49knvGFVDScOkJRUlXvaPWCpmhi-zX2ww1mai8F1U6AWnnfMdIJRmOZUbNTyhv8ExpaMEIcK5rN1GHG2IjcUKOlPAi14sqhDEdum511Itye55cAlG62_WPMg6O7cxvN_c5OUnx24iMdFDIK_aF3czaZU_k-CKVw18dn5NsdMpNwsrEeOqiElgUlrUM8zS7bOIis8fpldDGaiJ0XxVXWFCKnRzzTZFNXgKUDINUpadc2klxBUk50x9_FI1MIbCIp--HUQICwgdoCGkK4ueceber8iygN6PVoDyJPkuXs5k8vh4QcqjsEjnbQD1My5ThVYXbFA" }]

--- a/devolutions-gateway/tests/token_security.rs
+++ b/devolutions-gateway/tests/token_security.rs
@@ -362,6 +362,7 @@ fn token_cache(
             .validate(&token);
 
         let can_reuse = matches!(claims, TokenClaims::Kdc(_))
+            || matches!(claims, TokenClaims::Bridge(_))
             || same_ip
                 && matches!(
                     claims,

--- a/tools/tokengen/src/lib.rs
+++ b/tools/tokengen/src/lib.rs
@@ -375,7 +375,13 @@ pub fn generate_token(
                 nbf,
                 jti,
                 target_host: &target_host,
-                jet_ap: jet_ap.unwrap_or(ApplicationProtocol::Unknown),
+                jet_ap: jet_ap.unwrap_or_else(|| {
+                    if target_host.starts_with("https") {
+                        ApplicationProtocol::Https
+                    } else {
+                        ApplicationProtocol::Http
+                    }
+                }),
                 jet_rec: if jet_rec {
                     RecordingPolicy::Stream
                 } else {

--- a/tools/tokengen/src/main.rs
+++ b/tools/tokengen/src/main.rs
@@ -81,6 +81,19 @@ fn sign(
             jet_aid,
         },
         SignSubCommand::Scope { scope } => SubCommandArgs::Scope { scope },
+        SignSubCommand::Bridge {
+            target_host,
+            jet_aid,
+            jet_ap,
+            jet_rec,
+            jet_ttl,
+        } => SubCommandArgs::Bridge {
+            target_host,
+            jet_aid,
+            jet_ap,
+            jet_rec,
+            jet_ttl,
+        },
         SignSubCommand::Jmux {
             jet_ap,
             dst_hst,
@@ -103,7 +116,8 @@ fn sign(
     };
 
     let validity_duration = humantime::parse_duration(validity_duration)?;
-    generate_token(
+
+    let result = generate_token(
         provisioner_key,
         validity_duration,
         kid.to_owned(),
@@ -111,6 +125,8 @@ fn sign(
         jet_gw_id,
         subcommand,
     )?;
+
+    println!("{result}");
 
     Ok(())
 }
@@ -186,6 +202,18 @@ enum SignSubCommand {
     },
     Scope {
         scope: String,
+    },
+    Bridge {
+        #[clap(long)]
+        target_host: String,
+        #[clap(long)]
+        jet_aid: Option<Uuid>,
+        #[clap(long)]
+        jet_ap: Option<ApplicationProtocol>,
+        #[clap(long)]
+        jet_rec: bool,
+        #[clap(long)]
+        jet_ttl: Option<u64>,
     },
     Jmux {
         #[clap(long)]


### PR DESCRIPTION
Currently behind the unstable flag.
Some details may be adjusted in the future.

For HTTP requests without upgrade, we do not account the operation as a session: it does not influence DVLS licensing quota, subscriber events, etc.
HTTP requests resulting into a WebSocket upgrade however will count as a fully-fledged session as usual.

Issue: DGW-217
Changelog: ignore

# How to test

## Enable instable features

In `gateway.json`:

```json
{
  /* snip */
  "__debug__": {
    "enable_unstable": true
  }
}
```

## HTTP request without upgrade

You can use `curl`:

```shell
curl -X GET \
  "http://localhost:7171/jet/fwd/http/f4fae090-5c07-4350-8fd6-937e0f3a5b43" \
  -H "Dgw-Request-Target: GET /todos/1" \
  -H "Authorization: Bearer $(
    tokengen \
      sign --provisioner-key /path/to/provisioner.key \
      bridge --target-host https://jsonplaceholder.typicode.com --jet-aid f4fae090-5c07-4350-8fd6-937e0f3a5b43
    )"
```

## HTTP request with WebSocket upgrade

You can use `jetsocat`:

```shell
jetsocat forward \
  "ws://127.0.0.1:7171/jet/fwd/http/d3a8ac78-49a4-4866-9ded-cf73a24f52c4?requestTarget=%2F&token=$(
    tokengen \
      sign --provisioner-key /path/to/provisioner.key \
      bridge --target-host wss://echo.websocket.org --jet-aid d3a8ac78-49a4-4866-9ded-cf73a24f52c4
  )" \
  -
```