### PR TITLE
chore(tools): update packaging changelogs in bump-version.ps1

### DIFF
--- a/tools/bump-version.ps1
+++ b/tools/bump-version.ps1
@@ -24,24 +24,63 @@ $targetFiles = @(
 	'./fuzz/Cargo.lock'
 )
 
+$linuxPackagingChangelogs = @(
+	'./package/AgentLinux/CHANGELOG.md'
+	'./package/Linux/CHANGELOG.md'
+)
+
+$today = Get-Date -Format 'yyyy-MM-dd'
+
+$newLinuxChangelogSection = @(
+    "## $NewVersion ($today)",
+    "",
+    "- No changes.",
+    ""
+)
+
 try {
 	$currentVersion = Get-Content -Path './VERSION'
 	Write-Host "Current version is $currentVersion"
 	Write-Host "Next version is $NewVersion"
 	Write-Host
 
-	ForEach ($file in $targetFiles)
+	if ($NewVersion -eq $currentVersion)
+	{
+		throw "The new version must be different than the current version."
+	}
+
+	foreach ($file in $targetFiles)
 	{
 		Write-Host "Updating $file"
 		((Get-Content -Path "$file" -Raw) -Replace "$currentVersion","$NewVersion") | Set-Content -Path "$file" -NoNewline
 	}
+
+	foreach ($file in $linuxPackagingChangelogs)
+	{
+		Write-Host "Updating $file..."
+
+		$lines = Get-Content -Path $file
+
+		$prevSection = $lines | Where-Object { $_ -like "## $currentVersion*" }
+		$prevSectionIndex = $lines.IndexOf($prevSection)
+
+		if ($prevSectionIndex -lt 0) {
+			throw "Could not find '## $currentVersion' in $file"
+		}
+
+		$updatedLines = $lines[0..($prevSectionIndex - 1)] + $newLinuxChangelogSection + $lines[$prevSectionIndex..($lines.Count - 1)]
+
+		$updatedLines | Set-Content -Path $file
+	}
+
 	Write-Host
 
 	Write-Host 'Script executed successfully. Run `git status` to make sure everything looks good.'
 }
 catch {
-	Write-Host 'An error occurred:'
+	Write-Host "An error occurred: $_"
 	Write-Host $_.ScriptStackTrace
+
 }
 finally {
 	Pop-Location


### PR DESCRIPTION
`tools/bump-version.ps1` will now update the packaging changelogs as well. The only thing it does is adding a new section for the new version, stating that no change was made to the package itself. If something was changed, the files should be modified manually afterwards.