### PR TITLE
ci: exclude DLLs from release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
         run: |
           $Version = "${{ needs.preflight.outputs.version }}"
           $HashPath = 'checksums'
-          $Files = Get-ChildItem -Recurse -File -Exclude 'CHANGELOG.md' | % { Get-FileHash -Algorithm SHA256 $_.FullName }
+          $Files = Get-ChildItem -Recurse -File -Exclude 'CHANGELOG.md', '*.dll' | % { Get-FileHash -Algorithm SHA256 $_.FullName }
           $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
 
           echo "::group::checksums"


### PR DESCRIPTION
This PR excludes unwanted DLL files from the release assets.

The output of the "Create GitHub release" step of the call-release-workflow job confirms that the DLLs are removed.

[Previous workflow run with DLLs](https://github.com/Devolutions/devolutions-gateway/actions/runs/12123470160/job/33800868911)
[Workflow run for this PR](https://github.com/Devolutions/devolutions-gateway/actions/runs/12361298709/job/34519437866)
