### PR TITLE
split gateway powershell module build + code sign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,10 +391,48 @@ jobs:
           name: webapp-client
           path: webapp/client/
 
+  devolutions-gateway-powershell:
+    name: devolutions-gateway-powershell
+    runs-on: ubuntu-latest
+    needs: preflight
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Install Pester
+        id: prepare
+        shell: pwsh
+        run: Install-Module Pester -RequiredVersion 5.6.0
+
+      - name: Build module
+        shell: pwsh
+        run: |
+          ./powershell/build.ps1
+          $PSModuleName = "DevolutionsGateway"
+          $PSModuleVersion = "${{ needs.preflight.outputs.version }}"
+          $PSModuleOutputPath = Join-Path "powershell" "package" $PSModuleName
+          $PSStagingPath = Join-Path "powershell-staging" "PowerShell"
+          New-Item -Path $PSStagingPath -ItemType Directory | Out-Null
+          $PSModuleZipFilePath = Join-Path $PSStagingPath "$PSModuleName-ps-$PSModuleVersion.zip"
+          Compress-Archive -Path $PSModuleOutputPath -Destination $PSModuleZipFilePath
+
+      - name: Pester tests
+        shell: pwsh
+        run: |
+          ./powershell/run-tests.ps1
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: devolutions-gateway-powershell
+          path: powershell-staging
+
   devolutions-gateway:
     name: devolutions-gateway [${{ matrix.os }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
-    needs: [preflight, devolutions-gateway-web-ui]
+    needs: [preflight, devolutions-gateway-powershell, devolutions-gateway-web-ui]
     if: always() # The webapp can’t be build without secrets that we don’t provide for PRs coming from forks.
     strategy:
       matrix:
@@ -412,6 +450,12 @@ jobs:
         with:
           name: webapp-client
           path: webapp/client
+
+      - name: Download devolutions-gateway-powershell
+        uses: actions/download-artifact@v4
+        with:
+          name: devolutions-gateway-powershell
+          path: powershell-staging
 
       - name: Download Cadeau
         shell: pwsh
@@ -432,12 +476,7 @@ jobs:
           if ($Env:RUNNER_OS -eq "Windows") {
             $ExecutableFileName = "$($ExecutableFileName).exe"
             $PackageFileName = "DevolutionsGateway-${{ matrix.arch }}-${PackageVersion}.msi"
-            $PSModuleOutputPath = Join-Path $StagingPath PowerShell
-            $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
             $DGatewayPackage = Join-Path $TargetOutputPath $PackageFileName
-
-            echo "psmodule-output-path=$PSModuleOutputPath" >> $Env:GITHUB_OUTPUT
-            echo "dgateway-psmodule-output-path=$DGatewayPSModulePath" >> $Env:GITHUB_OUTPUT
             echo "dgateway-package=$DGatewayPackage" >> $Env:GITHUB_OUTPUT
           }
 
@@ -471,7 +510,7 @@ jobs:
         run: |
           # https://github.com/actions/runner-images/issues/9667
           choco uninstall wixtoolset
-          choco install wixtoolset --version 3.14.0 --allow-downgrade --force
+          choco install wixtoolset --version 3.14.0 --allow-downgrade --no-progress --force
 
           # WiX is installed on Windows runners but not in the PATH
           Write-Output "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -490,12 +529,6 @@ jobs:
           CARGO_PACKAGE: devolutions-gateway
         run: ./ci/tlk.ps1 build -Product gateway -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
 
-      - name: Build PowerShell module
-        if: matrix.os == 'windows'
-        env:
-          PSMODULE_OUTPUT_PATH: ${{ steps.load-variables.outputs.psmodule-output-path }}
-        run: .\powershell\build.ps1
-
       - name: Add msbuild to PATH
         if: matrix.os == 'windows'
         uses: microsoft/setup-msbuild@v2
@@ -509,8 +542,13 @@ jobs:
         run: |
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}"
-            $Env:DGATEWAY_PSMODULE_PATH = "${{ steps.load-variables.outputs.dgateway-psmodule-output-path }}"
             $Env:DGATEWAY_LIB_XMF_PATH = Join-Path "native-libs" "xmf.dll" | Resolve-Path
+
+            $PSStagingPath = Join-Path (Get-Location) "powershell-staging"
+            $PSModuleOutputPath = Join-Path $PSStagingPath "DevolutionsGateway"
+            $PSModuleZipFilePath = Get-ChildItem -Path "$PSStagingPath/PowerShell" "*-ps-*.zip" | Select-Object -First 1
+            Expand-Archive -Path $PSModuleZipFilePath -Destination $PSStagingPath
+            $Env:DGATEWAY_PSMODULE_PATH = $PSModuleOutputPath
           } else {
             $Env:DGATEWAY_LIB_XMF_PATH = Join-Path "native-libs" "libxmf.so" | Resolve-Path
           }
@@ -560,6 +598,7 @@ jobs:
           $PackageVersion = "${{ needs.preflight.outputs.version }}"
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $SymbolsPath = Join-Path $Env:RUNNER_TEMP "symbols"
+          New-Item -ItemType Directory $StagingPath
           New-Item -ItemType Directory $SymbolsPath
 
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
@@ -710,32 +749,6 @@ jobs:
             Set-PSDebug -Trace 1
             dotnet test utils/dotnet/GatewayUtils.sln
 
-  powershell-tests:
-      name: PowerShell module tests
-      runs-on: windows-2022
-      needs: preflight
-
-      steps:
-        - name: Checkout ${{ github.repository }}
-          uses: actions/checkout@v4
-          with:
-            ref: ${{ needs.preflight.outputs.ref }}
-
-        - name: Install Pester module
-          id: prepare
-          shell: pwsh
-          run: Install-Module Pester -RequiredVersion 5.6.0
-
-        - name: Build module
-          shell: pwsh
-          run: |
-            ./powershell/build.ps1
-
-        - name: Pester
-          shell: pwsh
-          run: |
-            ./powershell/run-tests.ps1
-
   winapi-sanitizer-tests:
     name: Windows API sanitizer tests
     runs-on: windows-2022
@@ -822,11 +835,11 @@ jobs:
       - tests
       - check-dependencies
       - jetsocat-lipo
+      - devolutions-gateway-powershell
       - devolutions-gateway
       - devolutions-gateway-merge
       - devolutions-agent-merge
       - dotnet-utils-tests
-      - powershell-tests
       - winapi-sanitizer-tests
       - winapi-miri
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -218,19 +218,48 @@ jobs:
 
           # https://github.com/actions/runner-images/issues/9667
           choco uninstall wixtoolset
-          choco install wixtoolset --version 3.14.0 --allow-downgrade --force
+          choco install wixtoolset --version 3.14.0 --allow-downgrade --no-progress --force
           echo "C:\Program Files (x86)\WiX Toolset v3.14\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Sign PowerShell module contents
+        if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
+        shell: pwsh
+        run: |
+          . .\ci\PSModuleHelpers.ps1
+          $PSModuleOutputPath = Join-Path ${{ runner.temp }} ${{ matrix.project }} "PowerShell"
+          $PSModuleZipFilePath = Get-ChildItem -Path $PSModuleOutputPath "DevolutionsGateway-ps-*.zip" | Select-Object -First 1
+          Expand-Archive -Path $PSModuleZipFilePath -Destination $PSModuleOutputPath
+          $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
+
+          $IncludePattern = @('*.ps1', '*.psd1', '*.psm1', 'DevolutionsGateway.dll')
+          Get-ChildItem -Path $PSModuleOutputPath -Recurse -Include $IncludePattern | % {
+            $Params = @('sign',
+              '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+              '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+              '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+              '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+              '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+              '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+              '-v')
+            AzureSignTool @Params $_.FullName
+          }
+
+          Remove-Item $PSModuleZipFilePath -ErrorAction SilentlyContinue | Out-Null
+          Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -CompressionLevel Optimal
+
+          $PSModuleParentPath = Split-Path $DGatewayPSModulePath -Parent
+          New-ModulePackage $DGatewayPSModulePath $PSModuleParentPath
 
       - name: Sign executables
         if: matrix.os == 'windows' || matrix.os == 'macos'
         shell: pwsh
         run: |
-          $IncludePattern = switch ('${{ matrix.project }}') {
-            'devolutions-gateway' { 'DevolutionsGateway_*.exe' }
-            'devolutions-agent' { 'DevolutionsAgent_*.exe', 'DevolutionsPedmShellExt.dll',
-              'DevolutionsPedmShellExt.msix', 'DevolutionsDesktopAgent.exe' }
-            'jetsocat' { 'jetsocat_*' }
-          }
+          $IncludePattern = @(switch ('${{ matrix.project }}') {
+            'devolutions-gateway' { @('DevolutionsGateway_*.exe') }
+            'devolutions-agent' { @('DevolutionsAgent_*.exe', 'DevolutionsPedmShellExt.dll',
+              'DevolutionsPedmShellExt.msix', 'DevolutionsDesktopAgent.exe') }
+            'jetsocat' { @('jetsocat_*') }
+          })
           $ExcludePattern = "*.pdb"
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include $IncludePattern -Exclude $ExcludePattern | % {
             if ('${{ matrix.os }}' -Eq 'windows') {
@@ -319,10 +348,6 @@ jobs:
           $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client" | Resolve-Path
           $Env:DGATEWAY_LIB_XMF_PATH = Join-Path "native-libs" "xmf.dll" | Resolve-Path
 
-          Get-ChildItem -Path (Join-Path $PackageRoot PowerShell "*.zip") -Recurse | % {
-            Remove-Item $_.FullName -Force
-          }
-
           ./ci/tlk.ps1 package -Product gateway -PackageOption generate
 
       - name: Regenerate Agent MSI
@@ -381,6 +406,9 @@ jobs:
 
           ./ci/tlk.ps1 package -Product gateway -PackageOption assemble
 
+          $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
+          Remove-Item $Env:DGATEWAY_PSMODULE_PATH -Recurse -ErrorAction SilentlyContinue | Out-Null
+
       - name: Repackage Agent
         if: matrix.project == 'devolutions-agent' && matrix.os == 'windows'
         shell: pwsh
@@ -389,6 +417,17 @@ jobs:
           $Env:DAGENT_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsAgent*.msi' | Select -First 1
 
           ./ci/tlk.ps1 package -Product agent -PackageOption assemble
+
+          $Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH = Join-Path $PackageRoot ${{ matrix.os }} x86_64 DesktopAgent
+          $Env:DAGENT_PEDM_SHELL_EXT_DLL = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.dll' | Select -First 1
+          $Env:DAGENT_PEDM_SHELL_EXT_MSIX = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.msix' | Select -First 1
+          $Env:DAGENT_SESSION_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsSession.exe' | Select -First 1
+
+          @($Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH,
+            $Env:DAGENT_PEDM_SHELL_EXT_DLL, $Env:DAGENT_PEDM_SHELL_EXT_MSIX,
+            $Env:DAGENT_SESSION_EXECUTABLE) | ForEach-Object {
+            Remove-Item $_ -Recurse -ErrorAction SilentlyContinue | Out-Null
+          }
 
       - name: Sign packages
         if: (matrix.project == 'devolutions-gateway' || matrix.project == 'devolutions-agent') && matrix.os == 'windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           New-Item -ItemType Directory -Path $TargetPath
           tar -xvzf $WebAppArchive.FullName -C $TargetPath --strip-components=1
 
-          $PowerShellArchive = Get-ChildItem -Recurse -Filter "Devolutionsgateway-ps-*.zip" | Select-Object -First 1
+          $PowerShellArchive = Get-ChildItem -Recurse -Filter "DevolutionsGateway-ps-*.zip" | Select-Object -First 1
           Expand-Archive $PowerShellArchive -DestinationPath "$PkgDir"
 
       - name: Build container

--- a/ci/PSModuleHelpers.ps1
+++ b/ci/PSModuleHelpers.ps1
@@ -1,0 +1,146 @@
+function New-ModulePackage
+{
+    [CmdletBinding()]
+	param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string] $InputPath,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string] $OutputPath,
+        [string] $TempPath
+    )
+
+    $UniqueId = New-Guid
+
+    if ([string]::IsNullOrEmpty($TempPath)) {
+        $TempPath = [System.IO.Path]::GetTempPath()
+    }
+
+    $PSRepoName = "psrepo-$UniqueId"
+    $PSRepoPath = Join-Path $TempPath $UniqueId
+
+    if (-Not (Test-Path -Path $InputPath -PathType 'Container')) {
+        throw "`"$InputPath`" does not exist"
+    }
+
+    $PSModulePath = $InputPath
+    $PSManifestFile = $(@(Get-ChildItem -Path $PSModulePath -Depth 1 -Filter "*.psd1")[0]).FullName
+    $PSManifest = Import-PowerShellDataFile -Path $PSManifestFile
+    $PSModuleName = $(Get-Item $PSManifestFile).BaseName
+    $PSModuleVersion = $PSManifest.ModuleVersion
+    $PSModulePrerelease = $PSManifest.PrivateData.PSData.Prerelease
+
+    # https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#normalized-version-numbers
+    $NugetVersion = $PSModuleVersion -Replace "^(\d+)\.(\d+)\.(\d+)(\.0)$", "`$1.`$2.`$3"
+    $NugetVersion = (@($NugetVersion, $PSModulePrerelease) | Where-Object { $_ }) -Join '-'
+
+    New-Item -Path $PSRepoPath -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+
+    $Params = @{
+        Name = $PSRepoName;
+        SourceLocation = $PSRepoPath;
+        PublishLocation = $PSRepoPath;
+        InstallationPolicy = "Trusted";
+    }
+
+    Register-PSRepository @Params | Out-Null
+
+    $OutputFileName = "${PSModuleName}.${NugetVersion}.nupkg"
+    $PSModulePackage = Join-Path $PSRepoPath $OutputFileName
+    Remove-Item -Path $PSModulePackage -ErrorAction 'SilentlyContinue'
+    Publish-Module -Path $PSModulePath -Repository $PSRepoName
+
+    Unregister-PSRepository -Name $PSRepoName | Out-Null
+
+    New-Item -Path $OutputPath -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
+    $OutputFile = Join-Path $OutputPath $OutputFileName
+    Copy-Item $PSModulePackage $OutputFile
+
+    Remove-Item $PSmodulePackage
+    Remove-Item -Path $PSRepoPath
+
+    $OutputFile
+}
+
+function Repair-ModulePackage
+{
+    [CmdletBinding()]
+	param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [string] $PackageFile,
+        [string] $UnpackedDir
+    )
+
+    if (-Not (Test-Path -Path $PackageFile)) {
+        throw "`"$PackageFile`" does not exist"
+    }
+
+    if (-Not $PackageFile.EndsWith('.nupkg')) {
+        throw "`"$PackageFile`" does not have .nupkg file extension"
+    }
+
+    $PackageFileItem = $(Get-Item $PackageFile)
+    $OutputDirectory = $PackageFileItem.Directory.FullName
+    if ([string]::IsNullOrEmpty($UnpackedDir)) {
+        $UnpackedDir = Join-Path $OutputDirectory $PackageFileItem.BaseName
+    }
+
+    Remove-Item -Path $UnpackedDir -Recurse -ErrorAction SilentlyContinue | Out-Null
+    Expand-Archive -Path $PackageFile -Destination $UnpackedDir
+
+    $nuspecPath = Get-ChildItem -Path $UnpackedDir -Filter "*.nuspec" -File
+    [xml]$nuspecXml = Get-Content -Path $nuspecPath
+    $ns = $nuspecXml.DocumentElement.NamespaceURI
+    $nsManager = New-Object System.Xml.XmlNamespaceManager($nuspecXml.NameTable)
+    $nsManager.AddNamespace("ns", $ns)
+    $idNode = $nuspecXml.SelectSingleNode("//ns:metadata/ns:id", $nsManager)
+    $titleNode = $nuspecXml.SelectSingleNode("//ns:metadata/ns:title", $nsManager)
+    if ($titleNode) {
+        $titleNode.InnerText = $idNode.InnerText
+    } else {
+        $titleNode = $nuspecXml.CreateElement("title", $nuspecXml.package.NamespaceURI)
+        $titleNode.InnerText = $idNode.InnerText
+        $nuspecXml.package.metadata.InsertAfter($titleNode, $idNode)
+    }
+    $nuspecXml.Save($nuspecPath)
+
+    Remove-Item $PackageFile -ErrorAction SilentlyContinue | Out-Null
+    & nuget pack $UnpackedDir -OutputDirectory $OutputDirectory
+    Remove-Item -Path $UnpackedDir -Recurse -ErrorAction SilentlyContinue | Out-Null
+}
+
+Add-Type -Assembly System.IO.Compression.FileSystem
+
+function Test-ModulePackage
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true, Position=0, ValueFromPipeline=$true)]
+        [System.IO.FileInfo] $PackageFile
+    )
+
+    Process {
+        $PackageFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PackageFile.FullName)
+
+        if (-Not (Test-Path -Path $PackageFile)) {
+            throw "`"$PackageFile`" does not exist"
+        }
+
+        if (-Not $PackageFile.FullName.EndsWith('.nupkg')) {
+            throw "`"$PackageFile`" does not have .nupkg file extension"
+        }
+
+        $ZipArchive = $null
+        try {
+            $ZipArchive = [System.IO.Compression.ZipFile]::OpenRead($PackageFile)
+            $NuspecEntry = $zipArchive.Entries | Where-Object { $_.Name -like "*.nuspec" -and $_.FullName -eq $_.Name } | Select-Object -First 1
+
+            if (-Not $NuspecEntry) {
+                throw "`"$PackageFile`" does not contain .nuspec file in the root directory"
+            }
+        } finally {
+            if ($ZipArchive) {
+                $ZipArchive.Dispose()
+            }
+        }
+    }
+}

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -54,64 +54,6 @@ function Merge-Tokens
     $OutputValue
 }
 
-function New-ModulePackage
-{
-    [CmdletBinding()]
-	param(
-        [Parameter(Mandatory=$true,Position=0)]
-        [string] $InputPath,
-        [Parameter(Mandatory=$true,Position=1)]
-        [string] $OutputPath,
-        [string] $TempPath
-    )
-
-    $UniqueId = New-Guid
-
-    if ([string]::IsNullOrEmpty($TempPath)) {
-        $TempPath = [System.IO.Path]::GetTempPath()
-    }
-
-    $PSRepoName = "psrepo-$UniqueId"
-    $PSRepoPath = Join-Path $TempPath $UniqueId
-
-    if (-Not (Test-Path -Path $InputPath -PathType 'Container')) {
-        throw "`"$InputPath`" does not exist"
-    }
-
-    $PSModulePath = $InputPath
-    $PSManifestFile = $(@(Get-ChildItem -Path $PSModulePath -Depth 1 -Filter "*.psd1")[0]).FullName
-    $PSManifest = Import-PowerShellDataFile -Path $PSManifestFile
-    $PSModuleName = $(Get-Item $PSManifestFile).BaseName
-    $PSModuleVersion = $PSManifest.ModuleVersion
-
-    New-Item -Path $PSRepoPath -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
-
-    $Params = @{
-        Name = $PSRepoName;
-        SourceLocation = $PSRepoPath;
-        PublishLocation = $PSRepoPath;
-        InstallationPolicy = "Trusted";
-    }
-
-    Register-PSRepository @Params | Out-Null
-
-    $OutputFileName = "${PSModuleName}.${PSModuleVersion}.nupkg"
-    $PSModulePackage = Join-Path $PSRepoPath $OutputFileName
-    Remove-Item -Path $PSModulePackage -ErrorAction 'SilentlyContinue'
-    Publish-Module -Path $PSModulePath -Repository $PSRepoName
-
-    Unregister-PSRepository -Name $PSRepoName | Out-Null
-
-    New-Item -Path $OutputPath -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
-    $OutputFile = Join-Path $OutputPath $OutputFileName
-    Copy-Item $PSModulePackage $OutputFile
-
-    Remove-Item $PSmodulePackage
-    Remove-Item -Path $PSRepoPath
-
-    $OutputFile
-}
-
 function Get-DestinationSymbolFile {
     param(
         [Parameter(Mandatory=$true,Position=0)]
@@ -523,18 +465,11 @@ class TlkRecipe
 
         $PSManifestFile = $(@(Get-ChildItem -Path $DGatewayPSModulePath -Depth 1 -Filter "*.psd1")[0]).FullName
         $PSManifest = Import-PowerShellDataFile -Path $PSManifestFile
-        $PSModuleName = $(Get-Item $PSManifestFile).BaseName
         $PSModuleVersion = $PSManifest.ModuleVersion
 
         if ($PackageVersion -ne $PSModuleVersion) {
             Write-Warning "PowerShell module version mismatch: $PSModuleVersion (expected: $PackageVersion)"
         }
-
-        $PSModuleParentPath = Split-Path $DGatewayPSModulePath -Parent
-        $PSModuleZipFilePath = Join-Path $PSModuleParentPath "$PSModuleName-ps-$PSModuleVersion.zip"
-        Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -Update
-
-        New-ModulePackage $DGatewayPSModulePath $PSModuleParentPath
 
         $DGatewayPSModuleStagingPath = Join-Path $Env:Temp "DevolutionsGateway"
         New-Item -Force -Type Directory $DGatewayPSModuleStagingPath


### PR DESCRIPTION
- Split Devolutions Gateway PowerShell module into its own build step
- Produce nupkg for PowerShell module only in the packaging workflow
- Properly code sign PowerShell module contents and reuse them in MSI
- Import PSModuleHelpers.ps1 reusable helpers, move out from tlk.ps1
- Fix "Devolutionsgateway" casing to "DevolutionsGateway" in release.yml