### PR TITLE
fix(dgw): improve log quality

### DIFF
--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -58,7 +58,13 @@ where
                 anyhow::bail!("timed out at preconnection blob reception");
             }
             result = read_pcb_fut => {
-                result?
+                match result {
+                    Ok(result) => result,
+                    Err(error) => {
+                        info!(%error, "Received payload not matching the expected protocol");
+                        return Ok(())
+                    }
+                }
             }
         };
 

--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -55,7 +55,8 @@ where
 
         let (pdu, mut leftover_bytes) = tokio::select! {
             () = timeout => {
-                anyhow::bail!("timed out at preconnection blob reception");
+                info!("Timed out at preconnection blob reception");
+                return Ok(())
             }
             result = read_pcb_fut => {
                 match result {

--- a/devolutions-gateway/src/listener.rs
+++ b/devolutions-gateway/src/listener.rs
@@ -46,7 +46,7 @@ impl GatewayListener {
     pub fn init_and_bind(url: impl ToInternalUrl, state: DgwState) -> anyhow::Result<Self> {
         let url = url.to_internal_url();
 
-        info!(%url, "Initiating listener…");
+        info!(%url, "Initiating listener...");
 
         let socket_addr = url_to_socket_addr(&url).context("invalid url")?;
 
@@ -119,12 +119,12 @@ async fn run_tcp_listener(listener: TcpListener, state: DgwState) -> anyhow::Res
 
                 ChildTask::spawn(async move {
                     if let Err(e) = handle_tcp_peer(stream, state, peer_addr).await {
-                        error!(error = format!("{e:#}"), "Peer failure");
+                        error!(error = format!("{e:#}"), client = %peer_addr, "TCP peer failure");
                     }
                 })
                 .detach();
             }
-            Err(e) => error!(error = format!("{e:#}"), "Listener failure"),
+            Err(e) => error!(error = format!("{e:#}"), "TCP listener failure"),
         }
     }
 }
@@ -181,7 +181,7 @@ async fn run_http_listener(listener: TcpListener, state: DgwState) -> anyhow::Re
                 ChildTask::spawn(fut).detach();
             }
             Err(error) => {
-                error!(%error, "failed to accept connection");
+                error!(%error, "Failed to accept connection");
             }
         }
     }


### PR DESCRIPTION
- Enhance the "Peer failure" log to include the peer address and the listener kind (in fact, always TCP).
- Instead of an ERROR-level trace, log an INFO-level trace when the wrong protocol is used on the TCP listener.