### PR TITLE
build(dgw): move libxmf.so to /usr/lib

### DIFF
--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -769,7 +769,7 @@ class TlkRecipe
             arch = $DebianArchitecture
             deps = $($Dependencies -Join ", ")
             email = $Email
-            package = $Packager
+            packager = $Packager
             website = $Website
         } -OutputFile $ControlFile
 

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -315,27 +315,17 @@ impl Conf {
             return Some(path.to_owned());
         }
 
-        #[cfg(target_os = "windows")]
-        {
+        if cfg!(target_os = "windows") {
             let path = env::current_exe().ok()?.parent()?.join("xmf.dll");
             return Utf8PathBuf::from_path_buf(path).ok();
+        } else if cfg!(all(
+            target_os = "linux",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        )) {
+            Some(Utf8PathBuf::from("/usr/lib/devolutions-gateway/libxmf.so"))
+        } else {
+            None
         }
-
-        #[cfg(target_os = "linux")]
-        {
-            #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
-            {
-                return None;
-            }
-
-            let arch_path = format!(
-                "/usr/lib/{arch}-linux-gnu/devolutions-gateway/libxmf.so",
-                arch = env::consts::ARCH,
-            );
-            return Some(Utf8PathBuf::from(arch_path));
-        }
-
-        None
     }
 }
 

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -317,7 +317,7 @@ impl Conf {
 
         if cfg!(target_os = "windows") {
             let path = env::current_exe().ok()?.parent()?.join("xmf.dll");
-            return Utf8PathBuf::from_path_buf(path).ok();
+            Utf8PathBuf::from_path_buf(path).ok()
         } else if cfg!(target_os = "linux") {
             Some(Utf8PathBuf::from("/usr/lib/devolutions-gateway/libxmf.so"))
         } else {

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -318,10 +318,7 @@ impl Conf {
         if cfg!(target_os = "windows") {
             let path = env::current_exe().ok()?.parent()?.join("xmf.dll");
             return Utf8PathBuf::from_path_buf(path).ok();
-        } else if cfg!(all(
-            target_os = "linux",
-            any(target_arch = "x86_64", target_arch = "aarch64")
-        )) {
+        } else if cfg!(target_os = "linux") {
             Some(Utf8PathBuf::from("/usr/lib/devolutions-gateway/libxmf.so"))
         } else {
             None

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -1,4 +1,16 @@
 #!/usr/bin/make -f
+
+ifeq ($(DEB_HOST_ARCH),amd64)
+ARCH = x86_64
+else ifeq ($(DEB_HOST_ARCH),arm64)
+ARCH = aarch64
+else
+$(error Unsupported architecture: $(DEB_HOST_ARCH))
+endif
+
+WEBAPP_DIR := $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
+LIBXMF_DIR := $$(pwd)/debian/devolutions-gateway/usr/lib/$(ARCH)-linux-gnu/devolutions-gateway
+
 %:
 	dh $@
 override_dh_auto_clean:
@@ -10,9 +22,10 @@ override_dh_usrlocal:
 	install -D -m 0755 {{ dgateway_executable }} $$(pwd)/debian/devolutions-gateway/usr/bin/devolutions-gateway
 override_dh_install:
 	dh_install
-	mkdir -p $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
-	cp -r {{ dgateway_webclient }} $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
-	cp -r {{ root_path }}/webapp/player $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
-	cp {{ dgateway_libxmf }} $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/libxmf.so
+	mkdir -p $(WEBAPP_DIR)
+	cp -r {{ dgateway_webclient }} $(WEBAPP_DIR)
+	cp -r {{ root_path }}/webapp/player $(WEBAPP_DIR)
+	mkdir -p $(LIBXMF_DIR)
+	cp {{ dgateway_libxmf }} $(LIBXMF_DIR)/libxmf.so
 override_dh_shlibdeps:
 	{{ dh_shlibdeps }}

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -1,15 +1,7 @@
 #!/usr/bin/make -f
 
-ifeq ($(DEB_HOST_ARCH),amd64)
-ARCH = x86_64
-else ifeq ($(DEB_HOST_ARCH),arm64)
-ARCH = aarch64
-else
-$(error Unsupported architecture: $(DEB_HOST_ARCH))
-endif
-
 WEBAPP_DIR := $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
-LIBXMF_DIR := $$(pwd)/debian/devolutions-gateway/usr/lib/$(ARCH)-linux-gnu/devolutions-gateway
+LIBXMF_DIR := $$(pwd)/debian/devolutions-gateway/usr/lib/devolutions-gateway
 
 %:
 	dh $@


### PR DESCRIPTION
This moves _libxmf.so_ from `/usr/share/devolutions-gateway` to
`/usr/lib/devolutions-gateway`.

According to the [FHS](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s11.html), `/usr/share` is for architecture-independent data files.