### PR TITLE
fix(jetsocat): preemptively install crypto provider on start

### DIFF
--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -80,6 +80,13 @@ fn generate_usage() -> String {
 }
 
 pub fn run<F: Future<Output = anyhow::Result<()>>>(f: F) -> anyhow::Result<()> {
+    // Install the default crypto provider when rustls is used.
+    #[cfg(feature = "rustls")]
+    if rustls::crypto::ring::default_provider().install_default().is_err() {
+        let installed_provider = rustls::crypto::CryptoProvider::get_default();
+        debug!(?installed_provider, "default crypto provider is already installed");
+    }
+
     let rt = runtime::Builder::new_multi_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
This is typically not required because we only enable the ring backend, which is then automatically installed by rustls when `ClientConfig::builder` is called later down the road. However, it may be the case that during development the aws-lc-rs feature of rustls is enabled (especially when building the whole workspace at once), causing rustls to crash the process requesting to install a default crypto provider.
To smoothen the developer experience, we attempt to install the ring crypto provider just before executing the command action. Our CI is already ensuring that we are not shipping both crypto backends by mistake.

Changelog: ignore