### PR TITLE
fix(dgw): send close code 1005 when video streaming ends

### DIFF
--- a/crates/video-streamer/src/streamer/mod.rs
+++ b/crates/video-streamer/src/streamer/mod.rs
@@ -23,6 +23,7 @@ pub(crate) mod signal_writer;
 pub(crate) mod tag_writers;
 
 use crate::{reopenable::Reopenable, StreamingConfig};
+use tokio::io::AsyncWriteExt;
 
 #[instrument(skip_all)]
 pub fn webm_stream(
@@ -226,6 +227,7 @@ fn spawn_sending_task<W>(
                 },
             }
         }
+        let _ = ws_frame.lock().await.get_mut().shutdown().await;
         Ok::<_, anyhow::Error>(())
     });
 
@@ -249,6 +251,7 @@ fn spawn_sending_task<W>(
             }
         }
         info!("Stopping streaming task");
+        let _ = ws_frame_clone.lock().await.get_mut().shutdown().await;
         handle.abort();
         stop_notifier.notify_waiters();
         Ok::<_, anyhow::Error>(())


### PR DESCRIPTION
Trying to make the `websocket_compact ` function return a result with a new trait.
I tried to make a Generic type for the `WithExplict` but faild as the combination for With and Map trait generic and bounds is beyond my comprehension. I hope @CBenoit  could make a better type than this... 
feel free to edit it, and let me know your thoughts, thanks! 