### PR TITLE
fix(deb): improve deb package

### DIFF
--- a/package/Linux/gateway/debian/postinst
+++ b/package/Linux/gateway/debian/postinst
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# System-wide package configuration.
-DEFAULTS_FILE="/etc/default/devolutions-gateway"
-
 if [ ! -d /etc/devolutions-gateway ]; then
 	/bin/mkdir /etc/devolutions-gateway
 	/bin/chmod 655 /etc/devolutions-gateway
@@ -10,7 +7,7 @@ fi
 
 if [ -d /run/systemd/system ]; then
 	/usr/bin/devolutions-gateway service register >/dev/null
-	/usr/bin/devolutions-gateway service --config-init-only >/dev/null
-	systemctl restart devolutions-gateway >/dev/null 2>&1
 	systemctl daemon-reload
+	/usr/bin/devolutions-gateway --config-init-only >/dev/null
+	systemctl enable --now devolutions-gateway >/dev/null 2>&1
 fi

--- a/package/Linux/gateway/debian/postrm
+++ b/package/Linux/gateway/debian/postrm
@@ -9,9 +9,6 @@ if [ "$action" != "purge" ] ; then
   exit 0
 fi
 
-# System-wide package configuration.
-DEFAULTS_FILE="/etc/default/devolutions-gateway"
-
-if [ -s "$DEFAULTS_FILE" ]; then
-  rm "$DEFAULTS_FILE" || exit 1
+if [ -d /etc/devolutions-gateway ]; then
+  rm -rf /etc/devolutions-gateway
 fi

--- a/package/Linux/gateway/debian/prerm
+++ b/package/Linux/gateway/debian/prerm
@@ -8,7 +8,7 @@ if [ "$2" = "in-favour" ]; then
   action="upgrade"
 fi
 
-# Don't clean-up just for an upgrade.`
+# Don't clean-up just for an upgrade.
 if [ "$action" = "upgrade" ] ; then
   exit 0
 fi
@@ -16,4 +16,5 @@ fi
 if [ -d /run/systemd/system ]; then
   systemctl stop devolutions-gateway >/dev/null 2>&1
   /usr/bin/devolutions-gateway service unregister >/dev/null
+  systemctl daemon-reload
 fi


### PR DESCRIPTION
~~This PR is somewhat related to #1223 as currently you cannot uninstall `devolutions-gateway` properly (on Ubuntu) without modifying `/var/lib/dpkg/info/devolutions-gateway.prerm` because of the service name change making the `systemctl stop` command.~~ Post-publication edit: #1223 is a bug, hence the modifications related to this are removed.

~~And although not utilized by the service file, this PR also adds the functionality to create `/etc/defaults/devolutions-gateway` file.~~ Post-publication edit: References to the defaults file are also removed.

Lastly, the PR adds an `rm -rf /etc/devolutions-gateway` command if `postrm` is called with `purge` flag.

Post-publication edit: PR also changes the systemd reload command order and also enables (and starts) `devolutions-gateway` service to start on boot.