### PR TITLE
fix(dgw): fix illegal invocation for send method on streaming player websocket proxy

### DIFF
--- a/webapp/player-project/src/ws-proxy.ts
+++ b/webapp/player-project/src/ws-proxy.ts
@@ -38,6 +38,15 @@ const WebSocketProxy = new Proxy(window.WebSocket, {
         }
         return Reflect.set(target, prop, value);
       },
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        // Bind native methods to the original WebSocket instance
+        // Websocket send and other method need the `this` to points to the WebSocket instance
+        if (typeof value === 'function') {
+          return value.bind(target);
+        }
+        return value;
+      },
     });
   },
 });

--- a/webapp/player-project/src/ws-proxy.ts
+++ b/webapp/player-project/src/ws-proxy.ts
@@ -40,7 +40,7 @@ const WebSocketProxy = new Proxy(window.WebSocket, {
       },
       get(target, prop, receiver) {
         const value = Reflect.get(target, prop, receiver);
-        // Because these methods are part of the native WebSocket prototype,       
+        // Because these methods are part of the native WebSocket prototype,
         // they must be called with the original WebSocket as `this`.
         // If they're called with the Proxy as `this`, it results in an "illegal invocation".
         // Binding them to the underlying `target` (the real WebSocket) avoids this issue.

--- a/webapp/player-project/src/ws-proxy.ts
+++ b/webapp/player-project/src/ws-proxy.ts
@@ -40,8 +40,10 @@ const WebSocketProxy = new Proxy(window.WebSocket, {
       },
       get(target, prop, receiver) {
         const value = Reflect.get(target, prop, receiver);
-        // Bind native methods to the original WebSocket instance
-        // Websocket send and other method need the `this` to points to the WebSocket instance
+        // Because these methods are part of the native WebSocket prototype,       
+        // they must be called with the original WebSocket as `this`.
+        // If they're called with the Proxy as `this`, it results in an "illegal invocation".
+        // Binding them to the underlying `target` (the real WebSocket) avoids this issue.
         if (typeof value === 'function') {
           return value.bind(target);
         }


### PR DESCRIPTION
Fix the problem when Websocket send is called, we have an illegal invocation exception. The Websocket send method needs to be tied to the Websocket instance instead of the proxy, that is, the `this` keywords need to be bind to the correct object. This problem was introduced in the previous effort to intercept the `close` method for Websocket

Changelog: ignore