### PR TITLE
build: remove unused Linux deps

### DIFF
--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -650,13 +650,7 @@ class TlkRecipe
         $Website = "https://devolutions.net"
         $PackageVersion = $this.Version
         $DistroCodeName = "focal" # Ubuntu 20.04
-        $Dependencies = @('liblzma5', 'liblz4-1')
-
-        if ($this.Target.DebianArchitecture() -Eq 'arm64') {
-            $Dependencies += @("libc6 (>= 2.29)", "libgcc-s1 (>= 4.2)")
-        } else {
-            $Dependencies += @('${shlibs:Depends}', '${misc:Depends}')
-        }
+        $Dependencies = @('libc6 (>= 2.31)')
 
         $Env:DEBFULLNAME = $Packager
         $Env:DEBEMAIL = $Email
@@ -875,6 +869,7 @@ class TlkRecipe
             '-p', "$OutputPath/${RpmPkgNameTarget}.rpm",
             '-n', $PkgName,
             '-v', $PackageVersion,
+            '-d', 'glibc',
             '--maintainer', "$Packager <$Email>",
             '--description', $Description,
             '--url', $Website,


### PR DESCRIPTION
This removes unused dependencies.
libc6 on Debian is glibc on RPM-based systems.

libc6 version is bumped to 2.31 as that is the version provided by the CI runner generating the build.
libgcc-s1 depedency is removed as it is a dependency of libc6.

```
> ldd devolutions-gateway
  linux-vdso.so.1 (0x000077b2330a9000)
  libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x000077b22f5b1000)
  libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x000077b22f4c4000)
  libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000077b22f200000)
  /lib64/ld-linux-x86-64.so.2 (0x000077b2330ab000)
```

The ldd output for Agent is identical.