### PR TITLE
fix(webapp): active session connection status in menu

### DIFF
--- a/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts
+++ b/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts
@@ -57,12 +57,10 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
   @ViewChild('ironGuiElementVnc') ironGuiElement: ElementRef;
 
   screenScale = ScreenScale;
-  currentStatus: ComponentStatus;
   formData: ArdFormDataInput;
   ardError: { kind: string; backtrace: string };
   isFullScreenMode = false;
   showToolbarDiv = true;
-  loading = true;
 
   middleToolbarButtons = [
     {
@@ -111,7 +109,6 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
 
   ngOnInit(): void {
     this.removeWebClientGuiElement();
-    this.initializeStatus();
   }
 
   ngAfterViewInit(): void {
@@ -159,7 +156,7 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
   private initializeStatus(): void {
     this.currentStatus = {
       id: this.webSessionId,
-      isInitialized: false,
+      isInitialized: true,
       isDisabled: false,
       isDisabledByUser: false,
     };
@@ -354,7 +351,7 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
 
   private handleSessionStarted(event: SessionEvent): void {
     this.handleIronRDPConnectStarted();
-    this.currentStatus.isInitialized = true;
+    this.initializeStatus();
   }
 
   private handleSessionEndedOrError(event: SessionEvent): void {

--- a/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.ts
+++ b/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.ts
@@ -56,12 +56,10 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
   @ViewChild('ironGuiElement') ironGuiElement: ElementRef;
 
   screenScale = ScreenScale;
-  currentStatus: ComponentStatus;
   formData: RdpFormDataInput;
   rdpError: { kind: string; backtrace: string };
   isFullScreenMode = false;
   showToolbarDiv = true;
-  loading = true;
 
   leftToolbarButtons = [
     {
@@ -124,7 +122,6 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
 
   ngOnInit(): void {
     this.removeWebClientGuiElement();
-    this.initializeStatus();
   }
 
   ngAfterViewInit(): void {
@@ -184,7 +181,7 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
   private initializeStatus(): void {
     this.currentStatus = {
       id: this.webSessionId,
-      isInitialized: false,
+      isInitialized: true,
       isDisabled: false,
       isDisabledByUser: false,
     };
@@ -381,7 +378,7 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
 
   private handleSessionStarted(event: SessionEvent): void {
     this.handleIronRDPConnectStarted();
-    this.currentStatus.isInitialized = true;
+    this.initializeStatus();
   }
 
   private handleSessionEndedOrError(event: SessionEvent): void {

--- a/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
+++ b/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
@@ -57,12 +57,10 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
   @ViewChild('ironGuiElementVnc') ironGuiElement: ElementRef;
 
   screenScale = ScreenScale;
-  currentStatus: ComponentStatus;
   formData: VncFormDataInput;
   clientError: { kind: string; backtrace: string };
   isFullScreenMode = false;
   showToolbarDiv = true;
-  loading = true;
 
   leftToolbarButtons = [
     {
@@ -124,7 +122,6 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
 
   ngOnInit(): void {
     this.removeWebClientGuiElement();
-    this.initializeStatus();
   }
 
   ngAfterViewInit(): void {
@@ -184,7 +181,7 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
   private initializeStatus(): void {
     this.currentStatus = {
       id: this.webSessionId,
-      isInitialized: false,
+      isInitialized: true,
       isDisabled: false,
       isDisabledByUser: false,
     };
@@ -380,7 +377,7 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
 
   private handleSessionStarted(event: SessionEvent): void {
     this.handleIronRDPConnectStarted();
-    this.currentStatus.isInitialized = true;
+    this.initializeStatus();
   }
 
   private handleSessionEndedOrError(event: SessionEvent): void {

--- a/webapp/src/client/app/shared/bases/base-web-client.component.ts
+++ b/webapp/src/client/app/shared/bases/base-web-client.component.ts
@@ -1,15 +1,27 @@
 import { Directive } from '@angular/core';
-import { BaseComponent } from '@shared/bases/base.component';
 import { GatewayAlertMessageService } from '@shared/components/gateway-alert-message/gateway-alert-message.service';
+import { ComponentStatus } from '@shared/models/component-status.model';
 import { BaseSessionComponent } from '../models/web-session.model';
 import { AnalyticService, ConnectionIdentifier, ProtocolString } from '../services/analytic.service';
+
+export interface WebComponentReady {
+  webComponentReady(event: Event, webSessionId: string): void;
+}
 
 @Directive()
 export abstract class WebClientBaseComponent extends BaseSessionComponent {
   hideSpinnerOnly = false;
   error: string;
+  loading = true;
 
   analyticHandle: ConnectionIdentifier;
+
+  currentStatus: ComponentStatus = {
+    id: undefined,
+    isInitialized: false,
+    isDisabled: false,
+    isDisabledByUser: false,
+  };
 
   protected constructor(
     protected gatewayAlertMessageService: GatewayAlertMessageService,

--- a/webapp/src/client/app/shared/services/component-listener.service.ts
+++ b/webapp/src/client/app/shared/services/component-listener.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, OnDestroy, Renderer2, RendererFactory2 } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ComponentListenerService implements OnDestroy {
+  private readonly renderer: Renderer2;
+  private readonly listeners: Array<() => void> = [];
+
+  private readonly sshInitialized$ = new Subject<Event>();
+  private readonly telnetInitialized$ = new Subject<Event>();
+
+  constructor(rendererFactory: RendererFactory2) {
+    this.renderer = rendererFactory.createRenderer(null, null);
+
+    const sshListener = this.renderer.listen('window', 'sshInitialized', (event) => {
+      this.handleSshInitializedEvent(event as CustomEvent);
+    });
+    this.listeners.push(sshListener);
+
+    const telnetListener = this.renderer.listen('window', 'telnetInitialized', (event) => {
+      this.handleTelnetInitializedEvent(event as CustomEvent);
+    });
+    this.listeners.push(telnetListener);
+  }
+
+  ngOnDestroy(): void {
+    this.destroyAllListeners();
+  }
+
+  onSshInitialized(): Observable<Event> {
+    return this.sshInitialized$.asObservable();
+  }
+
+  onTelnetInitialized(): Observable<Event> {
+    return this.telnetInitialized$.asObservable();
+  }
+
+  private destroyAllListeners(): void {
+    for (const unsubscribe of this.listeners) {
+      unsubscribe();
+    }
+    this.listeners.length = 0;
+
+    this.sshInitialized$.complete();
+    this.telnetInitialized$.complete();
+  }
+
+  private handleSshInitializedEvent(event: CustomEvent): void {
+    this.sshInitialized$.next(event);
+  }
+
+  private handleTelnetInitializedEvent(event: CustomEvent): void {
+    this.telnetInitialized$.next(event);
+  }
+}

--- a/webapp/src/client/app/shared/services/web-session.service.ts
+++ b/webapp/src/client/app/shared/services/web-session.service.ts
@@ -1,10 +1,10 @@
-import { ComponentRef, Injectable, Type } from '@angular/core';
+import { Injectable, Type } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
-  BaseSessionComponent,
   CanSendTerminateSessionCmd,
+  ComponentForSession,
   ConnectionSessionType,
   SessionType,
 } from './../models/web-session.model';
@@ -18,7 +18,7 @@ import { WebClientTelnetComponent } from '@gateway/modules/web-client/telnet/web
 import { WebClientVncComponent } from '@gateway/modules/web-client/vnc/web-client-vnc.component';
 import { Protocol } from '@shared/enums/web-client-protocol.enum';
 import { AutoCompleteInput } from '@shared/interfaces/forms.interfaces';
-import { WebSession, WebSessionComponentType } from '@shared/models/web-session.model';
+import { WebSession } from '@shared/models/web-session.model';
 import { DynamicComponentService } from '@shared/services/dynamic-component.service';
 
 // Offset is used to skip the first item in menu -- which is the create new session form.
@@ -85,7 +85,8 @@ export class WebSessionService {
     // WebSession's type now corresponds to the mapped component type
     const webSession = new WebSession<ConnectionSessionType>(
       submittedData.hostname,
-      sessionComponent,
+      // use a type assertion to help TypeScript recognize the type match
+      sessionComponent as Type<ComponentForSession<ConnectionSessionType>>,
       submittedData,
       iconName,
     );


### PR DESCRIPTION
Issue: DGW-231

Resolved an issue where the menu list of web session connection status for SSH/Telnet was briefly displayed as "connecting" even though the session was terminated.

**Improvements**:
- Added ComponentListenerService to manage SSH and Telnet listeners, ensuring only one listener per session type.

- Introduced the WebComponentReady interface for seamless listener integration via ComponentListenerService in dynamically loaded components.

- Refactored session status initialization and event handling across all session types for more reliable session tracking.