### PR TITLE
fix(dgw): notify all instead of notify one when recording ends

### DIFF
--- a/devolutions-gateway/src/recording.rs
+++ b/devolutions-gateway/src/recording.rs
@@ -596,7 +596,7 @@ impl RecordingManagerTask {
 
             // Notify all the streamers that recording has ended.
             if let Some(notify) = self.recording_end_notifier.get(&id) {
-                notify.notify_one();
+                notify.notify_waiters();
             }
 
             info!(%id, "Start video remuxing operation");


### PR DESCRIPTION
Fix the issue where recording ended but the  streaming task keeps alive, this will result in streaming client not received correct update of the streaming state.