### PR TITLE
fix(dgw): better custom recording paths handling in heartbeat endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,6 +1052,7 @@ dependencies = [
  "devolutions-log",
  "dlopen",
  "dlopen_derive",
+ "dunce",
  "embed-resource",
  "etherparse",
  "futures",

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -52,6 +52,7 @@ thiserror = "1"
 typed-builder = "0.19"
 backoff = "0.4"
 sysinfo = "0.30"
+dunce = "1.0"
 
 # Security, crypto…
 picky = { version = "7.0.0-rc.9", default-features = false, features = ["jose", "x509", "pkcs12"] }

--- a/devolutions-gateway/src/api/heartbeat.rs
+++ b/devolutions-gateway/src/api/heartbeat.rs
@@ -78,13 +78,12 @@ pub(super) async fn get_heartbeat(
     let (recording_storage_total_space, recording_storage_available_space) = if sysinfo::IS_SUPPORTED_SYSTEM {
         trace!("System is supporting listing storage disks");
 
-        let recording_path = conf
-            .recording_path
-            .canonicalize()
+        let recording_path = dunce::canonicalize(&conf.recording_path)
             .unwrap_or_else(|_| conf.recording_path.clone().into_std_path_buf());
 
         let disks = Disks::new_with_refreshed_list();
 
+        debug!(recording_path = %recording_path.display(), "Search mount point for path");
         debug!(?disks, "Found disks");
 
         let mut recording_disk = None;


### PR DESCRIPTION
On Windows, the std::fs::canonicalize function returns Windows NT UNC paths, but our code detecting the mount point does not understand that.
We use dunce to handle that for us instead.

Issue: DGW-218