### PR TITLE
fix(agent): fix downgrade logic for unreleased Devolutions Gateway

### DIFF
--- a/devolutions-agent/src/updater/mod.rs
+++ b/devolutions-agent/src/updater/mod.rs
@@ -278,31 +278,25 @@ async fn check_for_updates(product: Product, update_json: &UpdateJson) -> anyhow
             }))
         }
         VersionSpecification::Specific(version) => {
-            if version == remote_version {
-                // Product info DB version matches the requested version, proceed with update.
-                return Ok(Some(UpdateOrder {
-                    target_version: version,
-                    downgrade: None,
-                    package_url: product_info.url.clone(),
-                    hash: product_info.hash.clone(),
-                }));
-            }
-
             // If the target version is not available on devolutions.net, try to guess the requested
             // version MSI URL by modifying the detected version.
             //
             // TODO(@pacmancoder): This is a temporary workaround until we have improved productinfo
             // database with multiple version information.
-            let modified_url = try_modify_product_url_version(&product_info.url, remote_version, version)?;
+            let package_url = if version == remote_version {
+                product_info.url.clone()
+            } else {
+                try_modify_product_url_version(&product_info.url, remote_version, version)?
+            };
 
-            // Quick check if the modified URL points to existing resource.
-            let response = reqwest::Client::builder().build()?.head(&modified_url).send().await?;
+            // Quick check if the package URL points to existing resource.
+            let response = reqwest::Client::builder().build()?.head(&package_url).send().await?;
             if let Err(error) = response.error_for_status() {
                 warn!(
                     %error,
                     %product,
                     %version,
-                    %modified_url,
+                    %package_url,
                     "Failed to access the product URL, skipping update"
                 );
                 return Ok(None);
@@ -326,7 +320,7 @@ async fn check_for_updates(product: Product, update_json: &UpdateJson) -> anyhow
             Ok(Some(UpdateOrder {
                 target_version: version,
                 downgrade,
-                package_url: modified_url,
+                package_url,
                 hash: None,
             }))
         }

--- a/devolutions-agent/src/updater/product_actions.rs
+++ b/devolutions-agent/src/updater/product_actions.rs
@@ -67,7 +67,7 @@ impl ProductUpdateActions for GatewayUpdateActions {
         if self.service_startup_was_automatic {
             info!("Adjusting MSIEXEC parameters for Gateway service startup mode");
 
-            return vec!["P.SERVICESTART=Automatic".to_string()];
+            return vec!["P.SERVICESTART=Automatic".to_owned()];
         }
 
         Vec::new()


### PR DESCRIPTION
Fix the updater corner case when the user is trying to downgrade to the latest specified version in `productinfo.htm` while a newer unreleased version is installed locally.