### PR TITLE
fix(installer): lockdown PEDM directory tree from installer

### DIFF
--- a/devolutions-agent/src/updater/mod.rs
+++ b/devolutions-agent/src/updater/mod.rs
@@ -182,6 +182,7 @@ async fn update_product(conf: ConfHandle, product: Product, order: UpdateOrder) 
 
         let uninstall_log_path = package_path.with_extension("uninstall.log");
 
+        // NOTE: An uninstall/reinstall will lose any custom feature selection or other options in the existing installation
         uninstall_package(&ctx, downgrade.product_code, &uninstall_log_path).await?;
     }
 

--- a/package/AgentWindowsManaged/Resources/Includes.cs
+++ b/package/AgentWindowsManaged/Resources/Includes.cs
@@ -46,5 +46,17 @@ namespace DevolutionsAgent.Resources
         ///    BUILTIN\Users Allow ReadAndExecute, Synchronize
         /// </remarks>
         internal static string PROGRAM_DATA_SDDL = "O:SYG:SYD:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)";
+
+        /// <summary>
+        /// SDDL string representing desired %programdata%\devolutions\agent\pedm ACL
+        /// Easiest way to generate an SDDL is to configure the required access, and then query the path with PowerShell: `Get-Acl | Format-List`
+        /// </summary>
+        /// <remarks>
+        /// Owner  : NT AUTHORITY\SYSTEM
+        /// Group  : NT AUTHORITY\SYSTEM
+        /// Access :
+        ///    NT AUTHORITY\SYSTEM Allow  FullControl
+        /// </remarks>
+        internal static string PROGRAM_DATA_PEDM_SDDL = "O:SYG:SYD:(A;OICI;FA;;;SY)";
     }
 }


### PR DESCRIPTION
Create (if needed) and lock down the PEDM configuration directory at install time

Changelog: ignore