### PR TITLE
fix(agent): add logic to start Gateway service after update

### DIFF
--- a/crates/devolutions-agent-shared/src/lib.rs
+++ b/crates/devolutions-agent-shared/src/lib.rs
@@ -18,14 +18,20 @@ cfg_if! {
         const COMPANY_DIR: &str = "Devolutions";
         const PROGRAM_DIR: &str = "Agent";
         const APPLICATION_DIR: &str = "Devolutions\\Agent";
+
+        pub const GATEWAY_SERVICE_NAME: &str = "DevolutionsGateway";
     } else if #[cfg(target_os = "macos")] {
         const COMPANY_DIR: &str = "Devolutions";
         const PROGRAM_DIR: &str = "Agent";
         const APPLICATION_DIR: &str = "Devolutions Agent";
+
+        pub const GATEWAY_SERVICE_NAME: &str = "devolutions-agent";
     } else {
         const COMPANY_DIR: &str = "devolutions";
         const PROGRAM_DIR: &str = "agent";
         const APPLICATION_DIR: &str = "devolutions-agent";
+
+        pub const GATEWAY_SERVICE_NAME: &str = "devolutions-agent";
     }
 }
 

--- a/crates/win-api-wrappers/Cargo.toml
+++ b/crates/win-api-wrappers/Cargo.toml
@@ -45,6 +45,7 @@ features = [
     "Win32_System_Rpc",
     "Win32_System_StationsAndDesktops",
     "Win32_System_SystemServices",
+    "Win32_System_Services",
     "Win32_System_Threading",
     "Win32_System_WinRT",
     "Win32_UI_Controls",

--- a/crates/win-api-wrappers/src/lib.rs
+++ b/crates/win-api-wrappers/src/lib.rs
@@ -18,6 +18,7 @@ mod lib_win {
     pub mod netmgmt;
     pub mod process;
     pub mod security;
+    pub mod service;
     pub mod thread;
     pub mod token;
     pub mod ui;

--- a/crates/win-api-wrappers/src/service.rs
+++ b/crates/win-api-wrappers/src/service.rs
@@ -1,3 +1,5 @@
+use std::alloc::Layout;
+
 use windows::core::Owned;
 use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, GENERIC_READ};
 use windows::Win32::System::Services::{
@@ -7,49 +9,52 @@ use windows::Win32::System::Services::{
     SERVICE_SYSTEM_START,
 };
 
+use crate::raw_buffer::RawBuffer;
 use crate::utils::WideString;
-use crate::Error;
 
 pub struct ServiceManager {
     handle: Owned<SC_HANDLE>,
 }
 
 impl ServiceManager {
-    pub fn open_read() -> Result<Self, Error> {
+    pub fn open_read() -> anyhow::Result<Self> {
         Self::open_with_access(GENERIC_READ.0)
     }
 
-    pub fn open_all_access() -> Result<Self, Error> {
+    pub fn open_all_access() -> anyhow::Result<Self> {
         Self::open_with_access(SC_MANAGER_ALL_ACCESS)
     }
 
-    fn open_with_access(access: u32) -> Result<Self, Error> {
-        // SAFETY: No preconditions.
+    fn open_with_access(access: u32) -> anyhow::Result<Self> {
+        // SAFETY: FFI call with no outstanding preconditions.
         let raw_sc_handle = unsafe { OpenSCManagerW(None, None, access)? };
 
-        // SAFETY: No preconditions.
+        // SAFETY: Handle returned by `OpenSCManagerW` is valid and needs to be closed after use,
+        // thus it is safe to take ownership of it via `Owned`.
         let handle = unsafe { Owned::new(raw_sc_handle) };
 
         Ok(Self { handle })
     }
 
-    fn open_service_with_access(&self, service_name: &str, access: u32) -> Result<Service, Error> {
+    fn open_service_with_access(&self, service_name: &str, access: u32) -> anyhow::Result<Service> {
         let service_name_wide = WideString::from(service_name);
 
-        // SAFETY: No preconditions.
+        // SAFETY: Value passed as hSCManager is valid as long as `ServiceManager` instance is
+        // alive. Service name is valid null-terminated UTF-16 string allocated on the heap.
         let raw_service_handle = unsafe { OpenServiceW(*self.handle, service_name_wide.as_pcwstr(), access)? };
 
-        // SAFETY: No preconditions.
+        // SAFETY: Handle returned by `OpenServiceW` is valid and needs to be closed after use,
+        // thus it is safe to take ownership of it via `Owned`.
         let handle = unsafe { Owned::new(raw_service_handle) };
 
         Ok(Service { handle })
     }
 
-    pub fn open_service_read(&self, service_name: &str) -> Result<Service, Error> {
+    pub fn open_service_read(&self, service_name: &str) -> anyhow::Result<Service> {
         self.open_service_with_access(service_name, SERVICE_QUERY_CONFIG | SERVICE_QUERY_STATUS)
     }
 
-    pub fn open_service_all_access(&self, service_name: &str) -> Result<Service, Error> {
+    pub fn open_service_all_access(&self, service_name: &str) -> anyhow::Result<Service> {
         self.open_service_with_access(service_name, SERVICE_ALL_ACCESS)
     }
 }
@@ -68,7 +73,7 @@ pub struct Service {
 }
 
 impl Service {
-    pub fn startup_mode(&self) -> Result<ServiceStartupMode, Error> {
+    pub fn startup_mode(&self) -> anyhow::Result<ServiceStartupMode> {
         let mut cbbufsize = 0u32;
         let mut pcbbytesneeded = 0u32;
 
@@ -83,38 +88,38 @@ impl Service {
             Ok(_) => panic!("QueryServiceConfigW should fail with ERROR_INSUFFICIENT_BUFFER"),
         }
 
-        // Event though `QueryServiceConfigW` states that `lpserviceconfig` is a `buffer`,
-        // it needs to be aligned ir order to avoid undefined behavior when accessing
-        // `QUERY_SERVICE_CONFIGW.
+        // The most typical buffer we work with in Rust are homogeneous arrays of integers such
+        // as [u8] or Vec<u8>, but in Microsoft’s Win32 documentation, a `buffer` generally refers
+        // to a caller-allocated memory region that an API uses to either input or output data, and
+        // it is ultimately coerced into some other type with various alignment requirements.
         //
-        // Clippy warning:
-        // casting from `*mut u8` to a more-strictly-aligned pointer
-        // (`*mut windows::Win32::System::Services::QUERY_SERVICE_CONFIGW`) (1 < 8 bytes)
-        assert_eq!(align_of::<QUERY_SERVICE_CONFIGW>(), size_of::<u64>());
+        // lpServiceConfig should point to aligned buffer that could hold a QUERY_SERVICE_CONFIGW
+        // structure.
+        let layout = Layout::from_size_align(
+            usize::try_from(pcbbytesneeded).expect("pcbbytesneeded < 8K as per MSDN"),
+            align_of::<QUERY_SERVICE_CONFIGW>(),
+        )?;
 
-        let pcbbytesneeded_usize = usize::try_from(pcbbytesneeded).expect("pcbbytesneeded < 8K as per MSDN");
+        // SAFETY: The layout initialization is checked using the Layout::from_size_align method.
+        let mut buffer = unsafe { RawBuffer::alloc_zeroed(layout)? };
 
-        let aligned_u64_array_size =
-            pcbbytesneeded_usize / size_of::<u64>() + usize::from(pcbbytesneeded_usize % size_of::<u64>() != 0);
-
-        let aligned_size = u32::try_from(aligned_u64_array_size * size_of::<u64>()).expect("pcbbytesneeded <= 8K");
-
-        let mut buffer: Box<Vec<u64>> = Box::new(vec![0; aligned_u64_array_size]);
-
-        // SAFETY: Buffuer with correct size was allocated prior to the call.
+        // SAFETY: Buffer passed to `lpServiceConfig` have enough size to hold a
+        // QUERY_SERVICE_CONFIGW structure, as required size was queried and allocated above.
+        // Passed buffer have correct alignment to hold QUERY_SERVICE_CONFIGW structure.
         unsafe {
+            // NOTE: Pointer cast is valid, as `buffer` is allocated with correct alignment above.
+            #[allow(clippy::cast_ptr_alignment)]
             QueryServiceConfigW(
                 *self.handle,
-                Some(buffer.as_mut_ptr() as *mut QUERY_SERVICE_CONFIGW),
-                aligned_size,
+                Some(buffer.as_mut_ptr().cast::<QUERY_SERVICE_CONFIGW>()),
+                pcbbytesneeded,
                 &mut cbbufsize,
             )?
         };
 
-        let ptr = buffer.as_mut_ptr() as *mut QUERY_SERVICE_CONFIGW;
         // SAFETY: `QueryServiceConfigW` succeeded, thus `lpserviceconfig` is valid and contains
         // QUERY_SERVICE_CONFIGW structure.
-        let config = unsafe { &*ptr };
+        let config = unsafe { buffer.as_ref_cast::<QUERY_SERVICE_CONFIGW>() };
 
         match config.dwStartType {
             SERVICE_BOOT_START => Ok(ServiceStartupMode::Boot),
@@ -126,15 +131,18 @@ impl Service {
         }
     }
 
-    pub fn is_running(&self) -> Result<bool, Error> {
+    pub fn is_running(&self) -> anyhow::Result<bool> {
         let mut service_status = SERVICE_STATUS::default();
+
+        // SAFETY: hService is valid handle, lpServiceStatus is valid pointer to stack-allocated
+        // SERVICE_STATUS structure.
         unsafe { QueryServiceStatus(*self.handle, &mut service_status as *mut _)? };
 
         Ok(service_status.dwCurrentState == SERVICE_RUNNING)
     }
 
-    pub fn start(&self) -> Result<(), Error> {
-        // SAFETY: No preconditions, arguments are not used.
+    pub fn start(&self) -> anyhow::Result<()> {
+        // SAFETY: FFI call with no outstanding preconditions.
         unsafe { StartServiceW(*self.handle, None)? };
 
         Ok(())

--- a/crates/win-api-wrappers/src/service.rs
+++ b/crates/win-api-wrappers/src/service.rs
@@ -108,7 +108,8 @@ impl Service {
         // QUERY_SERVICE_CONFIGW structure, as required size was queried and allocated above.
         // Passed buffer have correct alignment to hold QUERY_SERVICE_CONFIGW structure.
         unsafe {
-            #[expect(clippy::cast_ptr_alignment)] // Pointer cast is valid, as `buffer` is allocated with correct alignment above.
+            // Pointer cast is valid, as `buffer` is allocated with correct alignment above.
+            #[expect(clippy::cast_ptr_alignment)]
             QueryServiceConfigW(
                 *self.handle,
                 Some(buffer.as_mut_ptr().cast::<QUERY_SERVICE_CONFIGW>()),

--- a/crates/win-api-wrappers/src/service.rs
+++ b/crates/win-api-wrappers/src/service.rs
@@ -1,0 +1,142 @@
+use windows::core::Owned;
+use windows::Win32::Foundation::{ERROR_INSUFFICIENT_BUFFER, GENERIC_READ};
+use windows::Win32::System::Services::{
+    OpenSCManagerW, OpenServiceW, QueryServiceConfigW, QueryServiceStatus, StartServiceW, QUERY_SERVICE_CONFIGW,
+    SC_HANDLE, SC_MANAGER_ALL_ACCESS, SERVICE_ALL_ACCESS, SERVICE_AUTO_START, SERVICE_BOOT_START, SERVICE_DEMAND_START,
+    SERVICE_DISABLED, SERVICE_QUERY_CONFIG, SERVICE_QUERY_STATUS, SERVICE_RUNNING, SERVICE_STATUS,
+    SERVICE_SYSTEM_START,
+};
+
+use crate::utils::WideString;
+use crate::Error;
+
+pub struct ServiceManager {
+    handle: Owned<SC_HANDLE>,
+}
+
+impl ServiceManager {
+    pub fn open_read() -> Result<Self, Error> {
+        Self::open_with_access(GENERIC_READ.0)
+    }
+
+    pub fn open_all_access() -> Result<Self, Error> {
+        Self::open_with_access(SC_MANAGER_ALL_ACCESS)
+    }
+
+    fn open_with_access(access: u32) -> Result<Self, Error> {
+        // SAFETY: No preconditions.
+        let raw_sc_handle = unsafe { OpenSCManagerW(None, None, access)? };
+
+        // SAFETY: No preconditions.
+        let handle = unsafe { Owned::new(raw_sc_handle) };
+
+        Ok(Self { handle })
+    }
+
+    fn open_service_with_access(&self, service_name: &str, access: u32) -> Result<Service, Error> {
+        let service_name_wide = WideString::from(service_name);
+
+        // SAFETY: No preconditions.
+        let raw_service_handle = unsafe { OpenServiceW(*self.handle, service_name_wide.as_pcwstr(), access)? };
+
+        // SAFETY: No preconditions.
+        let handle = unsafe { Owned::new(raw_service_handle) };
+
+        Ok(Service { handle })
+    }
+
+    pub fn open_service_read(&self, service_name: &str) -> Result<Service, Error> {
+        self.open_service_with_access(service_name, SERVICE_QUERY_CONFIG | SERVICE_QUERY_STATUS)
+    }
+
+    pub fn open_service_all_access(&self, service_name: &str) -> Result<Service, Error> {
+        self.open_service_with_access(service_name, SERVICE_ALL_ACCESS)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServiceStartupMode {
+    Boot,
+    System,
+    Automatic,
+    Manual,
+    Disabled,
+}
+
+pub struct Service {
+    handle: Owned<SC_HANDLE>,
+}
+
+impl Service {
+    pub fn startup_mode(&self) -> Result<ServiceStartupMode, Error> {
+        let mut cbbufsize = 0u32;
+        let mut pcbbytesneeded = 0u32;
+
+        // SAFETY: No preconditions. Query required buffer size.
+        let result = unsafe { QueryServiceConfigW(*self.handle, None, 0, &mut pcbbytesneeded) };
+
+        match result {
+            Err(err) if err.code() == ERROR_INSUFFICIENT_BUFFER.to_hresult() => {
+                // Expected error, continue.
+            }
+            Err(err) => return Err(err.into()),
+            Ok(_) => panic!("QueryServiceConfigW should fail with ERROR_INSUFFICIENT_BUFFER"),
+        }
+
+        // Event though `QueryServiceConfigW` states that `lpserviceconfig` is a `buffer`,
+        // it needs to be aligned ir order to avoid undefined behavior when accessing
+        // `QUERY_SERVICE_CONFIGW.
+        //
+        // Clippy warning:
+        // casting from `*mut u8` to a more-strictly-aligned pointer
+        // (`*mut windows::Win32::System::Services::QUERY_SERVICE_CONFIGW`) (1 < 8 bytes)
+        assert_eq!(align_of::<QUERY_SERVICE_CONFIGW>(), size_of::<u64>());
+
+        let pcbbytesneeded_usize = usize::try_from(pcbbytesneeded).expect("pcbbytesneeded < 8K as per MSDN");
+
+        let aligned_u64_array_size =
+            pcbbytesneeded_usize / size_of::<u64>() + usize::from(pcbbytesneeded_usize % size_of::<u64>() != 0);
+
+        let aligned_size = u32::try_from(aligned_u64_array_size * size_of::<u64>()).expect("pcbbytesneeded <= 8K");
+
+        let mut buffer: Box<Vec<u64>> = Box::new(vec![0; aligned_u64_array_size]);
+
+        // SAFETY: Buffuer with correct size was allocated prior to the call.
+        unsafe {
+            QueryServiceConfigW(
+                *self.handle,
+                Some(buffer.as_mut_ptr() as *mut QUERY_SERVICE_CONFIGW),
+                aligned_size,
+                &mut cbbufsize,
+            )?
+        };
+
+        let ptr = buffer.as_mut_ptr() as *mut QUERY_SERVICE_CONFIGW;
+        // SAFETY: `QueryServiceConfigW` succeeded, thus `lpserviceconfig` is valid and contains
+        // QUERY_SERVICE_CONFIGW structure.
+        let config = unsafe { &*ptr };
+
+        match config.dwStartType {
+            SERVICE_BOOT_START => Ok(ServiceStartupMode::Boot),
+            SERVICE_SYSTEM_START => Ok(ServiceStartupMode::System),
+            SERVICE_AUTO_START => Ok(ServiceStartupMode::Automatic),
+            SERVICE_DEMAND_START => Ok(ServiceStartupMode::Manual),
+            SERVICE_DISABLED => Ok(ServiceStartupMode::Disabled),
+            _ => panic!("WinAPI returned invalid service startup mode"),
+        }
+    }
+
+    pub fn is_running(&self) -> Result<bool, Error> {
+        let mut service_status = SERVICE_STATUS::default();
+        unsafe { QueryServiceStatus(*self.handle, &mut service_status as *mut _)? };
+
+        Ok(service_status.dwCurrentState == SERVICE_RUNNING)
+    }
+
+    pub fn start(&self) -> Result<(), Error> {
+        // SAFETY: No preconditions, arguments are not used.
+        unsafe { StartServiceW(*self.handle, None)? };
+
+        Ok(())
+    }
+}

--- a/devolutions-agent/src/session_manager.rs
+++ b/devolutions-agent/src/session_manager.rs
@@ -93,10 +93,6 @@ impl SessionManagerCtx {
         self.sessions.remove(&session.to_string());
     }
 
-    fn get_session(&self, session: &Session) -> Option<&GatewaySession> {
-        self.sessions.get(&session.to_string())
-    }
-
     fn get_session_mut(&mut self, session: &Session) -> Option<&mut GatewaySession> {
         self.sessions.get_mut(&session.to_string())
     }

--- a/devolutions-agent/src/updater/error.rs
+++ b/devolutions-agent/src/updater/error.rs
@@ -43,13 +43,7 @@ pub(crate) enum UpdaterError {
     #[error("process does not have required rights to install MSI")]
     NotElevated,
     #[error("failed to query service state for `{product}`")]
-    QueryServiceState {
-        product: Product,
-        source: win_api_wrappers::Error,
-    },
+    QueryServiceState { product: Product, source: anyhow::Error },
     #[error("failed to start service for `{product}`")]
-    StartService {
-        product: Product,
-        source: win_api_wrappers::Error,
-    },
+    StartService { product: Product, source: anyhow::Error },
 }

--- a/devolutions-agent/src/updater/error.rs
+++ b/devolutions-agent/src/updater/error.rs
@@ -42,4 +42,14 @@ pub(crate) enum UpdaterError {
     Io(#[from] std::io::Error),
     #[error("process does not have required rights to install MSI")]
     NotElevated,
+    #[error("failed to query service state for `{product}`")]
+    QueryServiceState {
+        product: Product,
+        source: win_api_wrappers::Error,
+    },
+    #[error("failed to start service for `{product}`")]
+    StartService {
+        product: Product,
+        source: win_api_wrappers::Error,
+    },
 }

--- a/devolutions-agent/src/updater/package.rs
+++ b/devolutions-agent/src/updater/package.rs
@@ -43,14 +43,20 @@ async fn install_msi(ctx: &UpdaterCtx, path: &Utf8Path, log_path: &Utf8Path) -> 
 
     info!("Installing MSI from path: {}", path);
 
-    let msi_install_result = tokio::process::Command::new("msiexec")
+    let mut msiexec_command = tokio::process::Command::new("msiexec");
+
+    msiexec_command
         .arg("/i")
         .arg(path.as_str())
         .arg("/quiet")
         .arg("/l*v")
-        .arg(log_path.as_str())
-        .status()
-        .await;
+        .arg(log_path.as_str());
+
+    for param in ctx.actions.get_msiexec_install_params() {
+        msiexec_command.arg(param);
+    }
+
+    let msi_install_result = msiexec_command.status().await;
 
     if log_path.exists() {
         info!("MSI installation log: {log_path}");

--- a/devolutions-agent/src/updater/product_actions.rs
+++ b/devolutions-agent/src/updater/product_actions.rs
@@ -19,7 +19,7 @@ struct GatewayUpdateActions {
 }
 
 impl GatewayUpdateActions {
-    fn pre_update_impl(&mut self) -> Result<(), win_api_wrappers::Error> {
+    fn pre_update_impl(&mut self) -> anyhow::Result<()> {
         info!("Querying service state for Gateway");
         let service_manager = ServiceManager::open_read()?;
         let service = service_manager.open_service_read(SERVICE_NAME)?;
@@ -35,7 +35,7 @@ impl GatewayUpdateActions {
         Ok(())
     }
 
-    fn post_update_impl(&self) -> Result<(), win_api_wrappers::Error> {
+    fn post_update_impl(&self) -> anyhow::Result<()> {
         // Start service if it was running prior to the update, but service startup
         // was set to manual.
         if !self.service_startup_was_automatic && self.service_was_running {

--- a/devolutions-agent/src/updater/product_actions.rs
+++ b/devolutions-agent/src/updater/product_actions.rs
@@ -1,0 +1,88 @@
+use win_api_wrappers::service::{ServiceManager, ServiceStartupMode};
+
+use crate::updater::{Product, UpdaterError};
+
+const SERVICE_NAME: &str = "DevolutionsGateway";
+
+/// Additional actions that need to be performed during product update process
+pub(crate) trait ProductUpdateActions {
+    fn pre_update(&mut self) -> Result<(), UpdaterError>;
+    fn get_msiexec_install_params(&self) -> Vec<String>;
+    fn post_update(&mut self) -> Result<(), UpdaterError>;
+}
+
+/// Gateway specific update actions
+#[derive(Default)]
+struct GatewayUpdateActions {
+    service_was_running: bool,
+    service_startup_was_automatic: bool,
+}
+
+impl GatewayUpdateActions {
+    fn pre_update_impl(&mut self) -> Result<(), win_api_wrappers::Error> {
+        info!("Querying service state for Gateway");
+        let service_manager = ServiceManager::open_read()?;
+        let service = service_manager.open_service_read(SERVICE_NAME)?;
+
+        self.service_startup_was_automatic = service.startup_mode()? == ServiceStartupMode::Automatic;
+        self.service_was_running = service.is_running()?;
+
+        info!(
+            "Service state for Gateway before update: running: {}, automatic_startup: {}",
+            self.service_was_running, self.service_startup_was_automatic
+        );
+
+        Ok(())
+    }
+
+    fn post_update_impl(&self) -> Result<(), win_api_wrappers::Error> {
+        // Start service if it was running prior to the update, but service startup
+        // was set to manual.
+        if !self.service_startup_was_automatic && self.service_was_running {
+            info!("Starting Gateway service after update");
+
+            let service_manager = ServiceManager::open_all_access()?;
+            let service = service_manager.open_service_all_access(SERVICE_NAME)?;
+            service.start()?;
+
+            info!("Gateway service started");
+        }
+
+        Ok(())
+    }
+}
+
+impl ProductUpdateActions for GatewayUpdateActions {
+    fn pre_update(&mut self) -> Result<(), UpdaterError> {
+        self.pre_update_impl()
+            .map_err(|source| UpdaterError::QueryServiceState {
+                product: Product::Gateway,
+                source,
+            })
+    }
+
+    fn get_msiexec_install_params(&self) -> Vec<String> {
+        // When performing update, we want to make sure the service startup mode is restored to the
+        // previous state. (Installer sets Manual by default).
+        if self.service_startup_was_automatic {
+            info!("Adjusting MSIEXEC parameters for Gateway service startup mode");
+
+            return vec!["P.SERVICESTART=Automatic".to_string()];
+        }
+
+        Vec::new()
+    }
+
+    fn post_update(&mut self) -> Result<(), UpdaterError> {
+        self.post_update_impl().map_err(|source| UpdaterError::StartService {
+            product: Product::Gateway,
+            source,
+        })
+    }
+}
+
+pub(crate) fn build_product_actions(product: Product) -> Box<dyn ProductUpdateActions + Sync + Send + 'static> {
+    match product {
+        Product::Gateway => Box::new(GatewayUpdateActions::default()),
+    }
+}

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -15,7 +15,8 @@ use std::time::Duration;
 use tap::prelude::*;
 use tokio::runtime::{self, Runtime};
 
-pub(crate) const SERVICE_NAME: &str = "devolutions-gateway";
+pub(crate) use devolutions_agent_shared::GATEWAY_SERVICE_NAME as SERVICE_NAME;
+
 pub(crate) const DISPLAY_NAME: &str = "Devolutions Gateway";
 pub(crate) const DESCRIPTION: &str = "Devolutions Gateway service";
 


### PR DESCRIPTION
This PR adds the following logic to the updater:
* Gateway service startup mode when correctly performing MSI install
* Start service if it was in "Manual" startup mode before installation, but in "Running" state, to avoid unintuitive behavior