### PR TITLE
refactor(agent): updater improvements

### DIFF
--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -35,7 +35,7 @@ git = "https://github.com/Devolutions/IronRDP"
 rev = "2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 default-features = false
 features = [
-    "server", # FIXME(@CBenoit): this is enabling AWS LC unconditionnally.
+    "server", # FIXME(@CBenoit): this is enabling AWS LC unconditionally.
     "acceptor",
 ]
 

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -4,8 +4,10 @@
 // Used by devolutions-agent library.
 use {
     anyhow as _, async_trait as _, camino as _, devolutions_agent_shared as _, devolutions_gateway_task as _,
-    devolutions_log as _, futures as _, ironrdp as _, parking_lot as _, rand as _, rustls_pemfile as _, serde as _,
-    serde_json as _, tap as _, tokio as _, tokio_rustls as _,
+    devolutions_log as _, devolutions_pedm as _, futures as _, hex as _, ironrdp as _, notify_debouncer_mini as _,
+    parking_lot as _, rand as _, reqwest as _, rustls_pemfile as _, serde as _, serde_json as _, sha2 as _,
+    smallvec as _, tap as _, thiserror as _, tokio as _, tokio_rustls as _, uuid as _, win_api_wrappers as _,
+    windows as _, winreg as _,
 };
 
 #[macro_use]

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -4,10 +4,14 @@
 // Used by devolutions-agent library.
 use {
     anyhow as _, async_trait as _, camino as _, devolutions_agent_shared as _, devolutions_gateway_task as _,
-    devolutions_log as _, devolutions_pedm as _, futures as _, hex as _, ironrdp as _, notify_debouncer_mini as _,
-    parking_lot as _, rand as _, reqwest as _, rustls_pemfile as _, serde as _, serde_json as _, sha2 as _,
-    smallvec as _, tap as _, thiserror as _, tokio as _, tokio_rustls as _, uuid as _, win_api_wrappers as _,
-    windows as _, winreg as _,
+    devolutions_log as _, futures as _, ironrdp as _, parking_lot as _, rand as _, rustls_pemfile as _, serde as _,
+    serde_json as _, tap as _, tokio as _, tokio_rustls as _,
+};
+
+#[cfg(windows)]
+use {
+    devolutions_pedm as _, hex as _, notify_debouncer_mini as _, reqwest as _, sha2 as _, smallvec as _,
+    thiserror as _, uuid as _, win_api_wrappers as _, windows as _, winreg as _,
 };
 
 #[macro_use]

--- a/devolutions-agent/src/updater/detect.rs
+++ b/devolutions-agent/src/updater/detect.rs
@@ -10,12 +10,12 @@ const GATEWAY_UPDATE_CODE: &str = "{db3903d6-c451-4393-bd80-eb9f45b90214}";
 /// Get the installed version of a product.
 pub(crate) fn get_installed_product_version(product: Product) -> Result<Option<DateVersion>, UpdaterError> {
     match product {
-        Product::Gateway => get_instaled_product_version_winreg(GATEWAY_UPDATE_CODE),
+        Product::Gateway => get_installed_product_version_winreg(GATEWAY_UPDATE_CODE),
     }
 }
 
 /// Get the installed version of a product using Windows registry.
-fn get_instaled_product_version_winreg(update_code: &str) -> Result<Option<DateVersion>, UpdaterError> {
+fn get_installed_product_version_winreg(update_code: &str) -> Result<Option<DateVersion>, UpdaterError> {
     let reversed_hex_uuid = uuid_to_reversed_hex(update_code)?;
 
     const REG_CURRENT_VERSION: &str = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion";

--- a/devolutions-agent/src/updater/error.rs
+++ b/devolutions-agent/src/updater/error.rs
@@ -19,8 +19,10 @@ pub(crate) enum UpdaterError {
     MsiCertHash { product: Product, msi_path: Utf8PathBuf },
     #[error("MSI for `{product}` is signed with invalid non-Devolutions certificate. Certificate thumbprint: `{thumbprint}`")]
     MsiCertificateThumbprint { product: Product, thumbprint: String },
-    #[error("failed to install `{product}` MSI. Path: `{msi_path}")]
+    #[error("failed to install `{product}` MSI. Path: `{msi_path}`")]
     MsiInstall { product: Product, msi_path: Utf8PathBuf },
+    #[error("failed to uninstall `{product}` MSI. Produc code: `{product_code}`")]
+    MsiUninstall { product: Product, product_code: String },
     #[error("ACL string `{acl}` is invalid")]
     AclString { acl: String },
     #[error("failed to set permissions for file: `{file_path}`")]

--- a/devolutions-agent/src/updater/mod.rs
+++ b/devolutions-agent/src/updater/mod.rs
@@ -210,13 +210,13 @@ async fn check_for_updates(product: Product, update_json: &UpdateJson) -> anyhow
 
     trace!(%product, %detected_version, "Detected installed product version");
 
-    let is_target_version_same_as_insatlled = match target_version {
+    let is_target_version_same_as_installed = match target_version {
         VersionSpecification::Latest => false,
         VersionSpecification::Specific(target) => target == detected_version,
     };
 
     // Early exit without checking remote database.
-    if is_target_version_same_as_insatlled {
+    if is_target_version_same_as_installed {
         info!(%product, %detected_version, "Product is up to date, skipping update");
         return Ok(None);
     }

--- a/devolutions-agent/src/updater/productinfo/db.rs
+++ b/devolutions-agent/src/updater/productinfo/db.rs
@@ -8,7 +8,7 @@ use crate::updater::UpdaterError;
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ProductInfo {
     pub version: String,
-    pub hash: String,
+    pub hash: Option<String>,
     pub url: String,
 }
 
@@ -31,13 +31,13 @@ impl FromStr for ProductInfoDb {
             let (product_id, property) = key.split_once('.').ok_or(UpdaterError::ProductInfo)?;
 
             let entry = records
-                .entry(product_id.to_string())
+                .entry(product_id.to_owned())
                 .or_insert_with(ProductInfo::default);
 
             match property {
-                "Version" => entry.version = value.to_string(),
-                "Url" => entry.url = value.to_string(),
-                "hash" => entry.hash = value.to_string(),
+                "Version" => entry.version = value.to_owned(),
+                "Url" => entry.url = value.to_owned(),
+                "hash" => entry.hash = Some(value.to_owned()),
                 _ => {
                     trace!(%product_id, %property, "Unknown productinfo property");
                     continue;
@@ -71,8 +71,8 @@ mod tests {
             "https://cdn.devolutions.net/download/DevolutionsGateway-x86_64-2024.2.1.0.msi"
         );
         assert_eq!(
-            db.get("Gatewaybin").unwrap().hash,
-            "BD2805075FCD78AC339126F4C4D9E6773DC3127CBE7DF48256D6910FA0C59C35"
+            db.get("Gatewaybin").unwrap().hash.as_deref(),
+            Some("BD2805075FCD78AC339126F4C4D9E6773DC3127CBE7DF48256D6910FA0C59C35")
         );
 
         assert_eq!(db.get("GatewaybinBeta").unwrap().version, "2024.2.1.0");
@@ -81,8 +81,8 @@ mod tests {
             "https://cdn.devolutions.net/download/DevolutionsGateway-x86_64-2024.2.1.0.msi"
         );
         assert_eq!(
-            db.get("GatewaybinBeta").unwrap().hash,
-            "BD2805075FCD78AC339126F4C4D9E6773DC3127CBE7DF48256D6910FA0C59C35"
+            db.get("GatewaybinBeta").unwrap().hash.as_deref(),
+            Some("BD2805075FCD78AC339126F4C4D9E6773DC3127CBE7DF48256D6910FA0C59C35")
         );
 
         assert_eq!(db.get("GatewaybinDebX64").unwrap().version, "2024.2.1.0");
@@ -91,8 +91,8 @@ mod tests {
             "https://cdn.devolutions.net/download/devolutions-gateway_2024.2.1.0_amd64.deb"
         );
         assert_eq!(
-            db.get("GatewaybinDebX64").unwrap().hash,
-            "72D7A836A6AF221D4E7631D27B91A358915CF985AA544CC0F7F5612B85E989AA"
+            db.get("GatewaybinDebX64").unwrap().hash.as_deref(),
+            Some("72D7A836A6AF221D4E7631D27B91A358915CF985AA544CC0F7F5612B85E989AA")
         );
 
         assert_eq!(db.get("GatewaybinDebX64Beta").unwrap().version, "2024.2.1.0");
@@ -101,8 +101,8 @@ mod tests {
             "https://cdn.devolutions.net/download/devolutions-gateway_2024.2.1.0_amd64.deb"
         );
         assert_eq!(
-            db.get("GatewaybinDebX64Beta").unwrap().hash,
-            "72D7A836A6AF221D4E7631D27B91A358915CF985AA544CC0F7F5612B85E989AA"
+            db.get("GatewaybinDebX64Beta").unwrap().hash.as_deref(),
+            Some("72D7A836A6AF221D4E7631D27B91A358915CF985AA544CC0F7F5612B85E989AA")
         );
 
         assert_eq!(db.get("DevoCLIbin").unwrap().version, "2023.3.0.0");
@@ -110,6 +110,6 @@ mod tests {
             db.get("DevoCLIbin").unwrap().url,
             "https://cdn.devolutions.net/download/DevoCLI.2023.3.0.0.zip"
         );
-        assert_eq!(db.get("DevoCLIbin").unwrap().hash, "");
+        assert_eq!(db.get("DevoCLIbin").unwrap().hash, None);
     }
 }

--- a/devolutions-agent/src/updater/uuid.rs
+++ b/devolutions-agent/src/updater/uuid.rs
@@ -39,7 +39,7 @@ pub(crate) fn uuid_to_reversed_hex(uuid: &str) -> Result<String, UpdaterError> {
     }
 
     if reversed_hex.len() != 32 || reversed_hex.chars().any(|ch| !UUID_ALPHABET.contains(&ch)) {
-        return Err(UpdaterError::Uuid { uuid: uuid.to_string() });
+        return Err(UpdaterError::Uuid { uuid: uuid.to_owned() });
     }
 
     Ok(reversed_hex)
@@ -50,7 +50,7 @@ pub(crate) fn uuid_to_reversed_hex(uuid: &str) -> Result<String, UpdaterError> {
 /// e.g.: `C3D81328F118D5D4A9287B3CB1707655` => `{82318d3c-811f-4d5d-9a82-b7c31b076755}`
 pub(crate) fn reversed_hex_to_uuid(mut hex: &str) -> Result<String, UpdaterError> {
     if hex.len() != 32 || hex.chars().any(|ch| !UUID_ALPHABET.contains(&ch)) {
-        return Err(UpdaterError::Uuid { uuid: hex.to_string() });
+        return Err(UpdaterError::Uuid { uuid: hex.to_owned() });
     }
 
     const FORMATTED_UUID_LEN: usize = UUID_CHARS

--- a/devolutions-agent/src/updater/uuid.rs
+++ b/devolutions-agent/src/updater/uuid.rs
@@ -62,13 +62,13 @@ pub(crate) fn reversed_hex_to_uuid(mut hex: &str) -> Result<String, UpdaterError
     formatted.push('{');
 
     // Hyphen pattern is not same as reversing pattern blocks.
-    const HYPEN_PATTERN: &[usize] = &[1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0];
+    const HYPHEN_PATTERN: &[usize] = &[1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0];
 
-    for (pattern, hypen) in UUID_REVERSING_PATTERN.iter().zip(HYPEN_PATTERN) {
+    for (pattern, hyphen) in UUID_REVERSING_PATTERN.iter().zip(HYPHEN_PATTERN) {
         let (part, rest) = hex.split_at(*pattern);
         formatted.extend(part.chars().rev());
 
-        if *hypen == 1 {
+        if *hyphen == 1 {
             formatted.push('-');
         }
         hex = rest;


### PR DESCRIPTION
This PR adds logic to allow arbitrary version upgrades for the devolutions gateway updater (previously we were only able to install the latest stable version) and also allows us to downgrade the product version.

However, currently, our MSI Installer [forbids ](https://github.com/Devolutions/devolutions-gateway/blob/fix/devolutions-updater-improvements/package/WindowsManaged/Program.cs#L209-L211)to perform the downgrade. MSI-related changes will be pushed in follow-up PR, as more in-depth manual testing is required for MSI. 

Additionally, multiple clippy fixes were performed in `updater` Agent module

JIRA Ticket: https://devolutions.atlassian.net/browse/DGW-233 (WIP)