### PR TITLE
fix(agent): stabilize RDP virtual channel server

### DIFF
--- a/devolutions-session/src/main.rs
+++ b/devolutions-session/src/main.rs
@@ -98,9 +98,7 @@ pub fn start(config: &Conf) -> anyhow::Result<(Runtime, ShutdownHandle, JoinHand
 async fn spawn_tasks(config: &Conf) -> anyhow::Result<Tasks> {
     let mut tasks = Tasks::new();
 
-    if config.debug.enable_unstable {
-        tasks.register(DvcIoTask::default());
-    }
+    tasks.register(DvcIoTask::default());
 
     Ok(tasks)
 }


### PR DESCRIPTION
The feature is still experimental, but it’s not necessary to guard the virtual channel behind the unstable flag when the "DevolutionsSession" feature itself is clearly marked as experimental.