### PR TITLE
docs: reword "blazing fast" to "blazingly fast"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/Devolutions/devolutions-gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/Devolutions/devolutions-gateway/actions/workflows/ci.yml)
 
-A blazing fast relay server adaptable to different protocols and desired levels of traffic inspection.
+A blazingly fast relay server adaptable to different protocols and desired levels of traffic inspection.
 
 ## Install
 

--- a/package/Windows/DevolutionsGateway_en-us.wxl
+++ b/package/Windows/DevolutionsGateway_en-us.wxl
@@ -4,7 +4,7 @@
    <!-- Supported language and codepage codes can be found here: http://www.tramontana.co.hu/wix/lesson2.php#2.4 -->
    <String Id="VendorName">Devolutions</String>
    <String Id="VendorFullName">Devolutions Inc.</String>
-   <String Id="ProductDescription">A blazing fast relay server adaptable to different protocols and desired levels of traffic inspection.</String>
+   <String Id="ProductDescription">A blazingly fast relay server adaptable to different protocols and desired levels of traffic inspection.</String>
    <String Id="OS2Old">This product requires at least Windows 8 / Windows Server 2012 R2</String>
    <String Id="NewerInstalled">A newer version of this product is already installed.</String>
    <String Id="x64VersionRequired">You need to install the 64-bit version of this product on 64-bit Windows.</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
@@ -2,7 +2,7 @@
 <WixLocalization Culture="en-us" Codepage="1252" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
         <!-- metadata -->
                 <String Id="Language">1033</String>
-                <String Id="ProductDescription">A blazing fast relay server adaptable to different protocols and desired levels of traffic inspection.</String>
+                <String Id="ProductDescription">A blazingly fast relay server adaptable to different protocols and desired levels of traffic inspection.</String>
                 <String Id="VendorFullName">Devolutions Inc.</String>
                 <String Id="VendorName">Devolutions</String>
                     <!-- messages -->

--- a/package/WindowsManaged/Resources/Strings.g.cs
+++ b/package/WindowsManaged/Resources/Strings.g.cs
@@ -21,7 +21,7 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string VendorFullName = "VendorFullName";		
 		/// <summary>
-		/// A blazing fast relay server adaptable to different protocols and desired levels of traffic inspection.
+		/// A blazingly fast relay server adaptable to different protocols and desired levels of traffic inspection.
 		/// </summary>
 		public const string ProductDescription = "ProductDescription";		
 		/// <summary>

--- a/package/WindowsManaged/Resources/Strings_en-US.json
+++ b/package/WindowsManaged/Resources/Strings_en-US.json
@@ -16,7 +16,7 @@
         },
         {
           "id": "ProductDescription",
-          "text": "A blazing fast relay server adaptable to different protocols and desired levels of traffic inspection."
+          "text": "A blazingly fast relay server adaptable to different protocols and desired levels of traffic inspection."
         }
       ],
       "messages": [


### PR DESCRIPTION
Although both are gramatically correct, the adverb is more idiomatically Rusty.

`git blame 4bcb1aa2 -L 5,5 README.md`
```
^4a744f8b (Marc-André Moreau    2018-12-18 13:39:54 -0500   5) A blazing fast relay server adaptable to different protocols and desired levels of traffic inspection.
```