### PR TITLE
feat(dgw): /jet/jrec/delete endpoint for mass deletion

### DIFF
--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -451,7 +451,7 @@ async fn fwd_http(
         let response = client.execute(request).await.map_err(HttpError::bad_gateway().err())?;
 
         if let Err(error) = response.error_for_status_ref() {
-            info!(%error, host = claims.target_host.host(), "Service responded with an failure HTTP status code");
+            info!(%error, host = claims.target_host.host(), "Service responded with a failure HTTP status code");
         }
 
         // 4.b Convert the response into the expected type and return it.

--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -8,6 +8,8 @@ use axum::extract::{self, ConnectInfo, Query, State, WebSocketUpgrade};
 use axum::response::Response;
 use axum::routing::{delete, get};
 use axum::{Json, Router};
+use cadeau::xmf::recorder::RecorderBuilder;
+use camino::Utf8Path;
 use devolutions_gateway_task::ShutdownSignal;
 use hyper::StatusCode;
 use tracing::Instrument as _;
@@ -23,6 +25,7 @@ pub fn make_router<S>(state: DgwState) -> Router<S> {
     Router::new()
         .route("/push/:id", get(jrec_push))
         .route("/delete/:id", delete(jrec_delete))
+        .route("/delete", delete(jrec_delete_many))
         .route("/list", get(list_recordings))
         .route("/pull/:id/:filename", get(pull_recording_file))
         .route("/play", get(get_player))
@@ -109,6 +112,7 @@ async fn handle_jrec_push(
         (status = 400, description = "Bad request"),
         (status = 401, description = "Invalid or missing authorization token"),
         (status = 403, description = "Insufficient permissions"),
+        (status = 404, description = "The specified recording was not found"),
         (status = 406, description = "The recording is still ongoing and can't be deleted yet"),
     ),
     security(("scope_token" = ["gateway.recording.delete"])),
@@ -122,24 +126,104 @@ async fn jrec_delete(
     _scope: RecordingDeleteScope,
     extract::Path(session_id): extract::Path<Uuid>,
 ) -> Result<(), HttpError> {
-    let state = recordings
-        .get_state(session_id)
-        .await
-        .map_err(HttpError::internal().with_msg("failed recording listing").err())?;
+    let is_active = recordings.active_recordings.contains(session_id);
 
-    if state.is_some() {
+    if is_active {
         return Err(
-            HttpErrorBuilder::new(StatusCode::CONFLICT).msg("Attempted to delete a recording for an ongoing session")
+            HttpErrorBuilder::new(StatusCode::CONFLICT).msg("attempted to delete a recording for an ongoing session")
         );
     }
 
     let recording_path = conf_handle.get_conf().recording_path.join(session_id.to_string());
 
-    debug!(%recording_path, "Delete recording");
+    if !recording_path.exists() {
+        return Err(HttpErrorBuilder::new(StatusCode::NOT_FOUND)
+            .msg("attempted to delete a recording not found on this instance"));
+    }
 
-    tokio::fs::remove_dir_all(recording_path)
+    delete_recording(&recording_path)
         .await
         .map_err(HttpError::internal().with_msg("failed to delete recording").err())?;
+
+    Ok(())
+}
+
+/// Deletes multiple recording stored on this instance
+#[cfg_attr(feature = "openapi", utoipa::path(
+    delete,
+    operation_id = "DeleteManyRecordings",
+    tag = "Jrec",
+    path = "/jet/jrec/delete",
+    request_body(content = Vec<Uuid>, description = "JSON-encoded list of session IDs", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Mass recording deletion task was successfully started"),
+        (status = 400, description = "Bad request"),
+        (status = 401, description = "Invalid or missing authorization token"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 404, description = "One of the recordings specified in the body was not found"),
+        (status = 406, description = "A recording is still ongoing and can't be deleted yet (nothing is deleted)"),
+    ),
+    security(("scope_token" = ["gateway.recording.delete"])),
+))]
+async fn jrec_delete_many(
+    State(DgwState {
+        conf_handle,
+        recordings,
+        ..
+    }): State<DgwState>,
+    _scope: RecordingDeleteScope,
+    Json(delete_list): Json<Vec<Uuid>>,
+) -> Result<(), HttpError> {
+    let active_recordings = recordings.active_recordings.cloned();
+
+    let conflict = delete_list.iter().any(|id| active_recordings.contains(id));
+
+    if conflict {
+        return Err(
+            HttpErrorBuilder::new(StatusCode::CONFLICT).msg("attempted to delete a recording for an ongoing session")
+        );
+    }
+
+    let conf = conf_handle.get_conf();
+
+    let recording_paths: Vec<_> = delete_list
+        .iter()
+        .map(|session_id| conf.recording_path.join(session_id.to_string()))
+        .collect();
+
+    for (path, session_id) in recording_paths.iter().zip(delete_list.iter()) {
+        if !path.exists() {
+            return Err(HttpErrorBuilder::new(StatusCode::NOT_FOUND)
+                .with_msg("attempted to delete a recording not found on this instance")
+                .err()(format!(
+                "folder {path} for session {session_id} does not exist"
+            )));
+        }
+    }
+
+    // FIXME: It would be better to have a job queue for this kind of things in case the service is killed.
+    tokio::spawn({
+        async move {
+            for (path, session_id) in recording_paths.into_iter().zip(delete_list.into_iter()) {
+                if let Err(error) = delete_recording(&path).await {
+                    error!(
+                        error = format!("{error:#}"),
+                        "Failed to delete recording for session {session_id}"
+                    );
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+async fn delete_recording(recording_path: &Utf8Path) -> anyhow::Result<()> {
+    info!(%recording_path, "Delete recording");
+
+    tokio::fs::remove_dir_all(&recording_path)
+        .await
+        .with_context(|| format!("failed to remove folder {recording_path}"))?;
 
     Ok(())
 }

--- a/devolutions-gateway/src/api/update.rs
+++ b/devolutions-gateway/src/api/update.rs
@@ -24,7 +24,7 @@ pub(crate) struct UpdateResponse {}
 /// currently installed version, Devolutions Agent will proceed with the update process.
 #[cfg_attr(feature = "openapi", utoipa::path(
     post,
-    operation_id = "Update",
+    operation_id = "TriggerUpdate",
     tag = "Update",
     path = "/jet/update",
     responses(

--- a/devolutions-gateway/src/openapi.rs
+++ b/devolutions-gateway/src/openapi.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
         crate::api::jrl::update_jrl,
         crate::api::jrl::get_jrl_info,
         crate::api::jrec::jrec_delete,
+        crate::api::jrec::jrec_delete_many,
         crate::api::jrec::list_recordings,
         crate::api::jrec::pull_recording_file,
         crate::api::webapp::sign_app_token,

--- a/devolutions-gateway/src/recording.rs
+++ b/devolutions-gateway/src/recording.rs
@@ -149,6 +149,11 @@ impl ActiveRecordings {
         self.0.lock().contains(&id)
     }
 
+    /// Returns a copy of the internal HashSet
+    pub fn cloned(&self) -> HashSet<Uuid> {
+        self.0.lock().clone()
+    }
+
     fn insert(&self, id: Uuid) -> usize {
         let mut guard = self.0.lock();
         guard.insert(id);


### PR DESCRIPTION
This patch adds a new endpoint not taking any parameter via the request path. Instead, a list of session IDs is provided in the request body.

Here is how to test with cURL and tokengen tool:

```shell
curl -X DELETE \
    -H "Content-Type: application/json" \
    --data '["d3a8ac78-49a4-4866-9ded-cf73a24f52c4"]' \
    "http://localhost:7171/jet/jrec/delete?token=$( \
        cargo run --manifest-path ./tools/tokengen/Cargo.toml \
            sign --provisioner-key ./config/provisioner.priv.key scope '*' \
    )"
```

Issue: DGW-219