### PR TITLE
fix(installer): prevent invalid configuration due to installer sequencing

### DIFF
--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -229,26 +229,27 @@ namespace DevolutionsAgent.Actions
             return ActionResult.Success;
         }
 
-        static ActionResult EnableAgentFeature(Session session, string feature)
+        static ActionResult ToggleAgentFeature(Session session, string feature, bool enable)
         {
             string path = Path.Combine(ProgramDataDirectory, "agent.json");
 
             try
             {
                 Dictionary<string, object> config = [];
+
                 try
                 {
-                    using var reader = new StreamReader(path);
+                    using StreamReader reader = new StreamReader(path);
                     config = JsonConvert.DeserializeObject<Dictionary<string, object>>(reader.ReadToEnd());
                 }
                 catch (Exception)
                 {
-                    // ignored. Previous config is either invalid or non existent.
+                    // ignored. Previous config is either invalid or non-existent.
                 }
 
-                config[feature] = new Dictionary<string, bool> {{"Enabled", true}};
+                config[feature] = new Dictionary<string, bool> {{"Enabled", enable}};
 
-                using var writer = new StreamWriter(path);
+                using StreamWriter writer = new StreamWriter(path);
                 writer.Write(JsonConvert.SerializeObject(config));
 
                 return ActionResult.Success;
@@ -263,13 +264,25 @@ namespace DevolutionsAgent.Actions
         [CustomAction]
         public static ActionResult InstallPedm(Session session)
         {
-            return EnableAgentFeature(session, "Pedm");
+            return ToggleAgentFeature(session, "Pedm", true);
         }
 
         [CustomAction]
         public static ActionResult InstallSession(Session session)
         {
-            return EnableAgentFeature(session, "Session");
+            return ToggleAgentFeature(session, "Session", true);
+        }
+
+        [CustomAction]
+        public static ActionResult UninstallPedm(Session session)
+        {
+            return ToggleAgentFeature(session, "Pedm", false);
+        }
+
+        [CustomAction]
+        public static ActionResult UninstallSession(Session session)
+        {
+            return ToggleAgentFeature(session, "Session", false);
         }
 
         [CustomAction]


### PR DESCRIPTION
The PEDM/Session feature toggle was manipulating `agent.json` _after_ `InstallFiles`.

The action that does an initialization of the `agent.json` was not actually added to the custom actions, and in any case it was sequenced _before_ `StartServices` (which is _after_ `InstallFiles`).

So: the PEDM/Session feature installation would create a new `agent.json` if it didn't already exist, and then the initialization custom action and service itself would not bother to initialize the `agent.json`. The result was that the "updater" configuration key would be missing if the user selected additional features.

This PR:

- Fixes the sequencing for feature installation and config file generation
- Disables the Agent/Session features when they are uninstalled
- Prevents the PEDM %programdata% subdirectory from being created if the user does not choose the "PEDM" feature