### PR TITLE
build: add RPM for gateway and agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,6 +606,7 @@ jobs:
           }
 
           $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client" | Resolve-Path
+          $Env:DGATEWAY_WEBPLAYER_PATH = Join-Path "webapp" "player" | Resolve-Path
 
           ./ci/tlk.ps1 package -Product gateway -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,10 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
           echo "STRIP_EXECUTABLE=aarch64-linux-gnu-strip" >> $GITHUB_ENV
 
+      - name: Install fpm
+        if: matrix.os == 'Linux'
+        run: sudo gem install --no-document fpm
+
       - name: Configure Windows runner
         if: matrix.os == 'windows'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,6 +727,10 @@ jobs:
         if: matrix.os == 'windows'
         uses: microsoft/setup-msbuild@v2
 
+      - name: Install fpm
+        if: runner.os == 'Linux'
+        run: sudo gem install --no-document fpm
+
       - name: Build
         shell: pwsh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,6 +702,10 @@ jobs:
           rustup target add aarch64-unknown-linux-gnu
           echo "STRIP_EXECUTABLE=aarch64-linux-gnu-strip" >> $GITHUB_ENV
 
+      - name: Install fpm
+        if: matrix.os == 'Linux'
+        run: sudo gem install --no-document fpm
+
       - name: Configure Windows runner
         if: matrix.os == 'windows'
         run: |
@@ -730,10 +734,6 @@ jobs:
       - name: Add msbuild to PATH
         if: matrix.os == 'windows'
         uses: microsoft/setup-msbuild@v2
-
-      - name: Install fpm
-        if: runner.os == 'Linux'
-        run: sudo gem install --no-document fpm
 
       - name: Build
         shell: pwsh

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -346,6 +346,7 @@ jobs:
           $Env:DGATEWAY_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.exe' | Select -First 1
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client" | Resolve-Path
+          $Env:DGATEWAY_WEBPLAYER_PATH = Join-Path "webapp" "player" | Resolve-Path
           $Env:DGATEWAY_LIB_XMF_PATH = Join-Path "native-libs" "xmf.dll" | Resolve-Path
 
           ./ci/tlk.ps1 package -Product gateway -PackageOption generate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ debug = 1
 [profile.production]
 inherits = "release"
 lto = true
+strip = "symbols"
 
 [patch.crates-io]
 tracing-appender = { git = "https://github.com/CBenoit/tracing.git", rev = "42097daf92e683cf18da7639ddccb056721a796c" }

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -823,9 +823,6 @@ class TlkRecipe
             $DpkgBuildPackageArgs += @('-a', $this.Target.DebianArchitecture())
         }
 
-        # Strip first so the included binary is identical for deb and rpm.
-        & 'strip' $Executable | Out-Host
-
         # Disable dpkg-buildpackage stripping as the binary is already stripped.
         $Env:DEB_BUILD_OPTIONS = "nostrip"
         & 'dpkg-buildpackage' $DpkgBuildPackageArgs | Out-Host

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -658,15 +658,14 @@ class TlkRecipe
         $Env:DEBFULLNAME = $Packager
         $Env:DEBEMAIL = $Email
 
-        $DGatewayExecutable = $null
+        $Executable = $null
         $DGatewayWebClient = $null
         $DGatewayLibXmf = $null
-        $DAgentExecutable = $null
 
         switch ($this.Product) {
             "gateway" {
                 if (Test-Path Env:DGATEWAY_EXECUTABLE) {
-                    $DGatewayExecutable = $Env:DGATEWAY_EXECUTABLE
+                    $Executable = $Env:DGATEWAY_EXECUTABLE
                 } else {
                     throw ("Specify DGATEWAY_EXECUTABLE environment variable")
                 }
@@ -685,7 +684,7 @@ class TlkRecipe
             }
             "agent" {
                 if (Test-Path Env:DAGENT_EXECUTABLE) {
-                    $DAgentExecutable = $Env:DAGENT_EXECUTABLE
+                    $Executable = $Env:DAGENT_EXECUTABLE
                 } else {
                     throw ("Specify DAGENT_EXECUTABLE environment variable")
                 }
@@ -697,9 +696,9 @@ class TlkRecipe
             "agent" { "Agent" }
         }
 
-        $Description = ""
-        if ($this.Product -eq "gateway") {
-            $Description = "Blazing fast relay server with desired levels of traffic inspection"
+        $Description = switch ($this.Product) {
+            "gateway" { "Blazing fast relay server with desired levels of traffic inspection" }
+            "agent" { "Agent companion service for Devolutions Gateway" }
         }
 
         $InputPackagePath = Join-Path $this.SourcePath "package/$($InputPackagePathPrefix)Linux"
@@ -754,7 +753,7 @@ class TlkRecipe
             "gateway" {
                 Merge-Tokens -TemplateFile $RulesTemplate -Tokens @{
                     root_path = $this.SourcePath
-                    dgateway_executable = $DGatewayExecutable
+                    executable = $Executable
                     dgateway_webclient = $DGatewayWebClient
                     dgateway_libxmf = $DGatewayLibXmf
                     platform_dir = $InputPackagePath
@@ -763,7 +762,7 @@ class TlkRecipe
             }
             "agent" {
                 Merge-Tokens -TemplateFile $RulesTemplate -Tokens @{
-                    dagent_executable = $DAgentExecutable
+                    executable = $Executable
                     platform_dir = $InputPackagePath
                     dh_shlibdeps = $DhShLibDepsOverride
                 } -OutputFile $RulesFile
@@ -833,7 +832,7 @@ class TlkRecipe
             '--license', 'Apache-2.0 OR MIT'
             '--rpm-attr', "755,root,root:/usr/bin/$PkgName"
             '--',
-            "$DGatewayExecutable=/usr/bin/$PkgName"
+            "$Executable=/usr/bin/$PkgName"
         )
 
         & 'fpm' @FpmArgs | Out-Host

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -826,6 +826,7 @@ class TlkRecipe
         # Strip first so the included binary is identical for deb and rpm
         & 'strip' $Executable | Out-Host
 
+        # Disable dpkg-buildpackage stripping as the binary is already stripped.
         $env:DEB_BUILD_OPTIONS = "nostrip"
         & 'dpkg-buildpackage' $DpkgBuildPackageArgs | Out-Host
 

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -660,6 +660,7 @@ class TlkRecipe
 
         $Executable = $null
         $DGatewayWebClient = $null
+        $DGatewayWebPlayer = $null
         $DGatewayLibXmf = $null
 
         switch ($this.Product) {
@@ -675,6 +676,7 @@ class TlkRecipe
                 } else {
                     throw ("Specify DGATEWAY_WEBCLIENT_PATH environment variable")
                 }
+                $DGatewayWebPlayer = "$($this.SourcePath)/webapp/player"
 
                 if (Test-Path Env:DGATEWAY_LIB_XMF_PATH) {
                     $DGatewayLibXmf = $Env:DGATEWAY_LIB_XMF_PATH
@@ -752,9 +754,9 @@ class TlkRecipe
         switch ($this.Product) {
             "gateway" {
                 Merge-Tokens -TemplateFile $RulesTemplate -Tokens @{
-                    root_path = $this.SourcePath
                     executable = $Executable
                     dgateway_webclient = $DGatewayWebClient
+                    dgateway_webplayer = $DGatewayWebPlayer
                     dgateway_libxmf = $DGatewayLibXmf
                     platform_dir = $InputPackagePath
                     dh_shlibdeps = $DhShLibDepsOverride
@@ -831,9 +833,19 @@ class TlkRecipe
             '--url', $Website,
             '--license', 'Apache-2.0 OR MIT'
             '--rpm-attr', "755,root,root:/usr/bin/$PkgName"
-            '--',
+            '--'
             "$Executable=/usr/bin/$PkgName"
+            "$ChangeLogFile=/usr/share/$PkgName/changelog"
+            "$CopyrightFile=/usr/share/$PkgName/copyright"
         )
+
+        if ($this.Product -eq "gateway") {
+            $FpmArgs += @(
+                "$DGatewayWebClient=/usr/share/devolutions-gateway/webapp",
+                "$DGatewayWebPlayer=/usr/share/devolutions-gateway/webapp",
+                "$DGatewayLibXmf=/usr/lib/devolutions-gateway/libxmf.so"
+            )
+        }
 
         & 'fpm' @FpmArgs | Out-Host
 

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -823,11 +823,11 @@ class TlkRecipe
             $DpkgBuildPackageArgs += @('-a', $this.Target.DebianArchitecture())
         }
 
-        # Strip first so the included binary is identical for deb and rpm
+        # Strip first so the included binary is identical for deb and rpm.
         & 'strip' $Executable | Out-Host
 
         # Disable dpkg-buildpackage stripping as the binary is already stripped.
-        $env:DEB_BUILD_OPTIONS = "nostrip"
+        $Env:DEB_BUILD_OPTIONS = "nostrip"
         & 'dpkg-buildpackage' $DpkgBuildPackageArgs | Out-Host
 
         $FpmArgs = @(

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -823,6 +823,10 @@ class TlkRecipe
             $DpkgBuildPackageArgs += @('-a', $this.Target.DebianArchitecture())
         }
 
+        # Strip first so the included binary is identical for deb and rpm
+        & 'strip' $Executable | Out-Host
+
+        $env:DEB_BUILD_OPTIONS = "nostrip"
         & 'dpkg-buildpackage' $DpkgBuildPackageArgs | Out-Host
 
         $FpmArgs = @(

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -676,7 +676,12 @@ class TlkRecipe
                 } else {
                     throw ("Specify DGATEWAY_WEBCLIENT_PATH environment variable")
                 }
-                $DGatewayWebPlayer = "$($this.SourcePath)/webapp/player"
+
+                if (Test-Path Env:DGATEWAY_WEBPLAYER_PATH) {
+                    $DGatewayWebPlayer = $Env:DGATEWAY_WEBPLAYER_PATH
+                } else {
+                    throw ("Specify DGATEWAY_WEBPLAYER_PATH environment variable")
+                }
 
                 if (Test-Path Env:DGATEWAY_LIB_XMF_PATH) {
                     $DGatewayLibXmf = $Env:DGATEWAY_LIB_XMF_PATH

--- a/package/AgentLinux/agent/template/control
+++ b/package/AgentLinux/agent/template/control
@@ -9,5 +9,5 @@ Homepage: {{ website }}
 Package: devolutions-agent
 Architecture: {{ arch }}
 Depends: {{ deps }}
-Description: Devolutions Agent
+Description: {{ description }}
  {{ website }}

--- a/package/AgentLinux/agent/template/rules
+++ b/package/AgentLinux/agent/template/rules
@@ -7,7 +7,7 @@ override_dh_auto_build:
 override_dh_auto_test:
 override_dh_auto_install:
 override_dh_usrlocal:
-	install -D -m 0755 {{ dagent_executable }} $$(pwd)/debian/devolutions-agent/usr/bin/devolutions-agent
+	install -D -m 0755 {{ executable }} $$(pwd)/debian/devolutions-agent/usr/bin/devolutions-agent
 override_dh_install:
 	dh_install
 override_dh_shlibdeps:

--- a/package/Linux/gateway/template/control
+++ b/package/Linux/gateway/template/control
@@ -9,5 +9,5 @@ Homepage: {{ website }}
 Package: devolutions-gateway
 Architecture: {{ arch }}
 Depends: {{ deps }}
-Description: Devolutions Gateway
+Description: {{ description }}
  {{ website }}

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -7,7 +7,7 @@ override_dh_auto_build:
 override_dh_auto_test:
 override_dh_auto_install:
 override_dh_usrlocal:
-	install -D -m 0755 {{ dgateway_executable }} $$(pwd)/debian/devolutions-gateway/usr/bin/devolutions-gateway
+	install -D -m 0755 {{ executable }} $$(pwd)/debian/devolutions-gateway/usr/bin/devolutions-gateway
 override_dh_install:
 	dh_install
 	mkdir -p $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -12,7 +12,7 @@ override_dh_install:
 	dh_install
 	mkdir -p $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
 	cp -r {{ dgateway_webclient }} $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
-	cp -r {{ root_path }}/webapp/player $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
+	cp -r {{ dgateway_webplayer }} $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/webapp
 	cp {{ dgateway_libxmf }} $$(pwd)/debian/devolutions-gateway/usr/share/devolutions-gateway/libxmf.so
 override_dh_shlibdeps:
 	{{ dh_shlibdeps }}

--- a/package/WindowsManaged/Program.cs
+++ b/package/WindowsManaged/Program.cs
@@ -100,6 +100,30 @@ internal class Program
         }
     }
 
+    private static string DevolutionsWebPlayerPath
+    {
+        get
+        {
+            string path = Environment.GetEnvironmentVariable("DGATEWAY_WEBPLAYER_PATH");
+
+            if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
+            {
+#if DEBUG
+                path = "..\\..\\webapp\\player";
+#else
+                throw new Exception("The environment variable DGATEWAY_WEBPLAYER_PATH is not specified or the directory does not exist");
+#endif
+            }
+
+            if (!Directory.Exists(path))
+            {
+                throw new DirectoryNotFoundException("The web player was not found");
+            }
+
+            return path;
+        }
+    }
+
     private static string LibXmfPath
     {
         get

--- a/package/WindowsManaged/Program.cs
+++ b/package/WindowsManaged/Program.cs
@@ -335,7 +335,7 @@ internal class Program
                         Dirs = new Dir[]
                         {
                             new("client", new Files($@"{DevolutionsWebClientPath}\*.*")),
-                            new("player", new Files(@"..\..\webapp\player\*.*"))
+                            new("player", new Files($@"{DevolutionsWebPlayerPath}\*.*")),
                         }
                     }
                 }


### PR DESCRIPTION
This commit adds RPM packages for Gateway and Agent to the release assets.

`tlk.ps1 -TlkVerb package -Platform linux` now generates both a deb and an rpm for the specified product.

The rpm is generated with fpm, a Linux packaging tool.
In CI, no cache is used for the fpm dependency since the cache would not persist across release jobs.

The RPM includes all the assets of the corresponding Debian package, including the changelog, copyright, maintainer scripts, and webapp/libxmf.so for Gateway.

The changelog is copied directly from Debian. A separate PR will be made to convert it to an RPM-friendly changelog format.

Tested with RHEL 9 (glibc 2.34).