### PR TITLE
ci: build the PEDM desktop app so it can be signed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,10 +630,34 @@ jobs:
           pattern: devolutions-gateway-*
           delete-merged: true
 
+  devolutions-pedm-desktop:
+    name: devolutions-pedm-desktop
+    runs-on: windows-latest
+    needs: preflight
+
+    steps:
+      - name: Checkout ${{ github.repository }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build
+        shell: pwsh
+        run: ./dotnet/DesktopAgent/build.ps1
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: devolutions-pedm-desktop
+          path: ./dotnet/DesktopAgent/bin/Release/net48/*
+
   devolutions-agent:
     name: devolutions-agent [${{ matrix.os }} ${{ matrix.arch }}]
     runs-on: ${{ matrix.runner }}
-    needs: [preflight]
+    needs: [preflight, devolutions-pedm-desktop]
     strategy:
       matrix:
         include: ${{ fromJson(needs.preflight.outputs.agent-build-matrix) }}
@@ -664,9 +688,6 @@ jobs:
 
             echo "dagent-package=$DAgentPackage" >> $Env:GITHUB_OUTPUT
 
-            $DAgentDesktopAgentOutputPath = Join-Path $TargetOutputPath "DesktopAgent"
-            echo "dagent-desktop-agent-output-path=$DAgentDesktopAgentOutputPath" >> $Env:GITHUB_OUTPUT
-
             $DAgentPedmShellExtDll = Join-Path $TargetOutputPath "DevolutionsPedmShellExt.dll"
             echo "dagent-pedm-shell-ext-dll=$DAgentPedmShellExtDll" >> $Env:GITHUB_OUTPUT
 
@@ -682,6 +703,13 @@ jobs:
           echo "symbols-path=$SymbolsPath" >> $Env:GITHUB_OUTPUT
           echo "target-output-path=$TargetOutputPath" >> $Env:GITHUB_OUTPUT
           echo "dagent-executable=$DAgentExecutable" >> $Env:GITHUB_OUTPUT
+
+      - name: Download devolutions-pedm-desktop
+        uses: actions/download-artifact@v4
+        if: matrix.os == 'windows'
+        with:
+          name: devolutions-pedm-desktop
+          path: devolutions-pedm-desktop
 
       - name: Configure Linux runner
         if: matrix.os == 'linux'
@@ -744,7 +772,6 @@ jobs:
           CARGO_PACKAGE: devolutions-agent
         run: |
           if ($Env:RUNNER_OS -eq "Windows") {
-            $Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH = "${{ steps.load-variables.outputs.dagent-desktop-agent-output-path }}"
             $Env:DAGENT_PEDM_SHELL_EXT_DLL = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-dll }}"
             $Env:DAGENT_PEDM_SHELL_EXT_MSIX = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-msix }}"
             $Env:DAGENT_SESSION_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-session-executable }}"
@@ -760,8 +787,11 @@ jobs:
           DAGENT_EXECUTABLE: ${{ steps.load-variables.outputs.dagent-executable }}
         run: |
           if ($Env:RUNNER_OS -eq "Windows") {
+            $DesktopStagingPath = Join-Path (Get-Location) "devolutions-pedm-desktop"
+            Get-ChildItem -Path $DesktopStagingPath -Recurse | Where-Object { $_.Extension -notin '.exe', '.dll' } | Remove-Item -Recurse -Force
+
             $Env:DAGENT_PACKAGE = "${{ steps.load-variables.outputs.dagent-package }}"
-            $Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH = "${{ steps.load-variables.outputs.dagent-desktop-agent-output-path }}"
+            $Env:DAGENT_DESKTOP_AGENT_PATH = $DesktopStagingPath
             $Env:DAGENT_PEDM_SHELL_EXT_DLL = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-dll }}"
             $Env:DAGENT_PEDM_SHELL_EXT_MSIX = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-msix }}"
             $Env:DAGENT_SESSION_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-session-executable }}"
@@ -917,6 +947,8 @@ jobs:
       - devolutions-gateway-player
       - devolutions-gateway
       - devolutions-gateway-merge
+      - devolutions-pedm-desktop
+      - devolutions-agent
       - devolutions-agent-merge
       - devolutions-pedm-client
       - dotnet-utils-tests

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -256,8 +256,7 @@ jobs:
         run: |
           $IncludePattern = @(switch ('${{ matrix.project }}') {
             'devolutions-gateway' { @('DevolutionsGateway_*.exe') }
-            'devolutions-agent' { @('DevolutionsAgent_*.exe', 'DevolutionsPedmShellExt.dll',
-              'DevolutionsPedmShellExt.msix', 'DevolutionsDesktopAgent.exe') }
+            'devolutions-agent' { @('DevolutionsAgent_*.exe', 'DevolutionsPedmShellExt.dll', 'DevolutionsPedmShellExt.msix', 'DevolutionsDesktopAgent.exe') }
             'jetsocat' { @('jetsocat_*') }
           })
           $ExcludePattern = "*.pdb"
@@ -318,6 +317,15 @@ jobs:
           $Destination = Join-Path "webapp" "client"
           gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -D "$Destination"
 
+      - name: Download web player artifacts
+        if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $Destination = Join-Path "webapp" "player"
+          gh run download ${{ needs.preflight.outputs.run }} -n webapp-player -D "$Destination"
+
       - name: Add msbuild to PATH
         if: matrix.os == 'windows' && (matrix.project == 'devolutions-gateway' || matrix.project == 'devolutions-agent')
         uses: microsoft/setup-msbuild@v2
@@ -351,13 +359,42 @@ jobs:
 
           ./ci/tlk.ps1 package -Product gateway -PackageOption generate
 
+      - name: Download pedm desktop artifacts
+        if: matrix.os == 'windows' && matrix.project == 'devolutions-agent'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $Destination = "devolutions-pedm-desktop"
+          gh run download ${{ needs.preflight.outputs.run }} -n devolutions-pedm-desktop -D "$Destination"
+          Get-ChildItem -Path $(Resolve-Path "devolutions-pedm-desktop") -Recurse | Where-Object { $_.Extension -notin '.exe', '.dll' } | Remove-Item -Recurse -Force
+          
+      - name: Sign pedm desktop executables
+        if: matrix.os == 'windows' && matrix.project == 'devolutions-agent'
+        shell: pwsh
+        run: |
+          $IncludePattern = '*Devolutions*'
+          Get-ChildItem -Path $(Resolve-Path "devolutions-pedm-desktop") | Where-Object { (Get-AuthenticodeSignature $_).Status -ne 'Valid'} | % {
+              $Params = @('sign',
+                '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+                '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+                '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+                '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+                '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+                '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+                '-v')
+
+              echo "::debug::signing $_.FullName"
+              AzureSignTool @Params $_.FullName
+          }
+
       - name: Regenerate Agent MSI
         if: matrix.project == 'devolutions-agent' && matrix.os == 'windows'
         shell: pwsh
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project}}
           $Env:DAGENT_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsAgent*.exe' | Select -First 1
-          $Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH = Join-Path $PackageRoot ${{ matrix.os }} x86_64 DesktopAgent
+          $Env:DAGENT_DESKTOP_AGENT_PATH = Resolve-Path -Path "devolutions-pedm-desktop"
           $Env:DAGENT_PEDM_SHELL_EXT_DLL = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.dll' | Select -First 1
           $Env:DAGENT_PEDM_SHELL_EXT_MSIX = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.msix' | Select -First 1
           $Env:DAGENT_SESSION_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsSession.exe' | Select -First 1
@@ -565,7 +602,7 @@ jobs:
 
   nuget:
     name: Nuget
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # nuget.exe not available on 24.04 and `nuget pack` doesn't work without a csproj
     needs: [preflight, codesign, jetsocat-merge]
 
     steps:

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -434,19 +434,6 @@ class TlkRecipe
         }
 
         if ($this.Product -Eq "agent" -And $this.Target.IsWindows()) {
-            if (Test-Path Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH) {
-                & './dotnet/DesktopAgent/build.ps1' | Out-Host
-                $DesktopAgentOutputPath = $Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH
-                Remove-Item -Path "$DesktopAgentOutputPath" -Recurse -Force -ErrorAction SilentlyContinue
-                New-Item -Path "$DesktopAgentOutputPath" -ItemType 'Directory' -Force | Out-Null
-
-                $BuiltDesktop = Get-ChildItem -Path "./dotnet/DesktopAgent/bin/Release/net48/*" -Recurse -Include *.dll,*.exe,*.pdb
-
-                foreach ($File in $BuiltDesktop) {
-                    Copy-Item $File.FullName -Destination $DesktopAgentOutputPath
-                }
-            }
-
             if (Test-Path Env:DAGENT_SESSION_EXECUTABLE) {
                 $sessionExe = Get-ChildItem -Recurse -Include 'devolutions-session.exe' | Select-Object -First 1
 

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -80,7 +80,7 @@ internal class Program
     private static string DevolutionsDesktopAgentPath
     {
         // ReSharper disable once ArrangeAccessorOwnerBody
-        get => ResolveDirectory("DAGENT_DESKTOP_AGENT_OUTPUT_PATH", "..\\..\\dotnet\\DesktopAgent\\bin\\Release\\");
+        get => ResolveDirectory("DAGENT_DESKTOP_AGENT_PATH", "..\\..\\dotnet\\DesktopAgent\\bin\\Release\\");
     }
 
     private static string DevolutionsPedmShellExtDll => ResolveArtifact("DAGENT_PEDM_SHELL_EXT_DLL", "..\\..\\target\\x86_64-pc-windows-msvc\\release\\devolutions_pedm_shell_ext.dll");


### PR DESCRIPTION
Build the PEDM desktop application independently - it's a .NET application and architecture "neutral". The artifacts are uploaded in CI, then extracted and signed before packaging.

Fix some minor issues that cropped up while debugging the workflows.