### PR TITLE
build(dgw): correct typo causing missing packager

### DIFF
--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -769,7 +769,7 @@ class TlkRecipe
             arch = $DebianArchitecture
             deps = $($Dependencies -Join ", ")
             email = $Email
-            package = $Packager
+            packager = $Packager
             website = $Website
         } -OutputFile $ControlFile
 


### PR DESCRIPTION
The control template expects a variable named `packager` but `package` was passed.