### PR TITLE
refactor(jetsocat): use tracing for diagnostic outputs

### DIFF
--- a/jetsocat/src/doctor/common.rs
+++ b/jetsocat/src/doctor/common.rs
@@ -1,17 +1,15 @@
-use std::fmt::Write as _;
-
-use crate::doctor::macros::{diagnostic, output};
+use crate::doctor::macros::diagnostic;
 use crate::doctor::{Diagnostic, DiagnosticCtx};
 
 pub(super) fn run(callback: &mut dyn FnMut(Diagnostic) -> bool) {
     diagnostic!(callback, openssl_probe());
 }
 
-pub(crate) fn openssl_probe(ctx: &mut DiagnosticCtx) -> anyhow::Result<()> {
+pub(crate) fn openssl_probe(_: &mut DiagnosticCtx) -> anyhow::Result<()> {
     let result = openssl_probe::probe();
 
-    output!(ctx.out, "cert_file = {:?}", result.cert_file)?;
-    output!(ctx.out, "cert_dir = {:?}", result.cert_dir)?;
+    info!(cert_file = ?result.cert_file);
+    info!(cert_dir = ?result.cert_dir);
 
     Ok(())
 }

--- a/jetsocat/src/doctor/macros.rs
+++ b/jetsocat/src/doctor/macros.rs
@@ -4,14 +4,21 @@ macro_rules! diagnostic {
 
         let diagnostic_name = stringify!($name);
 
+        let trace = $crate::doctor::DiagnosticTrace::new();
+
         let mut ctx = DiagnosticCtx::default();
 
-        let result = $name ( &mut ctx, $( $arg ),* );
+        let result = {
+            let dispatcher = $crate::doctor::build_tracing_dispatcher(std::sync::Arc::clone(&trace));
+            tracing::dispatcher::with_default(&dispatcher, || $name ( &mut ctx, $( $arg ),* ))
+        };
+
+        let output = trace.finish();
 
         let diagnostic = Diagnostic {
             name: diagnostic_name.to_owned(),
             success: result.is_ok(),
-            output: (!ctx.out.is_empty()).then_some(ctx.out.trim_end().to_owned()),
+            output: (!output.is_empty()).then_some(output.trim_end().to_owned()),
             error: result.as_ref().err().map(|e| format!("{:?}", e)),
             help: ctx.help,
             links: ctx.links,
@@ -26,11 +33,3 @@ macro_rules! diagnostic {
 }
 
 pub(crate) use diagnostic;
-
-macro_rules! output {
-    ( $dst:expr, $($arg:tt)* ) => {
-        anyhow::Context::context(writeln!( $dst, $($arg)* ), "write output")
-    };
-}
-
-pub(crate) use output;

--- a/jetsocat/src/doctor/mod.rs
+++ b/jetsocat/src/doctor/mod.rs
@@ -169,7 +169,6 @@ impl Link {
 
 #[derive(Default)]
 struct DiagnosticCtx {
-    out: String,
     help: Option<String>,
     links: Vec<Link>,
 }
@@ -188,11 +187,14 @@ impl DiagnosticCtx {
     }
 }
 
-fn write_cert_as_pem(mut out: impl fmt::Write, cert_der: &[u8]) -> fmt::Result {
+fn cert_to_pem(cert_der: &[u8]) -> Result<String, std::fmt::Error> {
     use base64::engine::general_purpose::STANDARD;
     use base64::Engine as _;
+    use std::fmt::Write as _;
 
     let body = STANDARD.encode(cert_der);
+
+    let mut out = String::new();
 
     write!(out, "------BEGIN CERTIFICATE------")?;
 
@@ -206,5 +208,45 @@ fn write_cert_as_pem(mut out: impl fmt::Write, cert_der: &[u8]) -> fmt::Result {
 
     writeln!(out, "\n------END CERTIFICATE------")?;
 
-    Ok(())
+    Ok(out)
+}
+
+struct DiagnosticTrace(std::sync::Mutex<Vec<u8>>);
+
+impl DiagnosticTrace {
+    fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self(std::sync::Mutex::new(Vec::new())))
+    }
+
+    fn finish(self: std::sync::Arc<Self>) -> String {
+        let trace = std::sync::Arc::into_inner(self).expect("call finish when you are done logging");
+        let inner = trace.0.into_inner().expect("poisoned");
+        String::from_utf8(inner).expect("only write UTF-8")
+    }
+}
+
+impl std::io::Write for &DiagnosticTrace {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("poisoned").write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn build_tracing_dispatcher(trace: std::sync::Arc<DiagnosticTrace>) -> tracing::Dispatch {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let filter = EnvFilter::try_from_env("JETSOCAT_LOG").unwrap_or_else(|_| EnvFilter::new("debug"));
+
+    let subscriber = fmt::Subscriber::builder()
+        .with_ansi(false)
+        .with_env_filter(filter)
+        .with_target(false)
+        .without_time()
+        .with_writer(trace)
+        .finish();
+
+    tracing::dispatcher::Dispatch::new(subscriber)
 }

--- a/jetsocat/src/doctor/native_tls.rs
+++ b/jetsocat/src/doctor/native_tls.rs
@@ -1,8 +1,7 @@
 use anyhow::Context as _;
-use std::fmt::Write as _;
 
-use crate::doctor::macros::{diagnostic, output};
-use crate::doctor::{help, write_cert_as_pem, Args, Diagnostic, DiagnosticCtx};
+use crate::doctor::macros::diagnostic;
+use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx};
 
 pub(crate) fn run(args: &Args, callback: &mut dyn FnMut(Diagnostic) -> bool) {
     #[cfg(not(windows))]
@@ -22,7 +21,7 @@ fn native_tls_connect(ctx: &mut DiagnosticCtx, subject_name: &str, port: Option<
     use native_tls::TlsConnector;
     use std::net::TcpStream;
 
-    output!(ctx.out, "-> Connect to {subject_name}")?;
+    info!("Connect to {subject_name}");
 
     let connector = TlsConnector::new().context("failed to build TLS connector")?;
 
@@ -30,7 +29,7 @@ fn native_tls_connect(ctx: &mut DiagnosticCtx, subject_name: &str, port: Option<
         .inspect_err(|_| help::failed_to_connect_to_server(ctx, subject_name))
         .context("failed to connect to server...")?;
 
-    output!(ctx.out, "-> Perform TLS handshake")?;
+    info!("Perform TLS handshake");
 
     let tls_stream = connector
         .connect(subject_name, socket)
@@ -42,10 +41,7 @@ fn native_tls_connect(ctx: &mut DiagnosticCtx, subject_name: &str, port: Option<
         })
         .context("TLS connection failed")?;
 
-    output!(
-        ctx.out,
-        "-> NOTE: We can't retrieve the certification chain using the API exposed by native-tls and schannel crates"
-    )?;
+    warn!("We can't retrieve the certification chain using the API exposed by native-tls and schannel crates");
 
     let peer_certificate = tls_stream
         .peer_certificate()
@@ -53,8 +49,9 @@ fn native_tls_connect(ctx: &mut DiagnosticCtx, subject_name: &str, port: Option<
         .context("no peer certificate attached to the TLS stream")?;
     let peer_certificate = peer_certificate.to_der().context("peer certificate der conversion")?;
 
-    output!(ctx.out, "-> Peer certificate:")?;
-    write_cert_as_pem(&mut ctx.out, &peer_certificate).context("failed to write the peer certificate as PEM")?;
+    info!("Peer certificate:");
+    let cert_pem = cert_to_pem(&peer_certificate).context("failed to write the peer certificate as PEM")?;
+    info!("{cert_pem}");
 
     Ok(())
 }
@@ -127,11 +124,10 @@ fn parse_tls_connect_error_string(_ctx: &mut DiagnosticCtx, _error: &native_tls:
 mod openssl {
     use anyhow::Context as _;
     use openssl::x509::X509;
-    use std::fmt::Write as _;
     use std::path::Path;
 
-    use crate::doctor::macros::{diagnostic, output};
-    use crate::doctor::{help, write_cert_as_pem, Args, Diagnostic, DiagnosticCtx};
+    use crate::doctor::macros::diagnostic;
+    use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx};
 
     pub(super) fn run(args: &Args, callback: &mut dyn FnMut(Diagnostic) -> bool) {
         let mut server_certificates = Vec::new();
@@ -168,7 +164,7 @@ mod openssl {
         use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
         use std::net::TcpStream;
 
-        output!(ctx.out, "-> Connect to {subject_name}")?;
+        info!("Connect to {subject_name}");
 
         let mut builder = SslConnector::builder(SslMethod::tls_client()).context("failed to create SSL builder")?;
         builder.set_verify(SslVerifyMode::NONE);
@@ -178,7 +174,7 @@ mod openssl {
             .inspect_err(|_| help::failed_to_connect_to_server(ctx, subject_name))
             .context("failed to connect to server...")?;
 
-        output!(ctx.out, "-> Fetch server certificates")?;
+        info!("Fetch server certificates");
 
         let stream = connector
             .connect(subject_name, socket)
@@ -192,7 +188,8 @@ mod openssl {
             .context("peer certification chain missing from SSL context")?
         {
             let der = certificate.to_der().context("certificate.to_der()")?;
-            write_cert_as_pem(&mut ctx.out, &der).context("failed to write the peer chain as PEM")?;
+            let cert_pem = cert_to_pem(&der).context("failed to write the peer chain as PEM")?;
+            info!("{cert_pem}");
             server_certificates.push(certificate.to_owned());
         }
 
@@ -211,7 +208,7 @@ mod openssl {
         chain_path: &Path,
         server_certificates: &mut Vec<X509>,
     ) -> anyhow::Result<()> {
-        output!(ctx.out, "-> Read file at {}", chain_path.display())?;
+        info!("Read file at {}", chain_path.display());
 
         let mut file = std::fs::File::open(chain_path)
             .map(std::io::BufReader::new)
@@ -219,8 +216,9 @@ mod openssl {
 
         for (idx, certificate) in rustls_pemfile::certs(&mut file).enumerate() {
             let certificate = certificate.with_context(|| format!("failed to read certificate number {idx}"))?;
-            write_cert_as_pem(&mut ctx.out, &certificate)
+            let cert_pem = cert_to_pem(&certificate)
                 .with_context(|| format!("failed to write certificate number {idx} as PEM"))?;
+            info!("{cert_pem}");
             let certificate = X509::from_der(&certificate).context("X509::from_der")?;
             server_certificates.push(certificate);
         }
@@ -244,7 +242,7 @@ mod openssl {
             .first()
             .context("end entity certificate is missing")?;
 
-        output!(ctx.out, "-> Inspect the end entity certificate")?;
+        info!("Inspect the end entity certificate");
 
         let mut certificate_names = Vec::new();
 
@@ -277,10 +275,10 @@ mod openssl {
         }
 
         for value in &certificate_names {
-            output!(ctx.out, "-> Found name: {value}")?;
+            info!("Found name: {value}");
         }
 
-        output!(ctx.out, "-> Verify validity for subject name {subject_name_to_verify}")?;
+        info!("Verify validity for subject name {subject_name_to_verify}");
 
         let success = certificate_names
             .into_iter()
@@ -314,7 +312,7 @@ mod openssl {
         use openssl::stack::Stack;
         use openssl::x509::{X509StoreContext, X509VerifyResult};
 
-        output!(ctx.out, "-> Create SSL context")?;
+        info!("Create SSL context");
 
         let connector = SslConnector::builder(SslMethod::tls_client())
             .context("failed to create SSL builder")?
@@ -328,7 +326,7 @@ mod openssl {
         let ssl_context = ssl.ssl_context();
         let store = ssl_context.cert_store();
 
-        output!(ctx.out, "-> Verify chain")?;
+        info!("Verify chain");
 
         let mut store_context = X509StoreContext::new().context("failed to create X509 store context")?;
 


### PR DESCRIPTION
This is a more convenient approach that benefits a lot the future schannel implementation I’m working on.