### PR TITLE
feat(installer): disable restart manager in Agent MSI

### DIFF
--- a/package/AgentWindowsManaged/Actions/AgentActions.cs
+++ b/package/AgentWindowsManaged/Actions/AgentActions.cs
@@ -183,6 +183,17 @@ internal static class AgentActions
         Impersonate = false,
     };
 
+    private static readonly ElevatedManagedAction shutdownDesktopApp = new(
+        CustomActions.ShutdownDesktopApp,
+        Return.ignore,
+        When.Before, Step.RemoveFiles,
+        Condition.Always,
+        Sequence.InstallExecuteSequence)
+    {
+        Execute = Execute.deferred,
+        Impersonate = false,
+    };
+
     /// <summary>
     /// Start the installed DevolutionsAgent service
     /// </summary>
@@ -332,6 +343,7 @@ internal static class AgentActions
         installSession,
         cleanAgentConfigIfNeeded,
         cleanAgentConfigIfNeededRollback,
+        shutdownDesktopApp,
         startAgentIfNeeded,
         restartAgent,
         rollbackConfig,

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -283,7 +283,19 @@ internal class Program
                 Feature = Features.PEDM_FEATURE,
             }
         };
-        project.Properties = AgentProperties.Properties.Select(x => x.ToWixSharpProperty()).ToArray();
+
+        List<Property> projectProperties = AgentProperties.Properties.Select(x => x.ToWixSharpProperty()).ToList();
+
+        // Disable the restart manager, based on the following assumptions:
+        // - DevolutionsAgent (service) is properly managed with ServiceControl, and won't trigger the restart manager
+        // - DevolutionsSession is managed by DevolutionsAgent (service) and will be properly closed on service stop
+        // - DevolutionsDesktopAgent will be closed by the installer before removing any files
+        // Since none of these executables have a main window, they will not trigger the old style "files in use" dialog
+        // TODO:
+        // - Make DevolutionsDesktopAgent answer WM_CLOSE
+        projectProperties.Add(new Property("MSIRESTARTMANAGERCONTROL", "Disable"));
+
+        project.Properties = projectProperties.ToArray();
         project.ManagedUI = new ManagedUI();
         project.ManagedUI.InstallDialogs.AddRange(Wizard.Dialogs);
         project.ManagedUI.InstallDialogs

--- a/package/AgentWindowsManaged/Properties/AgentProperties.g.cs
+++ b/package/AgentWindowsManaged/Properties/AgentProperties.g.cs
@@ -1,50 +1,8 @@
 ﻿
-using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
-using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
-using ServiceStartMode = System.ServiceProcess.ServiceStartMode;
 using System;
-using static DevolutionsAgent.Properties.Constants;
 
 namespace DevolutionsAgent.Properties
 {
-    /// <summary>
-    /// do not modify the contents of this class with the code editor.
-    /// </summary>
-    public partial class Constants
-    {
- 
-        public const string HttpProtocol = "http";
- 
-        public const string HttpsProtocol = "https";
- 
-        public const string TcpProtocol = "tcp";
-
- 
-        public enum AuthenticationMode 
-        {
-            None,
-            Custom,
-        }
- 
-        public enum CertificateMode 
-        {
-            External,
-            System,
-        }
- 
-        public enum CertificateFindType 
-        {
-            Thumbprint,
-            SubjectName,
-        }
- 
-        public enum CustomizeMode 
-        {
-            Now,
-            Later,
-        }
-    }
-
     /// <summary>
     /// do not modify the contents of this class with the code editor.
     /// </summary>
@@ -61,7 +19,7 @@ namespace DevolutionsAgent.Properties
             Public = true
         };
 
-        /// <summary>`true` to configure the Gateway interactively</summary>
+        /// <summary>`true` to configure the Agent interactively</summary>
         public Boolean ConfigureAgent
         {
             get

--- a/package/AgentWindowsManaged/Properties/AgentProperties.g.tt
+++ b/package/AgentWindowsManaged/Properties/AgentProperties.g.tt
@@ -1,40 +1,14 @@
 ﻿<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
-<#@ assembly name="System.ServiceProcess" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>
-<#@ import namespace="System.ServiceProcess" #>
-<#@ import namespace="System.Security.Cryptography.X509Certificates" #>
 <#@ output extension=".cs" #>
 
-using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
-using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
-using ServiceStartMode = System.ServiceProcess.ServiceStartMode;
 using System;
-using static DevolutionsAgent.Properties.Constants;
 
 namespace DevolutionsAgent.Properties
 {
-    /// <summary>
-    /// do not modify the contents of this class with the code editor.
-    /// </summary>
-    public partial class Constants
-    {
-<# for (int idx = 0; idx < this.StaticStrings.GetLength(0); idx++) { #> 
-        public const string <#=this.StaticStrings[idx, 0]#> = "<#=this.StaticStrings[idx, 1]#>";
-<# } #>
-
-<# for (int idx = 0; idx < this.Enums.GetLength(0); idx++) { #> 
-        public enum <#=this.Enums[idx].Name #> 
-        {
-    <# foreach (var value in Enum.GetValues(this.Enums[idx])) { #>
-        <#=value#>,
-    <# } #>
-    }
-<# } #>
-    }
-
     /// <summary>
     /// do not modify the contents of this class with the code editor.
     /// </summary>
@@ -89,54 +63,6 @@ namespace DevolutionsAgent.Properties
 }
 
 <#+
-    public class Statics
-    {
-        internal const string HttpProtocol = "http";
-
-        internal const string HttpsProtocol = "https";
-
-        internal const string TcpProtocol = "tcp";
-
-        public enum AuthenticationMode
-        {
-            None,
-            Custom,
-        }
-
-        public enum CertificateMode
-        {
-            External,
-            System
-        }
-
-        public enum CertificateFindType
-        {
-            Thumbprint,
-            SubjectName
-        }
-
-        public enum CustomizeMode
-        {
-            Now,
-            Later,
-        }
-    }
-
-    public string[,] StaticStrings = new[,]
-    {
-        {nameof(Statics.HttpProtocol), Statics.HttpProtocol}, 
-        {nameof(Statics.HttpsProtocol), Statics.HttpsProtocol}, 
-        {nameof(Statics.TcpProtocol), Statics.TcpProtocol}, 
-    };
-
-    public Type[] Enums = new[]
-    {
-        typeof(Statics.AuthenticationMode),
-        typeof(Statics.CertificateMode),
-        typeof(Statics.CertificateFindType),
-        typeof(Statics.CustomizeMode),
-    };
-
     public abstract class BasePropertyDefinition
     {
         public abstract string Comment { get; set; }
@@ -202,7 +128,7 @@ namespace DevolutionsAgent.Properties
   private static uint DefaultHttpPort = 7171;
 
   BasePropertyDefinition[] properties = {
-    new PropertyDefinition<bool>("ConfigureAgent", false, secure: false, comment: "`true` to configure the Gateway interactively"),
+    new PropertyDefinition<bool>("ConfigureAgent", false, secure: false, comment: "`true` to configure the Agent interactively"),
 
     new PropertyDefinition<bool>("DebugPowerShell", false),
 


### PR DESCRIPTION
This PR disables the Windows Restart Manager for the Agent MSI.

The restart manager is intended to reduce reboots due to locked files; and will attempt to shutdown and relaunch executables that are using files the installer will delete and recreate. It prompts the user interactively in this case and offers them the choice to attempt a shutdown/restart of the relevant applications (requires that the applications integrate with the restart manager) or to allow a reboot.

Both the Agent tray application and the session executable trigger the restart manager, but in both cases we will manage things ourselves here. We don't want to prompt the user.

- Disable the restart manager. This makes Windows Installer fall back to the old-style "files in use" dialog, which, importantly, won't trigger for these executables - because they don't have a main window
- Do nothing for DevolutionsSession.exe; it will be terminated when the DevolutionsAgent.exe service is shutdown by the installer
- Manually terminate the DevolutionsDesktopAgent.exe. Since this executable doesn't respond to `WM_CLOSE`, this will always end up being a process `Kill`, but that doesn't really matter for now