### PR TITLE
fix(installer): preserve Agent features across upgrades

### DIFF
--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -37,7 +37,7 @@ namespace DevolutionsAgent.Actions
         {
             uint version = session.Get(AgentProperties.netFx45Version);
 
-            if (version < 394802) //4.6.2
+            if (version < 528040) // 4.8
             {
                 session.Log($"netfx45 version: {version} is too old");
                 return ActionResult.Failure;

--- a/package/AgentWindowsManaged/Helpers/AppSearch.cs
+++ b/package/AgentWindowsManaged/Helpers/AppSearch.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using DevolutionsAgent.Resources;
+using Microsoft.Deployment.WindowsInstaller;
+using System;
+using System.Collections.Generic;
 using System.Linq;
-using DevolutionsAgent.Resources;
 
 namespace DevolutionsAgent.Helpers
 {
@@ -11,5 +13,11 @@ namespace DevolutionsAgent.Helpers
                 .Where(productCode => WixSharp.CommonTasks.AppSearch.GetProductName(productCode)?.Equals(Includes.PRODUCT_NAME) ?? false)
                 .Select(WixSharp.CommonTasks.AppSearch.GetProductVersion)
                 .FirstOrDefault();
+
+        internal static IEnumerable<FeatureInstallation> InstalledFeatures =>
+            ProductInstallation.GetRelatedProducts("{" + Includes.UPGRADE_CODE + "}")
+                .Where(product => product.ProductName?.Equals(Includes.PRODUCT_NAME) ?? false)
+                .Where(product => product.IsInstalled)
+                .SelectMany(product => product.Features.Where(feature => feature.State == InstallState.Local));
     }
 }

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -177,6 +177,7 @@ internal class Program
                 AllowSameVersionUpgrades = true,
                 DowngradeErrorMessage = "!(loc.NewerInstalled)",
                 Schedule = UpgradeSchedule.afterInstallInitialize,
+                MigrateFeatures = true,
             },
             Media = new List<Media>
             {
@@ -388,9 +389,9 @@ internal class Program
             e.Result = ActionResult.UserExit;
         }
 
-        if (!CustomActions.TryGetInstalledNetFx45Version(out uint netfx45Version) || netfx45Version < 394802)
+        if (!CustomActions.TryGetInstalledNetFx45Version(out uint netfx45Version) || netfx45Version < 528040)
         {
-            if (MessageBox.Show(I18n(Strings.Dotnet462IsRequired), I18n(Strings.AgentDlg_Title),
+            if (MessageBox.Show(I18n(Strings.Dotnet48IsRequired), I18n(Strings.AgentDlg_Title),
                     MessageBoxButtons.YesNo) == DialogResult.Yes)
             {
                 Process.Start("https://go.microsoft.com/fwlink/?LinkId=2085155");
@@ -400,13 +401,6 @@ internal class Program
             e.Result = ActionResult.UserExit;
         }
 
-        if (netfx45Version < 528040)
-        {
-            if (MessageBox.Show(I18n(Strings.DotNet48IsStrongRecommendedDownloadNow), I18n(Strings.AgentDlg_Title),
-                    MessageBoxButtons.YesNo) == DialogResult.Yes)
-            {
-                Process.Start("https://go.microsoft.com/fwlink/?LinkId=2085155");
-            }
-        }
+        e.Session["ADDLOCAL"] = Helpers.AppSearch.InstalledFeatures.Select(x => x.FeatureName).JoinBy(",");
     }
 }

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
@@ -12,8 +12,7 @@
                 <String Id="VendorFullName">Devolutions Inc.</String>
                 <String Id="VendorName">Devolutions</String>
                     <!-- messages -->
-                <String Id="Dotnet462IsRequired">The product requires Microsoft .NET Framework 4.6.2. Microsoft .NET Framework 4.8 is strongly recommended. Would you like to download it now?</String>
-                <String Id="DotNet48IsStrongRecommendedDownloadNow">Microsoft .NET Framework 4.8 is strongly recommended. Would you like to download it now?</String>
+                <String Id="Dotnet48IsRequired">The product requires Microsoft .NET Framework 4.8. Would you like to download it now?</String>
                 <String Id="NewerInstalled">A newer version of this product is already installed.</String>
                 <String Id="OS2Old">This product requires at least Windows 8 / Windows Server 2012 R2</String>
                 <String Id="ThereIsAProblemWithTheEnteredData">There is a problem with the entered data. Please correct the issue and try again.</String>

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
@@ -6,8 +6,7 @@
                 <String Id="VendorFullName">Devolutions Inc.</String>
                 <String Id="VendorName">Devolutions</String>
                     <!-- messages -->
-                <String Id="Dotnet462IsRequired">Le produit nécessite Microsoft .NET Framework 4.6.2. Microsoft .NET Framework 4.8 est fortement conseillé. Souhaiteriez-vous le télécharger maintenant?</String>
-                <String Id="DotNet48IsStrongRecommendedDownloadNow">Microsoft .NET Framework 4.8 est fortement conseillé. Souhaiteriez-vous le télécharger maintenant?</String>
+                <String Id="Dotnet48IsRequired">Le produit nécessite Microsoft .NET Framework 4.8. Souhaiteriez-vous le télécharger maintenant?</String>
                 <String Id="NewerInstalled">Une version plus récente de ce produit est déjà installée.</String>
                 <String Id="OS2Old">Ce produit requiert Windows 8 ou Windows Server 2012 R2 au minimum.</String>
                 <String Id="ThereIsAProblemWithTheEnteredData">Il y a un problème avec les informations fournies, veuillez les modifier et essayer de nouveau.</String>

--- a/package/AgentWindowsManaged/Resources/Includes.cs
+++ b/package/AgentWindowsManaged/Resources/Includes.cs
@@ -26,11 +26,11 @@ namespace DevolutionsAgent.Resources
 
         internal static string INFO_URL = "https://server.devolutions.net";
 
-        internal static Feature AGENT_FEATURE = new("!(loc.FeatureAgentName)", true, false) { Description = "!(loc.FeatureAgentDescription)" };
+        internal static Feature AGENT_FEATURE = new("!(loc.FeatureAgentName)", true, false) { Id = "F.Agent", Description = "!(loc.FeatureAgentDescription)" };
 
-        internal static Feature PEDM_FEATURE = new("!(loc.FeaturePedmName)", "!(loc.FeaturePedmDescription)", false);
+        internal static Feature PEDM_FEATURE = new("!(loc.FeaturePedmName)", "!(loc.FeaturePedmDescription)", false) { Id = "F.Pedm" };
 
-        internal static Feature SESSION_FEATURE = new("!(loc.FeatureSessionName)", "!(loc.FeatureSessionDescription)", false);
+        internal static Feature SESSION_FEATURE = new("!(loc.FeatureSessionName)", "!(loc.FeatureSessionDescription)", false) { Id = "F.Session" };
 
         /// <summary>
         /// SDDL string representing desired %programdata%\devolutions\agent ACL

--- a/package/AgentWindowsManaged/Resources/Strings.g.cs
+++ b/package/AgentWindowsManaged/Resources/Strings.g.cs
@@ -69,13 +69,9 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string x86VersionRequired = "x86VersionRequired";		
 		/// <summary>
-		/// Microsoft .NET Framework 4.8 is strongly recommended. Would you like to download it now?
+		/// The product requires Microsoft .NET Framework 4.8. Would you like to download it now?
 		/// </summary>
-		public const string DotNet48IsStrongRecommendedDownloadNow = "DotNet48IsStrongRecommendedDownloadNow";		
-		/// <summary>
-		/// The product requires Microsoft .NET Framework 4.6.2. Microsoft .NET Framework 4.8 is strongly recommended. Would you like to download it now?
-		/// </summary>
-		public const string Dotnet462IsRequired = "Dotnet462IsRequired";		
+		public const string Dotnet48IsRequired = "Dotnet48IsRequired";		
 		/// <summary>
 		/// View
 		/// </summary>

--- a/package/AgentWindowsManaged/Resources/Strings_en-US.json
+++ b/package/AgentWindowsManaged/Resources/Strings_en-US.json
@@ -65,12 +65,8 @@
           "text": "You need to install the 32-bit version of this product on 32-bit Windows."
         },
         {
-          "id": "DotNet48IsStrongRecommendedDownloadNow",
-          "text": "Microsoft .NET Framework 4.8 is strongly recommended. Would you like to download it now?"
-        },
-        {
-          "id": "Dotnet462IsRequired",
-          "text": "The product requires Microsoft .NET Framework 4.6.2. Microsoft .NET Framework 4.8 is strongly recommended. Would you like to download it now?"
+          "id": "Dotnet48IsRequired",
+          "text": "The product requires Microsoft .NET Framework 4.8. Would you like to download it now?"
         }
       ],
       "buttons": [

--- a/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
@@ -41,12 +41,8 @@
           "text": "Vous devez installer la version 32 bits de ce produit avec l'environnement 32 bits de Windows."
         },
         {
-          "id": "DotNet48IsStrongRecommendedDownloadNow",
-          "text": "Microsoft .NET Framework 4.8 est fortement conseillé. Souhaiteriez-vous le télécharger maintenant?"
-        },
-        {
-          "id": "Dotnet462IsRequired",
-          "text": "Le produit nécessite Microsoft .NET Framework 4.6.2. Microsoft .NET Framework 4.8 est fortement conseillé. Souhaiteriez-vous le télécharger maintenant?"
+          "id": "Dotnet48IsRequired",
+          "text": "Le produit nécessite Microsoft .NET Framework 4.8. Souhaiteriez-vous le télécharger maintenant?"
         }
       ],
       "buttons": [


### PR DESCRIPTION
Preserve installed features when upgrading Devolutions Agent.

Additionally, make .NET 4.8 a hard requirement.