### PR TITLE
fix(jetsocat): (also) return one link per certificate

### DIFF
--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [features]
-default = ["rustls", "detect-proxy"]
+default = ["rustls", "detect-proxy", "native-tls"]
 detect-proxy = ["proxy_cfg"]
 rustls = ["tokio-tungstenite/rustls-tls-native-roots", "dep:rustls", "dep:rustls-native-certs"]
 native-tls = ["tokio-tungstenite/native-tls", "dep:openssl", "dep:native-tls"]

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [features]
-default = ["rustls", "detect-proxy", "native-tls"]
+default = ["rustls", "detect-proxy"]
 detect-proxy = ["proxy_cfg"]
 rustls = ["tokio-tungstenite/rustls-tls-native-roots", "dep:rustls", "dep:rustls-native-certs"]
 native-tls = ["tokio-tungstenite/native-tls", "dep:openssl", "dep:native-tls"]

--- a/jetsocat/src/doctor/help.rs
+++ b/jetsocat/src/doctor/help.rs
@@ -1,4 +1,4 @@
-use crate::doctor::{CertInfo, DiagnosticCtx};
+use crate::doctor::{DiagnosticCtx, InspectCert};
 
 pub(crate) fn failed_to_connect_to_server(ctx: &mut DiagnosticCtx, hostname: &str) {
     ctx.attach_help(format!(
@@ -72,7 +72,7 @@ You need to generate a separate certificate valid for server authentication."
 pub(crate) fn x509_io_link<C>(ctx: &mut DiagnosticCtx, certs: C)
 where
     C: Iterator,
-    C::Item: CertInfo,
+    C::Item: InspectCert,
 {
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;

--- a/jetsocat/src/doctor/mod.rs
+++ b/jetsocat/src/doctor/mod.rs
@@ -325,6 +325,16 @@ impl<T: CertInfo> CertInfo for &T {
     }
 }
 
+impl CertInfo for ::rustls::pki_types::CertificateDer<'_> {
+    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        Ok(Cow::Borrowed(self))
+    }
+
+    fn friendly_name(&self) -> Option<Cow<'_, str>> {
+        None
+    }
+}
+
 #[cfg_attr(not(windows), expect(unused))]
 struct CertProxy {
     pub friendly_name: Option<String>,

--- a/jetsocat/src/doctor/mod.rs
+++ b/jetsocat/src/doctor/mod.rs
@@ -325,16 +325,6 @@ impl<T: InspectCert> InspectCert for &T {
     }
 }
 
-impl InspectCert for ::rustls::pki_types::CertificateDer<'_> {
-    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
-        Ok(Cow::Borrowed(self))
-    }
-
-    fn friendly_name(&self) -> Option<Cow<'_, str>> {
-        None
-    }
-}
-
 #[cfg_attr(not(windows), expect(unused))]
 struct CertInspectProxy {
     pub friendly_name: Option<String>,

--- a/jetsocat/src/doctor/mod.rs
+++ b/jetsocat/src/doctor/mod.rs
@@ -9,7 +9,7 @@ mod rustls;
 mod schannel;
 
 use core::fmt;
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf};
 
 use tinyjson::JsonValue;
 
@@ -218,6 +218,41 @@ fn cert_to_pem(cert_der: &[u8]) -> Result<String, std::fmt::Error> {
     Ok(out)
 }
 
+fn log_cert<C>(cert_idx: usize, cert: C) -> anyhow::Result<()>
+where
+    C: CertInfo,
+{
+    use anyhow::Context as _;
+
+    let friendly_name = if let Some(name) = cert.friendly_name() {
+        name
+    } else {
+        Cow::Owned(String::from("???"))
+    };
+    info!(cert_idx, cert_name = %friendly_name);
+
+    let cert_der = cert
+        .der()
+        .with_context(|| format!("failed to retrieve DER encoding for certificate number {cert_idx}"))?;
+    let cert_pem =
+        cert_to_pem(&cert_der).with_context(|| format!("failed to write certificate number {cert_idx} as PEM"))?;
+    info!("{cert_pem}");
+
+    Ok(())
+}
+
+fn log_chain<C>(certs: C)
+where
+    C: Iterator,
+    C::Item: CertInfo,
+{
+    for (cert_idx, cert) in certs.enumerate() {
+        if let Err(e) = log_cert(cert_idx, cert) {
+            warn!(error = format!("{e:#}"), "Failed to log certificate");
+        }
+    }
+}
+
 struct DiagnosticTrace(std::sync::Mutex<Vec<u8>>);
 
 impl DiagnosticTrace {
@@ -272,5 +307,36 @@ fn wildcard_host_match(wildcard_host: &str, actual_host: &str) -> bool {
             (None, None) => return true,
             _ => return false,
         }
+    }
+}
+
+trait CertInfo {
+    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>>;
+    fn friendly_name(&self) -> Option<Cow<'_, str>>;
+}
+
+impl<T: CertInfo> CertInfo for &T {
+    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        (*self).der()
+    }
+
+    fn friendly_name(&self) -> Option<Cow<'_, str>> {
+        (*self).friendly_name()
+    }
+}
+
+#[cfg_attr(not(windows), expect(unused))]
+struct CertProxy {
+    pub friendly_name: Option<String>,
+    pub der: Vec<u8>,
+}
+
+impl CertInfo for CertProxy {
+    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        Ok(Cow::Borrowed(&self.der))
+    }
+
+    fn friendly_name(&self) -> Option<Cow<'_, str>> {
+        self.friendly_name.as_deref().map(Cow::Borrowed)
     }
 }

--- a/jetsocat/src/doctor/native_tls.rs
+++ b/jetsocat/src/doctor/native_tls.rs
@@ -128,7 +128,7 @@ mod openssl {
     use std::path::Path;
 
     use crate::doctor::macros::diagnostic;
-    use crate::doctor::{help, Args, CertInfo, Diagnostic, DiagnosticCtx};
+    use crate::doctor::{help, Args, Diagnostic, DiagnosticCtx, InspectCert};
 
     pub(super) fn run(args: &Args, callback: &mut dyn FnMut(Diagnostic) -> bool) {
         let mut server_certificates = Vec::new();
@@ -345,7 +345,7 @@ To resolve this issue, you can:
 - Obtain and use a certificate signed by a legitimate certification authority.");
     }
 
-    impl CertInfo for X509 {
+    impl InspectCert for X509 {
         fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
             let der = self.to_der()?;
             Ok(Cow::Owned(der))

--- a/jetsocat/src/doctor/native_tls.rs
+++ b/jetsocat/src/doctor/native_tls.rs
@@ -124,10 +124,11 @@ fn parse_tls_connect_error_string(_ctx: &mut DiagnosticCtx, _error: &native_tls:
 mod openssl {
     use anyhow::Context as _;
     use openssl::x509::X509;
+    use std::borrow::Cow;
     use std::path::Path;
 
     use crate::doctor::macros::diagnostic;
-    use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx};
+    use crate::doctor::{help, Args, CertInfo, Diagnostic, DiagnosticCtx};
 
     pub(super) fn run(args: &Args, callback: &mut dyn FnMut(Diagnostic) -> bool) {
         let mut server_certificates = Vec::new();
@@ -187,18 +188,11 @@ mod openssl {
             .peer_cert_chain()
             .context("peer certification chain missing from SSL context")?
         {
-            let der = certificate.to_der().context("certificate.to_der()")?;
-            let cert_pem = cert_to_pem(&der).context("failed to write the peer chain as PEM")?;
-            info!("{cert_pem}");
             server_certificates.push(certificate.to_owned());
         }
 
-        help::x509_io_link(
-            ctx,
-            server_certificates
-                .iter()
-                .map(|cert| cert.to_der().expect("checked above")),
-        );
+        crate::doctor::log_chain(server_certificates.iter());
+        help::x509_io_link(ctx, server_certificates.iter());
 
         Ok(())
     }
@@ -216,19 +210,12 @@ mod openssl {
 
         for (idx, certificate) in rustls_pemfile::certs(&mut file).enumerate() {
             let certificate = certificate.with_context(|| format!("failed to read certificate number {idx}"))?;
-            let cert_pem = cert_to_pem(&certificate)
-                .with_context(|| format!("failed to write certificate number {idx} as PEM"))?;
-            info!("{cert_pem}");
             let certificate = X509::from_der(&certificate).context("X509::from_der")?;
             server_certificates.push(certificate);
         }
 
-        help::x509_io_link(
-            ctx,
-            server_certificates
-                .iter()
-                .map(|cert| cert.to_der().expect("checked above")),
-        );
+        crate::doctor::log_chain(server_certificates.iter());
+        help::x509_io_link(ctx, server_certificates.iter());
 
         Ok(())
     }
@@ -356,5 +343,28 @@ It is generally considered a bad practice to use self-signed certificates, becau
 To resolve this issue, you can:
 - Trust the self-signed certificate on your system, if you know what you are doing.
 - Obtain and use a certificate signed by a legitimate certification authority.");
+    }
+
+    impl CertInfo for X509 {
+        fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+            let der = self.to_der()?;
+            Ok(Cow::Owned(der))
+        }
+
+        fn friendly_name(&self) -> Option<Cow<'_, str>> {
+            let mut friendly_name = String::new();
+
+            self.subject_name().entries().enumerate().for_each(|(idx, entry)| {
+                if idx > 0 {
+                    friendly_name.push(' ');
+                }
+
+                if let Ok(name) = entry.data().as_utf8() {
+                    friendly_name.push_str(&name);
+                }
+            });
+
+            Some(Cow::Owned(friendly_name))
+        }
     }
 }

--- a/jetsocat/src/doctor/rustls.rs
+++ b/jetsocat/src/doctor/rustls.rs
@@ -1,10 +1,11 @@
 use anyhow::Context as _;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::{pki_types, DigitallySignedStruct, Error, SignatureScheme};
+use std::borrow::Cow;
 use std::path::Path;
 
 use crate::doctor::macros::diagnostic;
-use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx};
+use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx, InspectCert};
 
 pub(super) fn run(args: &Args, callback: &mut dyn FnMut(Diagnostic) -> bool) {
     let mut root_store = rustls::RootCertStore::empty();
@@ -192,6 +193,16 @@ fn rustls_check_chain(
     .context("failed to verify certification chain")?;
 
     Ok(())
+}
+
+impl InspectCert for pki_types::CertificateDer<'_> {
+    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
+        Ok(Cow::Borrowed(self))
+    }
+
+    fn friendly_name(&self) -> Option<Cow<'_, str>> {
+        None
+    }
 }
 
 #[derive(Debug)]

--- a/jetsocat/src/doctor/rustls.rs
+++ b/jetsocat/src/doctor/rustls.rs
@@ -1,11 +1,10 @@
 use anyhow::Context as _;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::{pki_types, DigitallySignedStruct, Error, SignatureScheme};
-use std::borrow::Cow;
 use std::path::Path;
 
 use crate::doctor::macros::diagnostic;
-use crate::doctor::{cert_to_pem, help, Args, CertInfo, Diagnostic, DiagnosticCtx};
+use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx};
 
 pub(super) fn run(args: &Args, callback: &mut dyn FnMut(Diagnostic) -> bool) {
     let mut root_store = rustls::RootCertStore::empty();

--- a/jetsocat/src/doctor/rustls.rs
+++ b/jetsocat/src/doctor/rustls.rs
@@ -246,13 +246,3 @@ impl ServerCertVerifier for NoCertificateVerification {
         ]
     }
 }
-
-impl CertInfo for pki_types::CertificateDer<'_> {
-    fn der(&self) -> anyhow::Result<Cow<'_, [u8]>> {
-        Ok(Cow::Borrowed(self))
-    }
-
-    fn friendly_name(&self) -> Option<Cow<'_, str>> {
-        None
-    }
-}

--- a/jetsocat/src/doctor/schannel.rs
+++ b/jetsocat/src/doctor/schannel.rs
@@ -10,7 +10,7 @@ use windows::Win32::Security::{Credentials, Cryptography};
 use wrapper::ScopeGuard;
 
 use crate::doctor::macros::diagnostic;
-use crate::doctor::{help, Args, CertProxy, Diagnostic, DiagnosticCtx};
+use crate::doctor::{help, Args, CertInspectProxy, Diagnostic, DiagnosticCtx};
 
 struct ChainCtx {
     store: wrapper::CertStore,
@@ -318,7 +318,7 @@ fn schannel_fetch_chain(
             warn!(cert_idx, %error, "Failed to add certificate to the store");
         }
 
-        certificates.push(CertProxy {
+        certificates.push(CertInspectProxy {
             friendly_name: element.cert.subject_friendly_name().ok(),
             der: element.cert.as_x509_der().to_owned(),
         });

--- a/jetsocat/src/doctor/schannel.rs
+++ b/jetsocat/src/doctor/schannel.rs
@@ -867,7 +867,7 @@ mod wrapper {
         }
 
         #[expect(clippy::similar_names)] // pp and p are close, but this is fine.
-        pub(super) fn for_each(&self, mut f: impl FnMut(usize, &ChainElement<'store>)) {
+        pub(super) fn for_each(&self, mut f: impl for<'cert> FnMut(usize, &ChainElement<'store, 'cert>)) {
             // SAFETY: Pointer is valid per invariants.
             let chain_context: &Cryptography::CERT_CHAIN_CONTEXT = unsafe { &*self.ptr };
 
@@ -917,13 +917,13 @@ mod wrapper {
                         continue;
                     }
 
-                    let borrowed_cert_context = CertContextRef {
+                    let cert_context = CertContextRef {
                         ptr: p_cert_context,
                         _marker: std::marker::PhantomData,
                     };
 
                     let chain_element = ChainElement {
-                        cert: borrowed_cert_context,
+                        cert: &cert_context,
                         trust_status: chain_element.TrustStatus,
                     };
 
@@ -940,8 +940,8 @@ mod wrapper {
         }
     }
 
-    pub(super) struct ChainElement<'store> {
-        pub cert: CertContextRef<'store>,
+    pub(super) struct ChainElement<'store, 'cert> {
+        pub cert: &'cert CertContextRef<'store>,
         pub trust_status: Cryptography::CERT_TRUST_STATUS,
     }
 

--- a/jetsocat/src/doctor/schannel.rs
+++ b/jetsocat/src/doctor/schannel.rs
@@ -10,7 +10,7 @@ use windows::Win32::Security::{Credentials, Cryptography};
 use wrapper::ScopeGuard;
 
 use crate::doctor::macros::diagnostic;
-use crate::doctor::{cert_to_pem, help, Args, Diagnostic, DiagnosticCtx};
+use crate::doctor::{help, Args, CertProxy, Diagnostic, DiagnosticCtx};
 
 struct ChainCtx {
     store: wrapper::CertStore,
@@ -301,8 +301,8 @@ fn schannel_fetch_chain(
         }
     }
 
-    let remote_end_entity_cert = wrapper::OwnedCertContext::schannel_remote_cert(ctx_handle.as_ref())
-        .context("failed to retrieve remote cert")?;
+    let remote_end_entity_cert =
+        wrapper::CertContext::schannel_remote_cert(ctx_handle.as_ref()).context("failed to retrieve remote cert")?;
 
     // Update the end entity info of the chain context.
     chain_ctx.end_entity_info = remote_end_entity_cert.to_info();
@@ -314,26 +314,17 @@ fn schannel_fetch_chain(
     let mut certificates = Vec::new();
 
     remote_chain.for_each(|cert_idx, element| {
-        let cert_name = if let Ok(name) = element.cert.subject_friendly_name() {
-            name
-        } else {
-            String::from("?")
-        };
-
-        info!(cert_idx, cert_name);
-
-        match cert_to_pem(element.cert.as_x509_der()) {
-            Ok(cert_pem) => info!("{cert_pem}"),
-            Err(error) => warn!(cert_idx, %error, "Failed to write certificate as PEM"),
-        }
-
         if let Err(error) = chain_ctx.store.add_x509_encoded_certificate(element.cert.as_x509_der()) {
             warn!(cert_idx, %error, "Failed to add certificate to the store");
         }
 
-        certificates.push(element.cert.as_x509_der().to_owned());
+        certificates.push(CertProxy {
+            friendly_name: element.cert.subject_friendly_name().ok(),
+            der: element.cert.as_x509_der().to_owned(),
+        });
     });
 
+    crate::doctor::log_chain(certificates.iter());
     help::x509_io_link(ctx, certificates.iter());
 
     return Ok(());
@@ -373,10 +364,6 @@ fn schannel_read_chain(ctx: &mut DiagnosticCtx, chain_path: &Path, chain_ctx: &m
     for (idx, certificate) in rustls_pemfile::certs(&mut file).enumerate() {
         let certificate = certificate.with_context(|| format!("failed to read certificate number {idx}"))?;
 
-        let cert_pem =
-            cert_to_pem(&certificate).with_context(|| format!("failed to write certificate number {idx} as PEM"))?;
-        info!("{cert_pem}");
-
         chain_ctx
             .store
             .add_x509_encoded_certificate(&certificate)
@@ -385,6 +372,7 @@ fn schannel_read_chain(ctx: &mut DiagnosticCtx, chain_path: &Path, chain_ctx: &m
         certificates.push(certificate);
     }
 
+    crate::doctor::log_chain(certificates.iter());
     help::x509_io_link(ctx, certificates.iter());
 
     Ok(())
@@ -601,7 +589,9 @@ mod wrapper {
             Ok(Self { ptr: cert_store })
         }
 
-        pub(super) fn add_x509_encoded_certificate(&mut self, cert: &[u8]) -> windows::core::Result<()> {
+        pub(super) fn add_x509_encoded_certificate(&mut self, cert: &[u8]) -> windows::core::Result<CertContext<'_>> {
+            let mut cert_ctx: *mut Cryptography::CERT_CONTEXT = ptr::null_mut();
+
             // SAFETY: FFI call with no outstanding preconditions.
             unsafe {
                 Cryptography::CertAddEncodedCertificateToStore(
@@ -609,14 +599,17 @@ mod wrapper {
                     Cryptography::X509_ASN_ENCODING,
                     cert,
                     Cryptography::CERT_STORE_ADD_ALWAYS,
-                    None,
+                    Some(&mut cert_ctx),
                 )?;
             }
 
-            Ok(())
+            Ok(CertContext {
+                ptr: cert_ctx,
+                _marker: core::marker::PhantomData,
+            })
         }
 
-        pub(super) fn fetch_certificate(&self, info: &CertInfo) -> windows::core::Result<OwnedCertContext<'_>> {
+        pub(super) fn fetch_certificate(&self, info: &CertInfo) -> windows::core::Result<CertContext<'_>> {
             let serial_number_blob = Cryptography::CRYPT_INTEGER_BLOB {
                 cbData: u32::try_from(info.serial.len()).expect("usize-to-u32"),
                 pbData: info.serial.as_ptr().cast_mut(),
@@ -643,12 +636,9 @@ mod wrapper {
             if ptr.is_null() {
                 Err(windows::core::Error::from_win32())
             } else {
-                Ok(OwnedCertContext {
+                Ok(CertContext {
                     ptr,
-                    borrowed: BorrowedCertContext {
-                        ptr: ptr.cast_const(),
-                        _marker: core::marker::PhantomData,
-                    },
+                    _marker: core::marker::PhantomData,
                 })
             }
         }
@@ -665,13 +655,14 @@ mod wrapper {
         }
     }
 
-    pub(super) struct BorrowedCertContext<'store> {
+    #[repr(transparent)]
+    pub(super) struct CertContextRef<'store> {
         /// INVARIANT: A valid pointer to a properly initialized CERT_CONTEXT.
         ptr: *const Cryptography::CERT_CONTEXT,
         _marker: core::marker::PhantomData<&'store CertStore>,
     }
 
-    impl BorrowedCertContext<'_> {
+    impl CertContextRef<'_> {
         pub(super) fn as_x509_der(&self) -> &[u8] {
             // SAFETY: Pointer is valid per invariant.
             let cert_context = unsafe { self.ptr.read() };
@@ -805,13 +796,14 @@ mod wrapper {
         }
     }
 
-    pub(super) struct OwnedCertContext<'store> {
+    #[repr(transparent)]
+    pub(super) struct CertContext<'store> {
         /// INVARIANT: A valid pointer to a properly initialized CERT_CONTEXT.
         ptr: *mut Cryptography::CERT_CONTEXT,
-        borrowed: BorrowedCertContext<'store>,
+        _marker: core::marker::PhantomData<&'store CertStore>,
     }
 
-    impl<'store> OwnedCertContext<'store> {
+    impl<'store> CertContext<'store> {
         pub(super) fn schannel_remote_cert(ctx_handle: &'store Credentials::SecHandle) -> windows::core::Result<Self> {
             let mut cert_ctx: *mut Cryptography::CERT_CONTEXT = ptr::null_mut();
 
@@ -831,15 +823,12 @@ mod wrapper {
 
             Ok(Self {
                 ptr: cert_ctx,
-                borrowed: BorrowedCertContext {
-                    ptr: cert_ctx.cast_const(),
-                    _marker: std::marker::PhantomData,
-                },
+                _marker: std::marker::PhantomData,
             })
         }
     }
 
-    impl Drop for OwnedCertContext<'_> {
+    impl Drop for CertContext<'_> {
         fn drop(&mut self) {
             // SAFETY: The CERT_CONTEXT handle is owned by us.
             let ret = unsafe { Cryptography::CertFreeCertificateContext(Some(self.ptr)) };
@@ -851,11 +840,16 @@ mod wrapper {
         }
     }
 
-    impl<'store> std::ops::Deref for OwnedCertContext<'store> {
-        type Target = BorrowedCertContext<'store>;
+    impl<'store> std::ops::Deref for CertContext<'store> {
+        type Target = CertContextRef<'store>;
 
         fn deref(&self) -> &Self::Target {
-            &self.borrowed
+            debug_assert!(!self.ptr.is_null());
+
+            // SAFETY:
+            // - Both CertContext and CertContextRef are #[repr(transparent)] over a raw pointer on a CERT_CONTEXT.
+            // - Per invariants, the pointers are on valid CERT_CONTEXT.
+            unsafe { &*(self as *const _ as *const CertContextRef<'_>) }
         }
     }
 
@@ -923,7 +917,7 @@ mod wrapper {
                         continue;
                     }
 
-                    let borrowed_cert_context = BorrowedCertContext {
+                    let borrowed_cert_context = CertContextRef {
                         ptr: p_cert_context,
                         _marker: std::marker::PhantomData,
                     };
@@ -947,7 +941,7 @@ mod wrapper {
     }
 
     pub(super) struct ChainElement<'store> {
-        pub cert: BorrowedCertContext<'store>,
+        pub cert: CertContextRef<'store>,
         pub trust_status: Cryptography::CERT_TRUST_STATUS,
     }
 


### PR DESCRIPTION
Make jetsocat doctor return one link per certificate in addition to the chain link.

Issue: DGW-235