### PR TITLE
feat(installer): register PEDM shell extension instead of msix

### DIFF
--- a/package/AgentWindowsManaged/Actions/AgentActions.cs
+++ b/package/AgentWindowsManaged/Actions/AgentActions.cs
@@ -237,48 +237,47 @@ internal static class AgentActions
         Condition = Features.PEDM_FEATURE.BeingInstall(),
     };
 
-    private static readonly ElevatedManagedAction cleanupPedmShellExt = new(
-        CustomActions.UninstallMsix
+    private static readonly ElevatedManagedAction registerExplorerCommand = new(
+        CustomActions.RegisterExplorerCommand
     )
     {
-        Id = new Id("cleanupPedmShellExt"),
+        Id = new Id($"CA.{nameof(registerExplorerCommand)}"),
         Feature = Features.PEDM_FEATURE,
-        Impersonate = false,
-        Execute = Execute.deferred,
-        Return = Return.check,
-        Step = Step.RemoveFiles,
-        When = When.Before,
         Sequence = Sequence.InstallExecuteSequence,
-        Condition = Features.PEDM_FEATURE.BeingUninstall(),
-    };
-
-    private static readonly ElevatedManagedAction installPedmShellExt = new(
-        CustomActions.InstallMsix
-    )
-    {
-        Id = new Id("installPedmShellExt"),
-        Feature = Features.PEDM_FEATURE,
-        Impersonate = true,
-        Execute = Execute.deferred,
         Return = Return.check,
+        Execute = Execute.deferred,
+        Impersonate = false,
         Step = Step.InstallFiles,
         When = When.After,
-        Sequence = Sequence.InstallExecuteSequence,
         Condition = Features.PEDM_FEATURE.BeingInstall(),
     };
 
-    private static readonly ElevatedManagedAction uninstallPedmShellExt = new(
-        CustomActions.UninstallMsix
+    private static readonly ElevatedManagedAction registerExplorerCommandRollback = new(
+        CustomActions.UnregisterExplorerCommand
     )
     {
-        Id = new Id("uninstallPedmShellExt"),
+        Id = new Id($"CA.{nameof(registerExplorerCommandRollback)}"),
         Feature = Features.PEDM_FEATURE,
-        Impersonate = false,
-        Execute = Execute.deferred,
+        Sequence = Sequence.InstallExecuteSequence,
+        Return = Return.ignore,
+        Execute = Execute.rollback,
+        Step = new Step(registerExplorerCommand.Id),
+        When = When.Before,
+        Condition = Features.PEDM_FEATURE.BeingInstall(),
+    };
+
+    private static readonly ElevatedManagedAction unregisterExplorerCommand = new(
+        CustomActions.UnregisterExplorerCommand
+    )
+    {
+        Id = new Id($"CA.{nameof(unregisterExplorerCommand)}"),
+        Feature = Features.PEDM_FEATURE,
+        Sequence = Sequence.InstallExecuteSequence,
         Return = Return.check,
+        Execute = Execute.deferred,
+        Impersonate = false,
         Step = Step.RemoveFiles,
         When = When.Before,
-        Sequence = Sequence.InstallExecuteSequence,
         Condition = Features.PEDM_FEATURE.BeingUninstall(),
     };
 
@@ -327,9 +326,9 @@ internal static class AgentActions
         createProgramDataPedmDirectories,
         setProgramDataPedmDirectoryPermissions,
         installPedm,
-        cleanupPedmShellExt,
-        uninstallPedmShellExt,
-        installPedmShellExt,
+        registerExplorerCommand,
+        registerExplorerCommandRollback,
+        unregisterExplorerCommand,
         installSession,
         cleanAgentConfigIfNeeded,
         cleanAgentConfigIfNeededRollback,

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -1,9 +1,7 @@
 ﻿using DevolutionsAgent.Properties;
 using DevolutionsAgent.Resources;
 using Microsoft.Deployment.WindowsInstaller;
-using Windows.Management.Deployment;
 using Microsoft.Win32;
-using Microsoft.Win32.SafeHandles;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -12,7 +10,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
+using System.Security.Claims;
 using WixSharp;
 using File = System.IO.File;
 
@@ -20,11 +18,14 @@ namespace DevolutionsAgent.Actions
 {
     public class CustomActions
     {
-        private static readonly string[] ConfigFiles = new[] {
+        private const string EXPLORER_COMMAND_VERB = "RunElevated";
+
+        private static readonly string[] ConfigFiles = new[]
+        {
             "agent.json",
         };
 
-        private const int MAX_PATH = 260; // Defined in windows.h
+        private static readonly string[] explorerCommandExtensions = [".exe", ".msi", ".lnk", ".ps1", ".bat"];
 
         private static string ProgramDataDirectory => Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
@@ -54,7 +55,8 @@ namespace DevolutionsAgent.Actions
 
             try
             {
-                string zipFile = $"{Path.Combine(Path.GetTempPath(), session.Get(AgentProperties.installId).ToString())}.zip";
+                string zipFile =
+                    $"{Path.Combine(Path.GetTempPath(), session.Get(AgentProperties.installId).ToString())}.zip";
                 using ZipArchive archive = ZipFile.Open(zipFile, ZipArchiveMode.Create);
 
                 WinAPI.MoveFileEx(zipFile, IntPtr.Zero, WinAPI.MOVEFILE_DELAY_UNTIL_REBOOT);
@@ -93,7 +95,8 @@ namespace DevolutionsAgent.Actions
         [CustomAction]
         public static ActionResult CleanAgentConfigRollback(Session session)
         {
-            string zipFile = $"{Path.Combine(Path.GetTempPath(), session.Get(AgentProperties.installId).ToString())}.zip";
+            string zipFile =
+                $"{Path.Combine(Path.GetTempPath(), session.Get(AgentProperties.installId).ToString())}.zip";
 
             if (!File.Exists(zipFile))
             {
@@ -159,8 +162,8 @@ namespace DevolutionsAgent.Actions
 
             foreach (string directory in new[]
                      {
-                         "logs", 
-                         Path.Combine("policy", "profiles"), 
+                         "logs",
+                         Path.Combine("policy", "profiles"),
                          Path.Combine("policy", "rules")
                      })
             {
@@ -186,9 +189,11 @@ namespace DevolutionsAgent.Actions
         {
             try
             {
-                using RegistryKey localKey = RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, RegistryView.Registry64);
-                using RegistryKey agentKey = localKey.OpenSubKey($@"Software\{Includes.VENDOR_NAME}\{Includes.SHORT_NAME}");
-                string installDirValue = (string)agentKey.GetValue("InstallDir");
+                using RegistryKey localKey = RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine,
+                    RegistryView.Registry64);
+                using RegistryKey agentKey =
+                    localKey.OpenSubKey($@"Software\{Includes.VENDOR_NAME}\{Includes.SHORT_NAME}");
+                string installDirValue = (string) agentKey.GetValue("InstallDir");
 
                 if (string.IsNullOrEmpty(installDirValue))
                 {
@@ -239,7 +244,7 @@ namespace DevolutionsAgent.Actions
                     // ignored. Previous config is either invalid or non existent.
                 }
 
-                config[feature] = new Dictionary<string, bool> { { "Enabled", true } };
+                config[feature] = new Dictionary<string, bool> {{"Enabled", true}};
 
                 using var writer = new StreamWriter(path);
                 writer.Write(JsonConvert.SerializeObject(config));
@@ -263,6 +268,73 @@ namespace DevolutionsAgent.Actions
         public static ActionResult InstallSession(Session session)
         {
             return EnableAgentFeature(session, "Session");
+        }
+
+        [CustomAction]
+        public static ActionResult RegisterExplorerCommand(Session session)
+        {
+            try
+            {
+                string installDir = session.Property(AgentProperties.InstallDir);
+                string dllPath = Path.Combine(installDir, Includes.SHELL_EXT_BINARY_NAME);
+
+                if (!File.Exists(dllPath))
+                {
+                    session.Log($"can't register dll that does not exist on disk {dllPath}");
+                    return ActionResult.Failure;
+                }
+
+                string clsidPath = $"CLSID\\{Includes.SHELL_EXT_CSLID:B}";
+
+                using RegistryKey clsidKey = Registry.ClassesRoot.CreateSubKey(clsidPath);
+
+                if (clsidKey is null)
+                {
+                    session.Log("couldn't open or create key");
+                    return ActionResult.Failure;
+                }
+
+                clsidKey.SetValue("", "PedmShellExt", RegistryValueKind.String);
+
+                using RegistryKey inprocKey = Registry.ClassesRoot.CreateSubKey($"{clsidPath}\\InprocServer32");
+
+                if (inprocKey is null)
+                {
+                    session.Log("couldn't open or create key");
+                    return ActionResult.Failure;
+                }
+
+                inprocKey.SetValue("", dllPath, RegistryValueKind.String);
+                inprocKey.SetValue("ThreadingModel", "Apartment", RegistryValueKind.String);
+
+                const string explorerCommandDefaultText = "Run Elevated";
+
+                foreach (string extension in explorerCommandExtensions)
+                {
+                    string fileClass = Registry.GetValue($"{Registry.ClassesRoot.Name}\\{extension}", "", extension)
+                        .ToString();
+                    using RegistryKey commandPath =
+                        Registry.ClassesRoot.CreateSubKey($"{fileClass}\\shell\\{EXPLORER_COMMAND_VERB}");
+
+                    if (commandPath is null)
+                    {
+                        session.Log("couldn't open or create key");
+                        continue;
+                    }
+
+                    commandPath.SetValue("", explorerCommandDefaultText, RegistryValueKind.String);
+                    commandPath.SetValue("ExplorerCommandHandler", $"{Includes.SHELL_EXT_CSLID:B}",
+                        RegistryValueKind.String);
+                    commandPath.SetValue("MUIVerb", $"{dllPath},-150", RegistryValueKind.String);
+                }
+
+                return ActionResult.Success;
+            }
+            catch (Exception e)
+            {
+                session.Log($"unexpected error registering explorer command {e}");
+                return ActionResult.Failure;
+            }
         }
 
         [CustomAction]
@@ -385,296 +457,6 @@ namespace DevolutionsAgent.Actions
             }
         }
 
-        private static SafeFileHandle CreateSharedTempFile(Session session)
-        {
-            string tempPath = Path.GetTempPath();
-            StringBuilder sb = new(MAX_PATH);
-
-            if (WinAPI.GetTempFileName(tempPath, "DGW", 0, sb) == 0)
-            {
-                session.Log($"GetTempFileName failed (error: {Marshal.GetLastWin32Error()})");
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            string tempFilePath = sb.ToString();
-
-            WinAPI.SECURITY_ATTRIBUTES sa = new()
-            {
-                nLength = (uint)Marshal.SizeOf<WinAPI.SECURITY_ATTRIBUTES>(),
-                lpSecurityDescriptor = IntPtr.Zero,
-                bInheritHandle = true
-            };
-
-            using Buffer pSa = new(Marshal.SizeOf<WinAPI.SECURITY_ATTRIBUTES>());
-            Marshal.StructureToPtr(sa, pSa, false);
-
-            SafeFileHandle handle = WinAPI.CreateFile(tempFilePath,
-                WinAPI.GENERIC_WRITE, WinAPI.FILE_SHARE_READ | WinAPI.FILE_SHARE_WRITE, pSa, WinAPI.CREATE_ALWAYS,
-                WinAPI.FILE_ATTRIBUTE_NORMAL, IntPtr.Zero);
-
-            if (handle.IsInvalid)
-            {
-                int errno = Marshal.GetLastWin32Error();
-                session.Log($"CreateFile failed (error: {errno})");
-
-                handle.Dispose();
-
-                if (!WinAPI.DeleteFile(tempFilePath))
-                {
-                    session.Log($"DeleteFile failed (error: {Marshal.GetLastWin32Error()})");
-                }
-
-                throw new Win32Exception(errno);
-            }
-
-            if (!WinAPI.MoveFileEx(tempFilePath, IntPtr.Zero, WinAPI.MOVEFILE_DELAY_UNTIL_REBOOT))
-            {
-                session.Log($"MoveFileEx failed (error: {Marshal.GetLastWin32Error()})");
-            }
-
-            return handle;
-        }
-
-        private static uint ExecuteCommand(Session session, SafeFileHandle hTempFile, string command)
-        {
-            WinAPI.STARTUPINFO si = new()
-            {
-                cb = (uint)Marshal.SizeOf<WinAPI.STARTUPINFO>()
-            };
-
-            if (hTempFile.IsInvalid)
-            {
-                session.Log($"got an invalid file handle; command output will not be redirected");
-            }
-            else
-            {
-                si.dwFlags = WinAPI.STARTF_USESTDHANDLES;
-                si.hStdInput = WinAPI.GetStdHandle(WinAPI.STD_INPUT_HANDLE);
-                si.hStdOutput = hTempFile.DangerousGetHandle();
-                si.hStdError = hTempFile.DangerousGetHandle();
-            }
-
-            using Buffer pSi = new(Marshal.SizeOf<WinAPI.STARTUPINFO>());
-            Marshal.StructureToPtr(si, pSi, false);
-
-            WinAPI.PROCESS_INFORMATION pi = new();
-
-            using Buffer pPi = new(Marshal.SizeOf<WinAPI.PROCESS_INFORMATION>());
-            Marshal.StructureToPtr(pi, pPi, false);
-
-            if (session.Get(AgentProperties.debugPowerShell))
-            {
-                session.Log($"Executing command: {command}");
-            }
-
-            if (!WinAPI.CreateProcess(null, command, IntPtr.Zero, IntPtr.Zero,
-                    true, WinAPI.CREATE_NO_WINDOW, IntPtr.Zero, null, pSi, pPi))
-            {
-                session.Log($"CreateProcess failed (error: {Marshal.GetLastWin32Error()})");
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-
-            uint exitCode = 1;
-
-            try
-            {
-                pi = Marshal.PtrToStructure<WinAPI.PROCESS_INFORMATION>(pPi);
-
-                // Give the process reasonable time to finish, don't hang the installer
-                if (WinAPI.WaitForSingleObject(pi.hProcess, (uint)TimeSpan.FromMinutes(1).TotalMilliseconds) != 0) // WAIT_OBJECT_0
-                {
-                    session.Log("timeout or error waiting for sub process");
-
-                    if (!WinAPI.TerminateProcess(pi.hProcess, exitCode))
-                    {
-                        session.Log($"TerminateProcess failed (error: {Marshal.GetLastWin32Error()})");
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
-                    }
-                }
-
-                if (!WinAPI.GetExitCodeProcess(pi.hProcess, out exitCode))
-                {
-                    session.Log($"GetExitCodeProcess failed (error: {Marshal.GetLastWin32Error()})");
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-                }
-
-                if (exitCode != 0)
-                {
-                    session.Log($"sub process returned a non-zero exit code: {exitCode})");
-                }
-            }
-            finally
-            {
-                WinAPI.CloseHandle(pi.hProcess);
-                WinAPI.CloseHandle(pi.hThread);
-            }
-
-            return exitCode;
-        }
-
-        private static ActionResult ExecuteCommand(Session session, string command)
-        {
-            using SafeFileHandle hTempFile = CreateSharedTempFile(session);
-
-            uint exitCode;
-
-            try
-            {
-                exitCode = ExecuteCommand(session, hTempFile, command);
-            }
-            catch (Exception e)
-            {
-                session.Log($"command execution failure: {e}");
-
-                using Record record = new(3)
-                {
-                    FormatString = "Command execution failure: [1]",
-                };
-
-                record.SetString(1, e.ToString());
-                session.Message(InstallMessage.Error | (uint)MessageButtons.OK, record);
-                return ActionResult.Failure;
-            }
-
-            if (exitCode != 0)
-            {
-                StringBuilder tempFilePathBuilder = new(MAX_PATH);
-                uint pathLength = WinAPI.GetFinalPathNameByHandle(hTempFile.DangerousGetHandle(), tempFilePathBuilder, MAX_PATH, 0);
-                string result = "unknown";
-
-                try
-                {
-                    if (pathLength is > 0 and < MAX_PATH)
-                    {
-                        string tempFilePath = tempFilePathBuilder.ToString().TrimStart('\\', '?');
-
-                        using FileStream fileStream = new(tempFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-                        using StreamReader streamReader = new(fileStream);
-                        result = streamReader.ReadToEnd();
-                    }
-                }
-                catch (Exception e)
-                {
-                    session.Log($"error reading error from temp file: {e}");
-                }
-
-                using Record record = new(3)
-                {
-                    FormatString = "Command execution failure: [1]",
-                };
-
-                hTempFile.Close();
-
-                record.SetString(1, result);
-                session.Message(InstallMessage.Error | (uint)MessageButtons.OK, record);
-
-                return ActionResult.Failure;
-            }
-
-            return ActionResult.Success;
-        }
-
-        [CustomAction]
-        public static ActionResult InstallMsix(Session session)
-        {
-            try
-            {
-                string packageName = "DevolutionsAgent";
-                string installPath = session.Property("INSTALLDIR");
-                string packageFileName = "DevolutionsPedmShellExt.msix";
-                string packagePath = System.IO.Path.Combine(installPath, packageFileName);
-
-                session.Log($"Installing MSIX package from path: {packagePath}");
-                session.Log($"with external location: {installPath}");
-
-                InstallMsixPackage(packagePath, installPath);
-                return ActionResult.Success;
-            }
-            catch (Exception ex)
-            {
-                session.Log("ERROR: " + ex.Message);
-                session.Log("Stack Trace: " + ex.StackTrace);
-                if (ex.InnerException != null)
-                {
-                    session.Log("Inner Exception: " + ex.InnerException.Message);
-                    session.Log("Inner Exception Stack Trace: " + ex.InnerException.StackTrace);
-                }
-                return ActionResult.Failure;
-            }
-        }
-
-        [CustomAction]
-        public static ActionResult UninstallMsix(Session session)
-        {
-            try
-            {
-                string packageFamilyName = "DevolutionsAgent_tr5fa5yv8zr8w";
-                UninstallMsixPackage(packageFamilyName);
-                return ActionResult.Success;
-            }
-            catch (Exception ex)
-            {
-                session.Log("ERROR: " + ex.Message);
-                session.Log("Stack Trace: " + ex.StackTrace);
-                if (ex.InnerException != null)
-                {
-                    session.Log("Inner Exception: " + ex.InnerException.Message);
-                    session.Log("Inner Exception Stack Trace: " + ex.InnerException.StackTrace);
-                }
-                return ActionResult.Failure;
-            }
-        }
-
-        private static void InstallMsixPackage(string packagePath, string externalLocation)
-        {
-            var packageManager = new PackageManager();
-
-            if (!string.IsNullOrEmpty(externalLocation))
-            {
-                var options = new AddPackageOptions();
-                options.ExternalLocationUri = new Uri(externalLocation);
-                var deploymentOperation = packageManager.AddPackageByUriAsync(
-                    new Uri(packagePath), options
-                );
-                deploymentOperation.AsTask().Wait();
-            }
-            else
-            {
-                var deploymentOperation = packageManager.AddPackageAsync(
-                    new Uri(packagePath), null, DeploymentOptions.None
-                );
-                deploymentOperation.AsTask().Wait();
-            }
-        }
-
-        public static void UninstallMsixPackage(string packageFamilyName)
-        {
-            var packageManager = new PackageManager();
-
-            var packages = packageManager.FindPackages(packageFamilyName);
-
-            if (packages != null && packages.Any())
-            {
-                foreach (var package in packages)
-                {
-                    var deploymentOperation = packageManager.RemovePackageAsync(package.Id.FullName, RemovalOptions.RemoveForAllUsers);
-                    deploymentOperation.AsTask().Wait();
-                }
-            }
-        }
-
-        private static string FormatHttpUrl(string scheme, uint port)
-        {
-            string url = $"{scheme}://*";
-
-            if ((scheme.Equals(Constants.HttpProtocol) && port != 80) || (scheme.Equals(Constants.HttpsProtocol) && port != 443))
-            {
-                url += $":{port}";
-            }
-
-            return url;
-        }
-
         public static void SetFileSecurity(Session session, string path, string sddl)
         {
             const uint sdRevision = 1;
@@ -685,7 +467,8 @@ namespace DevolutionsAgent.Actions
             {
                 if (!WinAPI.ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, sdRevision, out pSd, out pSzSd))
                 {
-                    session.Log($"ConvertStringSecurityDescriptorToSecurityDescriptorW failed (error: {Marshal.GetLastWin32Error()})");
+                    session.Log(
+                        $"ConvertStringSecurityDescriptorToSecurityDescriptorW failed (error: {Marshal.GetLastWin32Error()})");
                     throw new Win32Exception(Marshal.GetLastWin32Error());
                 }
 
@@ -711,7 +494,8 @@ namespace DevolutionsAgent.Actions
             try
             {
                 // https://learn.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
-                using RegistryKey localKey = RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine, RegistryView.Registry64);
+                using RegistryKey localKey = RegistryKey.OpenBaseKey(Microsoft.Win32.RegistryHive.LocalMachine,
+                    RegistryView.Registry64);
                 using RegistryKey netFxKey = localKey.OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full");
 
                 if (netFxKey is null)
@@ -728,6 +512,29 @@ namespace DevolutionsAgent.Actions
             {
                 return false;
             }
+        }
+
+        [CustomAction]
+        public static ActionResult UnregisterExplorerCommand(Session session)
+        {
+            try
+            {
+                Registry.ClassesRoot.DeleteSubKeyTree($"CLSID\\{Includes.SHELL_EXT_CSLID:B}", false);
+
+                foreach (string extension in explorerCommandExtensions)
+                {
+                    string fileClass = Registry.GetValue($"{Registry.ClassesRoot.Name}\\{extension}", "", extension)
+                        .ToString();
+                    Registry.ClassesRoot.DeleteSubKeyTree($"{fileClass}\\shell\\{EXPLORER_COMMAND_VERB}", false);
+                }
+            }
+            catch (Exception e)
+            {
+                session.Log($"unexpected error unregistering explorer command {e}");
+                return ActionResult.Failure;
+            }
+
+            return ActionResult.Success;
         }
     }
 }

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -276,7 +276,7 @@ internal class Program
                 Win64 = project.Platform == Platform.x64,
                 RegistryKeyAction = RegistryKeyAction.create,
             },
-            new (RegistryHive.LocalMachine, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", Includes.SERVICE_NAME, $"[{AgentProperties.InstallDir}]desktop\\DevolutionsDesktopAgent.exe")
+            new (RegistryHive.LocalMachine, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", Includes.SERVICE_NAME, $"[{AgentProperties.InstallDir}]desktop\\{Includes.DESKTOP_EXECUTABLE_NAME}")
             {
                 Win64 = project.Platform == Platform.x64,
                 RegistryKeyAction = RegistryKeyAction.create,

--- a/package/AgentWindowsManaged/Resources/Includes.cs
+++ b/package/AgentWindowsManaged/Resources/Includes.cs
@@ -18,9 +18,15 @@ namespace DevolutionsAgent.Resources
 
         internal static string EXECUTABLE_NAME = "DevolutionsAgent.exe";
 
+        internal static string DESKTOP_EXECUTABLE_NAME = "DevolutionsDesktopAgent.exe";
+
         internal static string EMAIL_SUPPORT = "support@devolutions.net";
 
         internal static string FORUM_SUPPORT = "forum.devolutions.net";
+
+        internal static string SHELL_EXT_BINARY_NAME = "DevolutionsPedmShellExt.dll";
+
+        internal static Guid SHELL_EXT_CSLID = new("0BA604FD-4A5A-4ABB-92B1-09AC5C3BF356");
 
         internal static Guid UPGRADE_CODE = new("82318d3c-811f-4d5d-9a82-b7c31b076755");
 


### PR DESCRIPTION
Register the "Run Elevated" shell extension as a traditional context menu extension, via the registry. This will appear in the second level context menu (after clicking "Show more options") on a modern Win11 system.

For now, registration of the `IExplorerCommand` "modern" shell extension (to appear in the top-level context menu on a Win11 system) is removed. This is unstable: it's tricky to register the extension for multiple users, and it causes significant problems with upgrades or uninstall/reinstall, due to the DLL remaining locked by the shell. A future pull request will reinstate the .msix registration with a different approach.

Remove some unused code that was carried out needlessly from Devolutions Gateway.