### PR TITLE
refactor(pedm): audit and refactor privileges module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,7 @@ jobs:
           - tree-borrows
         include:
           - mode: tree-borrows
-            miri-flags: -Zmiri-tree-borrows
+            miriflags: -Zmiri-tree-borrows
 
     steps:
       - name: Checkout ${{ github.repository }}
@@ -807,7 +807,9 @@ jobs:
 
       - name: Run tests
         shell: pwsh
-        run: cargo +nightly test ${{ matrix.miri-flags }} --target ${{ matrix.target }} -p win-api-wrappers
+        run: |
+          $Env:MIRIFLAGS = "${{ matrix.miriflags }}"
+          cargo +nightly test --target ${{ matrix.target }} -p win-api-wrappers
 
   success:
     name: Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,6 +736,79 @@ jobs:
           run: |
             ./powershell/run-tests.ps1
 
+  winapi-sanitizer-tests:
+    name: Windows API sanitizer tests
+    runs-on: windows-2022
+    needs: preflight
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Prepare runner
+        shell: pwsh
+        run: |
+          $VSInstallationPath = $(vswhere.exe -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)
+          Write-Host "VCToolsInstallDir = $VSInstallationPath"
+          Get-ChildItem "$VSInstallationPath"
+
+          $toolsPath = "$VSInstallationPath\VC\Tools\MSVC"
+          Write-Host "toolsPath = $toolsPath"
+          Get-ChildItem "$toolsPath"
+
+          $firstItem = Get-ChildItem "$toolsPath" | Select-Object -Last 1
+          $binPath = "$toolsPath\$($firstItem.Name)\bin\Hostx64\x64"
+          Write-Host "binPath = $binPath"
+          Get-ChildItem "$binPath"
+
+          $asanDllPath = "$binPath\clang_rt.asan_dynamic-x86_64.dll"
+          Write-Host "asanDllPath = $asanDllPath"
+
+          New-Item -ItemType Directory ".\target\x86_64-pc-windows-msvc\debug\"
+          Copy-Item -Path "$asanDllPath" -Destination .\target\x86_64-pc-windows-msvc\debug\
+
+          rustup toolchain install nightly
+
+      - name: Run tests
+        shell: pwsh
+        run: |
+          $Env:RUSTFLAGS="-Zsanitizer=address"
+          cargo +nightly test --target x86_64-pc-windows-msvc -p win-api-wrappers -p devolutions-pedm
+
+  winapi-miri:
+    name: Windows API miri tests [${{ matrix.target }}][${{ matrix.mode }}]
+    runs-on: ubuntu-20.04
+    needs: preflight
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+        mode:
+          - stacked-borrow
+          - tree-borrows
+        include:
+          - mode: tree-borrows
+            miri-flags: -Zmiri-tree-borrows
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Prepare runner
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup target add ${{ matrix.target }}
+
+      - name: Run tests
+        shell: pwsh
+        run: cargo +nightly test ${{ matrix.miri-flags }} --target ${{ matrix.target }} -p win-api-wrappers
+
   success:
     name: Success
     runs-on: ubuntu-latest
@@ -749,6 +822,8 @@ jobs:
       - devolutions-agent-merge
       - dotnet-utils-tests
       - powershell-tests
+      - winapi-sanitizer-tests
+      - winapi-miri
 
     steps:
       - name: Check success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -778,19 +778,23 @@ jobs:
           cargo +nightly test --target x86_64-pc-windows-msvc -p win-api-wrappers -p devolutions-pedm
 
   winapi-miri:
-    name: Windows API miri tests [${{ matrix.target }}][${{ matrix.mode }}]
-    runs-on: ubuntu-20.04
+    name: Windows API miri tests [${{ matrix.os }}][${{ matrix.mode }}]
+    runs-on: ${{ matrix.runner }}
     needs: preflight
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-pc-windows-msvc
-          - x86_64-unknown-linux-gnu
+        os:
+          - windows
+          - linux
         mode:
           - stacked-borrow
           - tree-borrows
         include:
+          - os: windows
+            runner: windows-latest
+          - os: linux
+            runner: ubuntu-latest
           - mode: tree-borrows
             miriflags: -Zmiri-tree-borrows
 
@@ -803,13 +807,12 @@ jobs:
       - name: Prepare runner
         run: |
           rustup toolchain install nightly --component miri
-          rustup target add --toolchain nightly ${{ matrix.target }}
 
       - name: Run tests
         shell: pwsh
         run: |
           $Env:MIRIFLAGS = "${{ matrix.miriflags }}"
-          cargo +nightly test --target ${{ matrix.target }} -p win-api-wrappers
+          cargo +nightly test -p win-api-wrappers
 
   success:
     name: Success

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,7 +803,7 @@ jobs:
       - name: Prepare runner
         run: |
           rustup toolchain install nightly --component miri
-          rustup target add ${{ matrix.target }}
+          rustup target add --toolchain nightly ${{ matrix.target }}
 
       - name: Run tests
         shell: pwsh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6860,6 +6860,7 @@ dependencies = [
  "thiserror 1.0.68",
  "tracing",
  "uuid",
+ "widestring 1.1.0",
  "windows 0.58.0",
 ]
 

--- a/crates/devolutions-pedm/src/log.rs
+++ b/crates/devolutions-pedm/src/log.rs
@@ -6,8 +6,8 @@ use anyhow::Result;
 use camino::Utf8PathBuf;
 use chrono::Local;
 use devolutions_pedm_shared::policy::{ElevationResult, User};
-use std::fs::{self, OpenOptions};
-use std::io::{self, BufRead};
+use std::fs;
+use std::io::{self, BufRead as _};
 use walkdir::WalkDir;
 use win_api_wrappers::identity::sid::Sid;
 use win_api_wrappers::raw::Win32::Security::WinBuiltinUsersSid;
@@ -53,8 +53,10 @@ pub(crate) fn query_logs(user: Option<&User>) -> Result<Vec<ElevationResult>> {
     let log_path = user.map_or_else(|| Ok(log_path()), log_path_for_user)?;
 
     let mut logs = vec![];
+
     for entry in WalkDir::new(log_path).into_iter() {
         let entry = entry?;
+
         if !(entry.file_type().is_file() && entry.path().extension().is_some_and(|ext| ext == "json")) {
             continue;
         }

--- a/crates/win-api-wrappers/Cargo.toml
+++ b/crates/win-api-wrappers/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 tracing = "0.1"
 uuid = { version = "1.10", features = ["v4"] }
+widestring = "1.1.0"
 
 [dependencies.windows]
 version = "0.58.0"

--- a/crates/win-api-wrappers/src/dst.rs
+++ b/crates/win-api-wrappers/src/dst.rs
@@ -1,0 +1,196 @@
+//! Helpers for dynamically sized types found in Win32 API.
+
+use crate::raw_buffer::{InitedBuffer, RawBuffer};
+
+/// Definition for a Win32-style dynamically sized type.
+///
+/// # Safety
+///
+/// - The offsets must be in bound of the container.
+/// - The container must not be `#[repr(packed)]`.
+pub unsafe trait Win32DstDef {
+    type Container;
+
+    type Item;
+
+    type ItemCount: TryInto<usize, Error = core::num::TryFromIntError> + Copy;
+
+    /// Offset to the item count, in bounds of the container.
+    const ITEM_COUNT_OFFSET: usize;
+
+    /// Offset to the array, in bounds of the container.
+    const ARRAY_OFFSET: usize;
+
+    /// Builds a container holding a single element.
+    fn new_container(first_item: Self::Item) -> Self::Container;
+
+    /// Increments count by one.
+    fn increment_count(count: Self::ItemCount) -> Self::ItemCount;
+}
+
+/// Wrapper over a Win32-style dynamically sized type.
+pub struct Win32Dst<Def: Win32DstDef> {
+    /// INVARIANT: The array holds exactly `Def::ItemCount` elements.
+    /// INVARIANT: `Def::ITEM_COUNT_OFFSET` is in bounds of the allocated container.
+    /// INVARIANT: `Def::ARRAY_OFFSET` is in bounds of the allocated container.
+    /// INVARIANT: `Def::Container` is not #[repr(packed)], so the fields are properly aligned when reading.
+    inner: InitedBuffer<Def::Container>,
+}
+
+impl<Def: Win32DstDef> Win32Dst<Def> {
+    pub fn new(first_item: Def::Item) -> Self {
+        use core::alloc::Layout;
+
+        let container = Def::new_container(first_item);
+
+        let layout = Layout::new::<Def::Container>();
+
+        // SAFETY: The layout initialization is checked using the Layout::new method.
+        let mut inner = unsafe { RawBuffer::alloc_zeroed(layout).expect("OOM") };
+
+        // SAFETY: The pointed memory is valid for writes and is properly aligned.
+        unsafe { inner.as_mut_ptr().cast::<Def::Container>().write(container) };
+
+        // SAFETY: We initialized the value above.
+        let inner = unsafe { inner.assume_init() };
+
+        Self { inner }
+    }
+
+    /// Creates a new [`Win32Dst`] from the provided [`InitedBuffer`].
+    ///
+    /// # Safety
+    ///
+    /// The underlying array must holds exactly the amount of `Def::Item` specified inside the `Def::ItemCount`.
+    pub unsafe fn from_raw(buffer: InitedBuffer<Def::Container>) -> Self {
+        Self { inner: buffer }
+    }
+
+    pub fn as_raw(&self) -> &InitedBuffer<Def::Container> {
+        &self.inner
+    }
+
+    pub fn push(&mut self, value: Def::Item) {
+        let current_count = self.count();
+
+        let raw_buffer = self.inner.as_inner_mut();
+
+        let layout = raw_buffer.layout();
+
+        let current_size = layout.size();
+        let new_size = current_size + size_of::<Def::Item>();
+
+        let rounded_new_size = new_size + new_size % layout.align();
+
+        // Ensure `new_size`, when rounded up to the nearest multiple of `layout.align()`,
+        // does not overflow `isize` (i.e., the rounded value must be less than or
+        // equal to `isize::MAX`).
+        isize::try_from(rounded_new_size).expect("array contains too many elements");
+
+        // SAFETY:
+        // - We ensure new_size is valid just above.
+        // - We immediately write the new value in-place, keeping the underlying TOKEN_PRIVILEGES valid.
+        unsafe { raw_buffer.realloc(new_size).expect("OOM") };
+
+        // From here, the invariants of InitedBuffer are not holding anymore -->
+
+        // SAFETY: Per invariants, the offset is in bounds of the container.
+        let array_ptr = unsafe { raw_buffer.as_mut_ptr().byte_add(Def::ARRAY_OFFSET) };
+
+        // SAFETY:
+        // - The new pointer is placed somewhere where ptr + rounded_new_size does not overflow isize, and array_offset < rounded_new_size.
+        // - current_count is a reasonable value as per invariants.
+        let new_item_ptr = unsafe {
+            array_ptr
+                .cast::<Def::Item>()
+                .add(current_count.try_into().expect("fit into usize"))
+        };
+
+        // SAFETY: The pointed memory is valid for writes and is properly aligned.
+        unsafe { new_item_ptr.write(value) };
+
+        // Update the item count.
+
+        // SAFETY: Per invariants, the offset is in bounds of the container.
+        let count_ptr = unsafe { raw_buffer.as_mut_ptr().byte_add(Def::ITEM_COUNT_OFFSET) };
+
+        // SAFETY: The pointed memory is valid for writes and is properly aligned.
+        unsafe {
+            count_ptr
+                .cast::<Def::ItemCount>()
+                .write(Def::increment_count(current_count))
+        }
+
+        // <-- At this point, the InitedBuffer invariants are holding again.
+    }
+
+    pub fn count(&self) -> Def::ItemCount {
+        // SAFETY: Per invariants, the offset must be in bounds of the allocated object.
+        let count_ptr = unsafe { self.inner.as_ptr().byte_add(Def::ITEM_COUNT_OFFSET) };
+
+        unsafe { count_ptr.cast::<Def::ItemCount>().read() }
+    }
+
+    pub fn as_slice(&self) -> &[Def::Item] {
+        let count = self.count().try_into().expect("fit into usize");
+
+        // SAFETY: Per invariants, the offset must be in bounds of the allocated object.
+        let array_ptr = unsafe { self.inner.as_ptr().byte_add(Def::ARRAY_OFFSET) };
+
+        // SAFETY: Per invariants, the array contains `count` items.
+        unsafe { core::slice::from_raw_parts(array_ptr.cast::<Def::Item>(), count) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem;
+
+    use super::*;
+
+    struct MockContainer {
+        count: u32,
+        array: [u128; 1],
+    }
+
+    struct MockDef;
+
+    unsafe impl Win32DstDef for MockDef {
+        type Container = MockContainer;
+
+        type Item = u128;
+
+        type ItemCount = u32;
+
+        const ITEM_COUNT_OFFSET: usize = mem::offset_of!(MockContainer, count);
+
+        const ARRAY_OFFSET: usize = mem::offset_of!(MockContainer, array);
+
+        fn new_container(first_item: Self::Item) -> Self::Container {
+            MockContainer {
+                count: 1,
+                array: [first_item],
+            }
+        }
+
+        fn increment_count(count: Self::ItemCount) -> Self::ItemCount {
+            count + 1
+        }
+    }
+
+    type MockDst = Win32Dst<MockDef>;
+
+    // Ideally run with miri.
+    #[test]
+    fn smoke() {
+        let mut dst = MockDst::new(u128::MAX);
+
+        dst.push(u128::MIN);
+
+        for item in dst.as_slice() {
+            core::hint::black_box(item);
+        }
+
+        assert_eq!(dst.as_slice().len(), 2);
+    }
+}

--- a/crates/win-api-wrappers/src/lib.rs
+++ b/crates/win-api-wrappers/src/lib.rs
@@ -1,6 +1,10 @@
 #[macro_use]
 extern crate tracing;
 
+pub mod dst;
+pub mod raw_buffer;
+pub mod str;
+
 #[cfg(target_os = "windows")]
 #[path = ""]
 mod lib_win {

--- a/crates/win-api-wrappers/src/raw_buffer.rs
+++ b/crates/win-api-wrappers/src/raw_buffer.rs
@@ -1,0 +1,169 @@
+use core::fmt;
+use core::ptr::NonNull;
+use std::alloc::{alloc_zeroed, dealloc, realloc, Layout};
+
+/// The `AllocError` error indicates an allocation failure
+/// that may be due to resource exhaustion or to
+/// something wrong when combining the given input arguments with this
+/// allocator.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub struct AllocError;
+
+impl std::error::Error for AllocError {}
+
+impl fmt::Display for AllocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("memory allocation failed")
+    }
+}
+
+/// A RAII wrapper around a raw buffer.
+///
+/// Basically a convenient wrapper around the Rust std global allocator.
+/// Useful for DST structs found across the Windows API.
+///
+/// `ref_cast` and `ref_mut_cast` are used to retrieve a typed reference on the underlying data.
+/// This reference lifetime is bounded to the [`RawBuffer`] instance to prevent use-after-free bugs.
+pub struct RawBuffer {
+    ptr: NonNull<u8>,
+    layout: Layout,
+}
+
+impl RawBuffer {
+    /// Allocates memory as described by the given `layout`, ensuring that the contents are set to zero.
+    ///
+    /// # Safety
+    ///
+    /// See [`GlobalAlloc::alloc_zeroed`].
+    pub unsafe fn alloc_zeroed(layout: Layout) -> Result<Self, AllocError> {
+        let ptr = unsafe { alloc_zeroed(layout) };
+
+        if let Some(ptr) = NonNull::new(ptr) {
+            Ok(Self { ptr, layout })
+        } else {
+            Err(AllocError)
+        }
+    }
+
+    /// Shrinks or grows the memory to the given `new_size` in bytes.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// * `new_size` is greater than zero.
+    ///
+    /// * `new_size`, when rounded up to the nearest multiple of `layout.align()`,
+    ///   does not overflow `isize` (i.e., the rounded value must be less than or
+    ///   equal to `isize::MAX`).
+    pub unsafe fn realloc(&mut self, new_size: usize) -> Result<(), AllocError> {
+        let new_ptr = unsafe { realloc(self.ptr.as_ptr(), self.layout, new_size) };
+
+        if let Some(new_ptr) = NonNull::new(new_ptr) {
+            self.ptr = new_ptr;
+
+            // SAFETY: the caller must ensure that the `new_size` does not overflow.
+            // `layout.align()` comes from a `Layout` and is thus guaranteed to be valid.
+            let new_layout = unsafe { Layout::from_size_align_unchecked(new_size, self.layout.align()) };
+
+            self.layout = new_layout;
+
+            Ok(())
+        } else {
+            Err(AllocError)
+        }
+    }
+
+    /// Casts the underlying raw buffer and returns a reference to it.
+    ///
+    /// # Safety
+    ///
+    /// The underlying buffer must hold a valid, initialized `T`.
+    pub const unsafe fn as_ref_cast<T>(&self) -> &T {
+        unsafe { self.ptr.cast::<T>().as_ref() }
+    }
+
+    /// Casts the underlying raw buffer and returns a mutable reference to it.
+    ///
+    /// # Safety
+    ///
+    /// The underlying buffer must hold a valid, initialized `T`.
+    pub unsafe fn as_mut_cast<T>(&mut self) -> &mut T {
+        unsafe { self.ptr.cast::<T>().as_mut() }
+    }
+
+    pub const fn as_ptr(&self) -> *const u8 {
+        self.ptr.as_ptr().cast_const()
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+
+    pub fn layout(&self) -> &Layout {
+        &self.layout
+    }
+
+    /// Obtains an [`InitedBuffer`] guaranteed to contain a T.
+    ///
+    /// # Safety
+    ///
+    /// This raw buffer must hold a valid, properly initialized T.
+    pub unsafe fn assume_init<T>(self) -> InitedBuffer<T> {
+        InitedBuffer {
+            inner: self, // The caller guarantees this raw buffer is holding a valid, properly initialized T.
+            _marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for RawBuffer {
+    fn drop(&mut self) {
+        // SAFETY:
+        // - ptr is a block of memory currently allocated via the global allocator and,
+        // - layout is the same layout that was used to allocate that block of memory.
+        unsafe { dealloc(self.ptr.as_ptr(), self.layout) };
+    }
+}
+
+/// A buffer that is guaranteed to hold a properly initialized T.
+///
+/// If you use `realloc`, you should ensure that the `T` value is still valid
+/// before any call to [`InitedBuffer::as_ref`] or [`InitedBuffer::as_ref_mut`].
+pub struct InitedBuffer<T> {
+    /// INVARIANT: This raw buffer holds a properly initialized T.
+    inner: RawBuffer,
+    _marker: core::marker::PhantomData<*mut T>,
+}
+
+impl<T> InitedBuffer<T> {
+    pub const fn as_inner(&self) -> &RawBuffer {
+        &self.inner
+    }
+
+    pub fn as_inner_mut(&mut self) -> &mut RawBuffer {
+        &mut self.inner
+    }
+
+    pub fn into_inner(self) -> RawBuffer {
+        self.inner
+    }
+
+    pub const fn as_ref(&self) -> &T {
+        // SAFETY: Per invariants, the inner RawBuffer holds a properly initialized T.
+        unsafe { self.inner.as_ref_cast::<T>() }
+    }
+
+    pub fn as_mut(&mut self) -> &mut T {
+        // SAFETY: Per invariants, the inner RawBuffer holds a properly initialized T.
+        unsafe { self.inner.as_mut_cast::<T>() }
+    }
+
+    pub const fn as_ptr(&self) -> *const T {
+        self.inner.as_ptr().cast::<T>()
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self.inner.as_mut_ptr().cast::<T>()
+    }
+}

--- a/crates/win-api-wrappers/src/security/privilege.rs
+++ b/crates/win-api-wrappers/src/security/privilege.rs
@@ -108,6 +108,8 @@ pub struct TokenPrivilegesDstDef;
 // SAFETY:
 // - The offests are in bounds of the container (ensured via the offset_of! macro).
 // - The container (TOKEN_PRIVILEGES) is not #[repr(packet)].
+// - The container (TOKEN_PRIVILEGES) is #[repr(C)].
+// - The array is defined last and its hardcoded size if of 1.
 unsafe impl Win32DstDef for TokenPrivilegesDstDef {
     type Container = Security::TOKEN_PRIVILEGES;
 

--- a/crates/win-api-wrappers/src/str.rs
+++ b/crates/win-api-wrappers/src/str.rs
@@ -1,0 +1,56 @@
+pub use widestring::*;
+
+#[cfg(target_os = "windows")]
+pub use self::win_ext::*;
+
+#[cfg(target_os = "windows")]
+mod win_ext {
+    use super::{U16CStr, U16CString};
+
+    use windows::core::{PCWSTR, PWSTR};
+
+    pub trait U16CStrExt {
+        unsafe fn from_pwstr<'a>(ptr: PWSTR) -> &'a mut U16CStr;
+        unsafe fn from_pcwstr<'a>(ptr: PCWSTR) -> &'a U16CStr;
+        fn as_pwstr(&mut self) -> PWSTR;
+        fn as_pcwstr(&self) -> PCWSTR;
+    }
+
+    impl U16CStrExt for U16CStr {
+        unsafe fn from_pwstr<'a>(ptr: PWSTR) -> &'a mut U16CStr {
+            unsafe { U16CStr::from_ptr_str_mut(ptr.as_ptr()) }
+        }
+
+        unsafe fn from_pcwstr<'a>(ptr: PCWSTR) -> &'a U16CStr {
+            unsafe { U16CStr::from_ptr_str(ptr.as_ptr()) }
+        }
+
+        fn as_pwstr(&mut self) -> PWSTR {
+            PWSTR(self.as_mut_ptr())
+        }
+
+        fn as_pcwstr(&self) -> PCWSTR {
+            PCWSTR(self.as_ptr())
+        }
+    }
+
+    pub trait U16CStringExt {
+        unsafe fn from_pwstr(ptr: PWSTR) -> U16CString;
+        fn as_pwstr(&mut self) -> PWSTR;
+        fn as_pcwstr(&self) -> PCWSTR;
+    }
+
+    impl U16CStringExt for U16CString {
+        unsafe fn from_pwstr(ptr: PWSTR) -> U16CString {
+            unsafe { U16CString::from_raw(ptr.as_ptr()) }
+        }
+
+        fn as_pwstr(&mut self) -> PWSTR {
+            PWSTR(self.as_mut_ptr())
+        }
+
+        fn as_pcwstr(&self) -> PCWSTR {
+            PCWSTR(self.as_ptr())
+        }
+    }
+}

--- a/crates/win-api-wrappers/src/token.rs
+++ b/crates/win-api-wrappers/src/token.rs
@@ -304,7 +304,7 @@ impl Token {
         Ok(info)
     }
 
-    /// Very thin wrapper above `GetTokenInformation`
+    /// Very thin wrapper around `GetTokenInformation`
     ///
     /// # Safety
     ///

--- a/crates/win-api-wrappers/src/user.rs
+++ b/crates/win-api-wrappers/src/user.rs
@@ -1,5 +1,6 @@
 use windows::core::PWSTR;
-use windows::Win32::{Foundation::HINSTANCE, UI::WindowsAndMessaging::LoadStringW};
+use windows::Win32::Foundation::HINSTANCE;
+use windows::Win32::UI::WindowsAndMessaging::LoadStringW;
 
 pub fn load_string(hinstance: HINSTANCE, resource_id: u32) -> anyhow::Result<Option<String>, windows::core::Error> {
     let mut resource_ptr: PWSTR = PWSTR::null();

--- a/crates/win-api-wrappers/src/utils.rs
+++ b/crates/win-api-wrappers/src/utils.rs
@@ -505,7 +505,7 @@ impl Snapshot {
         // SAFETY: No preconditions. Flags or process ID cannot create scenarios where undefined behavior happens.
         let handle = unsafe { CreateToolhelp32Snapshot(flags, process_id.unwrap_or(0))? };
 
-        // SAFETY: We created the handle just above and are responsibles for closing it.
+        // SAFETY: We created the handle just above and are responsible for closing it.
         let handle = unsafe { OwnedHandle::from_raw_handle(handle.0) };
 
         Ok(Self { handle })

--- a/crates/win-api-wrappers/src/utils.rs
+++ b/crates/win-api-wrappers/src/utils.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::io::{self, Read, Write};
 use std::mem::MaybeUninit;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
+use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{ptr, slice};
@@ -457,7 +458,7 @@ pub fn expand_environment_path(src: &Path, environment: &HashMap<String, String>
 }
 
 pub struct Snapshot {
-    handle: Handle,
+    handle: OwnedHandle,
 }
 
 pub struct ProcessIdIterator<'a> {
@@ -490,8 +491,10 @@ impl Iterator for ProcessIdIterator<'_> {
             Process32Next
         };
 
+        let handle = HANDLE(self.snapshot.handle.as_raw_handle());
+
         // SAFETY: Only precondition is entry's `dwSize` being set correctly, which is done in `ProcessIdIterator::new`.
-        unsafe { iter_fn(self.snapshot.handle.raw(), &mut self.entry) }.ok()?;
+        unsafe { iter_fn(handle, &mut self.entry) }.ok()?;
 
         Some(self.entry.th32ProcessID)
     }
@@ -499,10 +502,11 @@ impl Iterator for ProcessIdIterator<'_> {
 
 impl Snapshot {
     pub fn new(flags: CREATE_TOOLHELP_SNAPSHOT_FLAGS, process_id: Option<u32>) -> anyhow::Result<Self> {
-        // SAFETY: No preconditions. Flags or process ID cannot create scenarios where unsafe behavior happens.
+        // SAFETY: No preconditions. Flags or process ID cannot create scenarios where undefined behavior happens.
         let handle = unsafe { CreateToolhelp32Snapshot(flags, process_id.unwrap_or(0))? };
-        // SAFETY: We created the handle just above and are responsibles for closing it ourselves.
-        let handle = unsafe { Handle::new_owned(handle)? };
+
+        // SAFETY: We created the handle just above and are responsibles for closing it.
+        let handle = unsafe { OwnedHandle::from_raw_handle(handle.0) };
 
         Ok(Self { handle })
     }


### PR DESCRIPTION
Audit and refactor the privileges module to remove code found to be causing undefined behaviors.
The token module was also partially rewritten accordingly.

To help ensuring the new code is correct and stays that way, tests were added, and the CI was updated to run them with the LLVM memory sanitizers and miri (for all the code that is not interfacing with Windows API directly)

Notable abstractions added:

- Safer wide strings (str module): Re-export string types from the widestring crate, and provide extension traits to integrate with the windows-strings crate.

- RawBuffer (raw_buffer module): A convenient RAII wrapper around the Rust std global allocator.

- Win32Dst (dst module): Generic wrapper for Win32-style dynamically sized types.

Issue: DGW-222
Changelog: ignore