### PR TITLE
fix(pedm): copy the shell extension before registration

### DIFF
--- a/package/AgentWindowsManaged/Actions/WinAPI.cs
+++ b/package/AgentWindowsManaged/Actions/WinAPI.cs
@@ -23,6 +23,8 @@ internal static class WinAPI
 
     internal static uint GENERIC_WRITE = 0x40000000;
 
+    internal static uint MOVEFILE_REPLACE_EXISTING = 0x1;
+
     internal static uint MOVEFILE_DELAY_UNTIL_REBOOT = 0x04;
 
     internal const uint SC_MANAGER_ALL_ACCESS = 0xF003F;
@@ -263,7 +265,7 @@ internal static class WinAPI
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static extern bool MoveFileEx(
         [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
-        IntPtr lpNewFileName,
+        [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName,
         uint dwFlags
     );
 

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -253,13 +253,14 @@ internal class Program
                             StopOn = SvcEvent.InstallUninstall,
                         },
                     },
-                    new (Features.PEDM_FEATURE, DevolutionsPedmShellExtDll),
-                    new (Features.PEDM_FEATURE, DevolutionsPedmShellExtMsix),
                     new (Features.SESSION_FEATURE, DevolutionsSession)
                 },
                 Dirs = new[]
                 {
-                    new Dir(Features.PEDM_FEATURE, "desktop", new Files(Features.PEDM_FEATURE, $"{DevolutionsDesktopAgentPath}\\*.*"))
+                    new Dir(Features.PEDM_FEATURE, "desktop", new Files(Features.PEDM_FEATURE, $"{DevolutionsDesktopAgentPath}\\*.*")),
+                    new Dir(Features.PEDM_FEATURE, "contextmenu", 
+                        new File(Features.PEDM_FEATURE, DevolutionsPedmShellExtDll), 
+                        new File(Features.PEDM_FEATURE, DevolutionsPedmShellExtMsix))
                 }
             })),
         };


### PR DESCRIPTION
Upgrading or uninstalling the PEDM shell extension is still problematic: in my test, the restart manager killed Windows Explorer and then failed to restart it properly. This caused a broken state on my machine that was difficult to recover.

Instead, we copy the shell extension DLL before registering it. On uninstall, the dll is moved to a temporary location and then marked for removal on reboot. This is the same approach taken by Notepad++ to avoid this issue.