### PR TITLE
feat(installer): make agent updater a selectable feature

### DIFF
--- a/package/AgentWindowsManaged/Actions/AgentActions.cs
+++ b/package/AgentWindowsManaged/Actions/AgentActions.cs
@@ -235,30 +235,15 @@ internal static class AgentActions
         Execute = Execute.rollback,
     };
 
-    private static readonly ElevatedManagedAction installPedm = new(
-        CustomActions.InstallPedm
+    private static readonly ElevatedManagedAction configureFeatures = new(
+        CustomActions.ConfigureFeatures
     )
     {
-        Id = new Id($"CA.{nameof(installPedm)}"),
-        Feature = Features.PEDM_FEATURE,
+        Id = new Id($"CA.{nameof(configureFeatures)}"),
         Sequence = Sequence.InstallExecuteSequence,
         Return = Return.check,
-        Step = new Step(initAgentConfigIfNeeded.Id),
-        When = When.After,
-        Condition = Features.PEDM_FEATURE.BeingInstall(),
-    };
-
-    private static readonly ElevatedManagedAction uninstallPedm = new(
-        CustomActions.UninstallPedm
-    )
-    {
-        Id = new Id($"CA.{nameof(uninstallPedm)}"),
-        Feature = Features.PEDM_FEATURE,
-        Sequence = Sequence.InstallExecuteSequence,
-        Return = Return.check,
-        Step = Step.StopServices,
-        When = When.After,
-        Condition = Features.PEDM_FEATURE.BeingUninstall(),
+        Step = Step.StartServices,
+        When = When.Before
     };
 
     private static readonly ElevatedManagedAction registerExplorerCommand = new(
@@ -305,32 +290,6 @@ internal static class AgentActions
         Condition = Features.PEDM_FEATURE.BeingUninstall(),
     };
 
-    private static readonly ElevatedManagedAction installSession = new(
-        CustomActions.InstallSession
-    )
-    {
-        Id = new Id("installSession"),
-        Feature = Features.SESSION_FEATURE,
-        Sequence = Sequence.InstallExecuteSequence,
-        Return = Return.check,
-        Step = new Step(installPedm.Id),
-        When = When.After,
-        Condition = Features.SESSION_FEATURE.BeingInstall(),
-    };
-
-    private static readonly ElevatedManagedAction uninstallSession = new(
-        CustomActions.UninstallSession
-    )
-    {
-        Id = new Id($"CA.{nameof(uninstallSession)}"),
-        Feature = Features.SESSION_FEATURE,
-        Sequence = Sequence.InstallExecuteSequence,
-        Return = Return.check,
-        Step = new Step(uninstallPedm.Id),
-        When = When.After,
-        Condition = Features.SESSION_FEATURE.BeingUninstall(),
-    };
-
     private static string UseProperties(IEnumerable<IWixProperty> properties)
     {
         if (!properties?.Any() ?? false)
@@ -358,18 +317,15 @@ internal static class AgentActions
         checkNetFxInstalledVersion,
         getInstallDirFromRegistry,
         setArpInstallLocation,
+        configureFeatures,
         createProgramDataDirectory,
         setProgramDataDirectoryPermissions,
         createProgramDataPedmDirectories,
         setProgramDataPedmDirectoryPermissions,
         initAgentConfigIfNeeded,
-        installPedm,
-        uninstallPedm,
         registerExplorerCommand,
         registerExplorerCommandRollback,
         unregisterExplorerCommand,
-        installSession,
-        uninstallSession,
         cleanAgentConfigIfNeeded,
         cleanAgentConfigIfNeededRollback,
         shutdownDesktopApp,

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -262,27 +262,16 @@ namespace DevolutionsAgent.Actions
         }
 
         [CustomAction]
-        public static ActionResult InstallPedm(Session session)
+        public static ActionResult ConfigureFeatures(Session session)
         {
-            return ToggleAgentFeature(session, "Pedm", true);
-        }
+            foreach (Feature feature in (Feature[]) [Features.SESSION_FEATURE, Features.PEDM_FEATURE, Features.AGENT_UPDATER_FEATURE])
+            {
+                bool enable = session.IsFeatureEnabled(feature.Id);
+                string jsonId = feature.Id.Substring(Features.FEATURE_ID_PREFIX.Length);
+                ToggleAgentFeature(session, jsonId, enable);
+            }
 
-        [CustomAction]
-        public static ActionResult InstallSession(Session session)
-        {
-            return ToggleAgentFeature(session, "Session", true);
-        }
-
-        [CustomAction]
-        public static ActionResult UninstallPedm(Session session)
-        {
-            return ToggleAgentFeature(session, "Pedm", false);
-        }
-
-        [CustomAction]
-        public static ActionResult UninstallSession(Session session)
-        {
-            return ToggleAgentFeature(session, "Session", false);
+            return ActionResult.Success;
         }
 
         [CustomAction]

--- a/package/AgentWindowsManaged/Dialogs/FeaturesDialog.Designer.cs
+++ b/package/AgentWindowsManaged/Dialogs/FeaturesDialog.Designer.cs
@@ -35,7 +35,6 @@ namespace DevolutionsAgent.Dialogs
             this.description = new System.Windows.Forms.Label();
             this.featuresTree = new System.Windows.Forms.ListView();
             this.label3 = new System.Windows.Forms.Label();
-            this.reset = new System.Windows.Forms.LinkLabel();
             this.topBorder = new System.Windows.Forms.Panel();
             this.topPanel = new System.Windows.Forms.Panel();
             this.label2 = new System.Windows.Forms.Label();
@@ -63,7 +62,6 @@ namespace DevolutionsAgent.Dialogs
             this.middlePanel.Controls.Add(this.descriptionPanel);
             this.middlePanel.Controls.Add(this.featuresTree);
             this.middlePanel.Controls.Add(this.label3);
-            this.middlePanel.Controls.Add(this.reset);
             this.middlePanel.Location = new System.Drawing.Point(0, 65);
             this.middlePanel.Name = "middlePanel";
             this.middlePanel.Size = new System.Drawing.Size(494, 241);
@@ -99,9 +97,9 @@ namespace DevolutionsAgent.Dialogs
             this.featuresTree.CheckBoxes = true;
             this.featuresTree.HideSelection = false;
             this.featuresTree.Location = new System.Drawing.Point(14, 28);
-            this.featuresTree.Name = "featuresTree";
             this.featuresTree.MultiSelect = false;
-            this.featuresTree.Size = new System.Drawing.Size(270, 186);
+            this.featuresTree.Name = "featuresTree";
+            this.featuresTree.Size = new System.Drawing.Size(280, 186);
             this.featuresTree.TabIndex = 0;
             this.featuresTree.UseCompatibleStateImageBehavior = false;
             this.featuresTree.View = System.Windows.Forms.View.List;
@@ -118,19 +116,6 @@ namespace DevolutionsAgent.Dialogs
             this.label3.Size = new System.Drawing.Size(98, 13);
             this.label3.TabIndex = 1;
             this.label3.Text = "[CustomizeDlgText]";
-            // 
-            // reset
-            // 
-            this.reset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.reset.AutoSize = true;
-            this.reset.BackColor = System.Drawing.Color.Transparent;
-            this.reset.Location = new System.Drawing.Point(17, 220);
-            this.reset.Name = "reset";
-            this.reset.Size = new System.Drawing.Size(105, 13);
-            this.reset.TabIndex = 9;
-            this.reset.TabStop = true;
-            this.reset.Text = "[CustomizeDlgReset]";
-            this.reset.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.Reset_LinkClicked);
             // 
             // topBorder
             // 
@@ -305,7 +290,6 @@ namespace DevolutionsAgent.Dialogs
         private Panel bottomPanel;
         private Panel descriptionPanel;
         private Label description;
-        private LinkLabel reset;
         private Label label3;
         private Panel border1;
         private Panel topBorder;

--- a/package/AgentWindowsManaged/Dialogs/ProgressDialog.cs
+++ b/package/AgentWindowsManaged/Dialogs/ProgressDialog.cs
@@ -2,7 +2,6 @@ using DevolutionsAgent.Dialogs;
 using Microsoft.Deployment.WindowsInstaller;
 using System;
 using System.Drawing;
-using System.Runtime.InteropServices;
 using System.Security.Principal;
 using DevolutionsAgent.Helpers;
 using DevolutionsAgent.Properties;
@@ -15,7 +14,7 @@ public partial class ProgressDialog : AgentDialog, IProgressDialog
 {
     private static Icon shieldIcon;
 
-    public static Icon ShieldLarge => shieldIcon ??= StockIcon.GetStockIcon(StockIcon.SIID_SHIELD, StockIcon.SHGSI_LARGEICON);
+    public static Icon ShieldLarge => shieldIcon ??= StockIcon.GetStockIcon(StockIcon.StockIconId.Shield);
 
     public ProgressDialog()
     {

--- a/package/AgentWindowsManaged/Helpers/StockIcon.cs
+++ b/package/AgentWindowsManaged/Helpers/StockIcon.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Tools.WindowsInstallerXml.Bootstrapper;
+using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
 
@@ -6,18 +7,25 @@ namespace DevolutionsAgent.Helpers
 {
     internal class StockIcon
     {
-        internal static Icon GetStockIcon(uint type, uint size)
+        public static Icon GetStockIcon(StockIconId stockIcon, StockIconOptions options = StockIconOptions.Default)
         {
-            var info = new SHSTOCKICONINFO();
-            info.cbSize = (uint)Marshal.SizeOf(info);
+            SHSTOCKICONINFO info = new()
+            {
+                cbSize = (uint)Marshal.SizeOf<SHSTOCKICONINFO>(),
+            };
 
-            SHGetStockIconInfo(type, SHGSI_ICON | size, ref info);
+            if (SHGetStockIconInfo((uint) stockIcon, (uint) options | SHGSI_ICON, ref info) != 0)
+            {
+                throw new Exception("failed to load stock icon");
+            }
 
-            var icon = (Icon)Icon.FromHandle(info.hIcon).Clone(); // Get a copy that doesn't use the original handle
+            Icon icon = (Icon)Icon.FromHandle(info.hIcon).Clone(); // Get a copy that doesn't use the original handle
             DestroyIcon(info.hIcon); // Clean up native icon to prevent resource leak
 
             return icon;
         }
+
+        private const uint SHGSI_ICON = 0x100;
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         private struct SHSTOCKICONINFO
@@ -36,12 +44,502 @@ namespace DevolutionsAgent.Helpers
         [DllImport("user32.dll")]
         private static extern bool DestroyIcon(IntPtr handle);
 
-        internal const uint SIID_HELP = 23;
-        internal const uint SIID_SHIELD = 77;
-        internal const uint SIID_WARNING = 78;
-        internal const uint SIID_INFO = 79;
-        internal const uint SHGSI_ICON = 0x100;
-        internal const uint SHGSI_LARGEICON = 0x0;
-        internal const uint SHGSI_SMALLICON = 0x1;
+        [Flags]
+        public enum StockIconOptions
+        {
+            /// <summary>
+            ///  Use the defaults, which is to retrieve a large version of the icon (as defined by the current system
+            ///  metrics).
+            /// </summary>
+            Default = 0x000000000,
+
+            /// <summary>
+            ///  Retrieve the small version of the icon (as defined by the current system metrics).
+            /// </summary>
+            SmallIcon = 0x000000001,
+
+            /// <summary>
+            ///  Retrieve the shell icon size of the icon.
+            /// </summary>
+            ShellIconSize = 0x000000004,
+
+            /// <summary>
+            ///  Adds a link overlay onto the icon.
+            /// </summary>
+            LinkOverlay = 0x000008000,
+
+            /// <summary>
+            ///  Blends the icon with the system highlight color.
+            /// </summary>
+            Selected = 0x000010000,
+        }
+
+        public enum StockIconId
+        {
+            /// <summary>
+            ///  Document (blank page), no associated program.
+            /// </summary>
+            DocumentNoAssociation = 0,      // SIID_DOCNOASSOC
+
+            /// <summary>
+            ///  Document with an associated program.
+            /// </summary>
+            DocumentWithAssociation = 1,    // SIID_DOCASSOC
+
+            /// <summary>
+            ///  Generic application with no custom icon.
+            /// </summary>
+            Application = 2,                // SIID_APPLICATION
+
+            /// <summary>
+            ///  Closed folder.
+            /// </summary>
+            Folder = 3,                     // SIID_FOLDER
+
+            /// <summary>
+            ///  Open folder.
+            /// </summary>
+            FolderOpen = 4,                 // SIID_FOLDEROPEN
+
+            /// <summary>
+            ///  5.25" floppy disk drive.
+            /// </summary>
+            Drive525 = 5,                   // SIID_DRIVE525
+
+            /// <summary>
+            ///  3.5" floppy disk drive.
+            /// </summary>
+            Drive35 = 6,                    // SIID_DRIVE35
+
+            /// <summary>
+            ///  Removable drive.
+            /// </summary>
+            DriveRemovable = 7,             // SIID_DRIVEREMOVE
+
+            /// <summary>
+            ///  Fixed drive.
+            /// </summary>
+            DriveFixed = 8,                 // SIID_DRIVEFIXED
+
+            /// <summary>
+            ///  Network drive.
+            /// </summary>
+            DriveNet = 9,                   // SIID_DRIVENET
+
+            /// <summary>
+            ///  Disabled network drive.
+            /// </summary>
+            DriveNetDisabled = 10,          // SIID_DRIVENETDISABLED
+
+            /// <summary>
+            ///  CD drive.
+            /// </summary>
+            DriveCD = 11,                   // SIID_DRIVECD
+
+            /// <summary>
+            ///  RAM disk drive.
+            /// </summary>
+            DriveRam = 12,                  // SIID_DRIVERAM
+
+            /// <summary>
+            ///  Entire network.
+            /// </summary>
+            World = 13,                     // SIID_WORLD
+
+            /// <summary>
+            ///  A computer on the network.
+            /// </summary>
+            Server = 15,                    // SIID_SERVER
+
+            /// <summary>
+            ///  Printer.
+            /// </summary>
+            Printer = 16,                   // SIID_PRINTER
+
+            /// <summary>
+            ///  My network places.
+            /// </summary>
+            MyNetwork = 17,                 // SIID_MYNETWORK
+
+            /// <summary>
+            ///  Find.
+            /// </summary>
+            Find = 22,                      // SIID_FIND
+
+            /// <summary>
+            ///  Help.
+            /// </summary>
+            Help = 23,                      // SIID_HELP
+
+            /// <summary>
+            ///  Overlay for shared items.
+            /// </summary>
+            Share = 28,                     // SIID_SHARE
+
+            /// <summary>
+            ///  Overlay for shortcuts to items.
+            /// </summary>
+            Link = 29,                      // SIID_LINK
+
+            /// <summary>
+            ///  Overlay for slow items.
+            /// </summary>
+            SlowFile = 30,                  // SIID_SLOWFILE
+
+            /// <summary>
+            ///  Empty recycle bin.
+            /// </summary>
+            Recycler = 31,                  // SIID_RECYCLER
+
+            /// <summary>
+            ///  Full recycle bin.
+            /// </summary>
+            RecyclerFull = 32,              // SIID_RECYCLERFULL
+
+            /// <summary>
+            ///  Audio CD media.
+            /// </summary>
+            MediaCDAudio = 40,              // SIID_MEDIACDAUDIO
+
+            /// <summary>
+            ///  Security lock.
+            /// </summary>
+            Lock = 47,                      // SIID_LOCK
+
+            /// <summary>
+            ///  AutoList.
+            /// </summary>
+            AutoList = 49,                  // SIID_AUTOLIST
+
+            /// <summary>
+            ///  Network printer.
+            /// </summary>
+            PrinterNet = 50,                // SIID_PRINTERNET
+
+            /// <summary>
+            ///  Server share.
+            /// </summary>
+            ServerShare = 51,               // SIID_SERVERSHARE
+
+            /// <summary>
+            ///  Fax printer.
+            /// </summary>
+            PrinterFax = 52,                // SIID_PRINTERFAX
+
+            /// <summary>
+            ///  Networked fax printer.
+            /// </summary>
+            PrinterFaxNet = 53,             // SIID_PRINTERFAXNET
+
+            /// <summary>
+            ///  Print to file.
+            /// </summary>
+            PrinterFile = 54,               // SIID_PRINTERFILE
+
+            /// <summary>
+            ///  Stack.
+            /// </summary>
+            Stack = 55,                     // SIID_STACK
+
+            /// <summary>
+            ///  SVCD media.
+            /// </summary>
+            MediaSVCD = 56,                 // SIID_MEDIASVCD
+
+            /// <summary>
+            ///  Folder containing other items.
+            /// </summary>
+            StuffedFolder = 57,             // SIID_STUFFEDFOLDER
+
+            /// <summary>
+            ///  Unknown drive.
+            /// </summary>
+            DriveUnknown = 58,              // SIID_DRIVEUNKNOWN
+
+            /// <summary>
+            ///  DVD drive.
+            /// </summary>
+            DriveDVD = 59,                  // SIID_DRIVEDVD
+
+            /// <summary>
+            ///  DVD media.
+            /// </summary>
+            MediaDVD = 60,                  // SIID_MEDIADVD
+
+            /// <summary>
+            ///  DVD-RAM media.
+            /// </summary>
+            MediaDVDRAM = 61,               // SIID_MEDIADVDRAM
+
+            /// <summary>
+            ///  DVD-RW media.
+            /// </summary>
+            MediaDVDRW = 62,                // SIID_MEDIADVDRW
+
+            /// <summary>
+            ///  DVD-R media.
+            /// </summary>
+            MediaDVDR = 63,                 // SIID_MEDIADVDR
+
+            /// <summary>
+            ///  DVD-ROM media.
+            /// </summary>
+            MediaDVDROM = 64,               // SIID_MEDIADVDROM
+
+            /// <summary>
+            ///  CD+ (Enhanced CD) media.
+            /// </summary>
+            MediaCDAudioPlus = 65,          // SIID_MEDIACDAUDIOPLUS
+
+            /// <summary>
+            ///  CD-RW media.
+            /// </summary>
+            MediaCDRW = 66,                 // SIID_MEDIACDRW
+
+            /// <summary>
+            ///  CD-R media.
+            /// </summary>
+            MediaCDR = 67,                  // SIID_MEDIACDR
+
+            /// <summary>
+            ///  Burning CD.
+            /// </summary>
+            MediaCDBurn = 68,               // SIID_MEDIACDBURN
+
+            /// <summary>
+            ///  Blank CD media.
+            /// </summary>
+            MediaBlankCD = 69,              // SIID_MEDIABLANKCD
+
+            /// <summary>
+            ///  CD-ROM media.
+            /// </summary>
+            MediaCDROM = 70,                // SIID_MEDIACDROM
+
+            /// <summary>
+            ///  Audio files.
+            /// </summary>
+            AudioFiles = 71,                // SIID_AUDIOFILES
+
+            /// <summary>
+            ///  Image files.
+            /// </summary>
+            ImageFiles = 72,                // SIID_IMAGEFILES
+
+            /// <summary>
+            ///  Video files.
+            /// </summary>
+            VideoFiles = 73,                // SIID_VIDEOFILES
+
+            /// <summary>
+            ///  Mixed files.
+            /// </summary>
+            MixedFiles = 74,                // SIID_MIXEDFILES
+
+            /// <summary>
+            ///  Folder back.
+            /// </summary>
+            FolderBack = 75,                // SIID_FOLDERBACK
+
+            /// <summary>
+            ///  Folder front.
+            /// </summary>
+            FolderFront = 76,               // SIID_FOLDERFRONT
+
+            /// <summary>
+            ///  Security shield. Use for UAC prompts only.
+            /// </summary>
+            Shield = 77,                    // SIID_SHIELD
+
+            /// <summary>
+            ///  Warning.
+            /// </summary>
+            Warning = 78,                   // SIID_WARNING
+
+            /// <summary>
+            ///  Informational.
+            /// </summary>
+            Info = 79,                      // SIID_INFO
+
+            /// <summary>
+            ///  Error.
+            /// </summary>
+            Error = 80,                     // SIID_ERROR
+
+            /// <summary>
+            ///  Key / secure.
+            /// </summary>
+            Key = 81,                       // SIID_KEY
+
+            /// <summary>
+            ///  Software.
+            /// </summary>
+            Software = 82,                  // SIID_SOFTWARE
+
+            /// <summary>
+            ///  Rename.
+            /// </summary>
+            Rename = 83,                    // SIID_RENAME
+
+            /// <summary>
+            ///  Delete.
+            /// </summary>
+            Delete = 84,                    // SIID_DELETE
+
+            /// <summary>
+            ///  Audio DVD media.
+            /// </summary>
+            MediaAudioDVD = 85,             // SIID_MEDIAAUDIODVD
+
+            /// <summary>
+            ///  Movied DVD media.
+            /// </summary>
+            MediaMovieDVD = 86,             // SIID_MEDIAMOVIEDVD
+
+            /// <summary>
+            ///  Enhanced CD media.
+            /// </summary>
+            MediaEnhancedCD = 87,           // SIID_MEDIAENHANCEDCD
+
+            /// <summary>
+            ///  Enhanced DVD media.
+            /// </summary>
+            MediaEnhancedDVD = 88,          // SIID_MEDIAENHANCEDDVD
+
+            /// <summary>
+            ///  HD-DVD media.
+            /// </summary>
+            MediaHDDVD = 89,                // SIID_MEDIAHDDVD
+
+            /// <summary>
+            ///  BluRay media.
+            /// </summary>
+            MediaBluRay = 90,               // SIID_MEDIABLURAY
+
+            /// <summary>
+            ///  VCD media.
+            /// </summary>
+            MediaVCD = 91,                  // SIID_MEDIAVCD
+
+            /// <summary>
+            ///  DVD+R media.
+            /// </summary>
+            MediaDVDPlusR = 92,             // SIID_MEDIADVDPLUSR
+
+            /// <summary>
+            ///  DVD+RW media.
+            /// </summary>
+            MediaDVDPlusRW = 93,            // SIID_MEDIADVDPLUSRW
+
+            /// <summary>
+            ///  Desktop computer.
+            /// </summary>
+            DesktopPC = 94,                 // SIID_DESKTOPPC
+
+            /// <summary>
+            ///  Mobile computer.
+            /// </summary>
+            MobilePC = 95,                  // SIID_MOBILEPC
+
+            /// <summary>
+            ///  Users.
+            /// </summary>
+            Users = 96,                     // SIID_USERS
+
+            /// <summary>
+            ///  Smart media.
+            /// </summary>
+            MediaSmartMedia = 97,           // SIID_MEDIASMARTMEDIA
+
+            /// <summary>
+            ///  Compact Flash.
+            /// </summary>
+            MediaCompactFlash = 98,         // SIID_MEDIACOMPACTFLASH
+
+            /// <summary>
+            ///  Cell phone.
+            /// </summary>
+            DeviceCellPhone = 99,           // SIID_DEVICECELLPHONE
+
+            /// <summary>
+            ///  Camera.
+            /// </summary>
+            DeviceCamera = 100,             // SIID_DEVICECAMERA
+
+            /// <summary>
+            ///  Video camera.
+            /// </summary>
+            DeviceVideoCamera = 101,        // SIID_DEVICEVIDEOCAMERA
+
+            /// <summary>
+            ///  Audio player.
+            /// </summary>
+            DeviceAudioPlayer = 102,        // SIID_DEVICEAUDIOPLAYER
+
+            /// <summary>
+            ///  Connect to network.
+            /// </summary>
+            NetworkConnect = 103,           // SIID_NETWORKCONNECT
+
+            /// <summary>
+            ///  Internet.
+            /// </summary>
+            Internet = 104,                 // SIID_INTERNET
+
+            /// <summary>
+            ///  ZIP file.
+            /// </summary>
+            ZipFile = 105,                  // SIID_ZIPFILE
+
+            /// <summary>
+            ///  Settings.
+            /// </summary>
+            Settings = 106,                 // SIID_SETTINGS
+
+            /// <summary>
+            ///  HD-DVD drive.
+            /// </summary>
+            DriveHDDVD = 132,               // SIID_DRIVEHDDVD
+
+            /// <summary>
+            ///  BluRay drive.
+            /// </summary>
+            DriveBD = 133,                  // SIID_DRIVEBD
+
+            /// <summary>
+            ///  HD-DVD-ROM media.
+            /// </summary>
+            MediaHDDVDROM = 134,            // SIID_MEDIAHDDVDROM
+
+            /// <summary>
+            ///  HD-DVD-R media.
+            /// </summary>
+            MediaHDDVDR = 135,              // SIID_MEDIAHDDVDR
+
+            /// <summary>
+            ///  HD-DVD-RAM media.
+            /// </summary>
+            MediaHDDVDRAM = 136,            // SIID_MEDIAHDDVDRAM
+
+            /// <summary>
+            ///  BluRay-ROM media.
+            /// </summary>
+            MediaBDROM = 137,               // SIID_MEDIABDROM
+
+            /// <summary>
+            ///  BluRay-R media.
+            /// </summary>
+            MediaBDR = 138,                 // SIID_MEDIABDR
+
+            /// <summary>
+            ///  BluRay-RE media.
+            /// </summary>
+            MediaBDRE = 139,                // SIID_MEDIABDRE
+
+            /// <summary>
+            ///  Clustered disk.
+            /// </summary>
+            ClusteredDrive = 140            // SIID_CLUSTEREDDRIVE
+        }
     }
 }

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -420,6 +420,13 @@ internal class Program
             e.Result = ActionResult.UserExit;
         }
 
-        e.Session["ADDLOCAL"] = Helpers.AppSearch.InstalledFeatures.Select(x => x.FeatureName).JoinBy(",");
+        FeatureList features = new FeatureList(Helpers.AppSearch.InstalledFeatures);
+
+        if (installedVersion is null)
+        {
+            features.Add(Features.AGENT_UPDATER_FEATURE.Id);
+        }
+
+        e.Session["ADDLOCAL"] = features.ToString();
     }
 }

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
@@ -3,6 +3,8 @@
         <!-- metadata -->
                 <String Id="FeatureAgentDescription">Install the Devolutions Agent service</String>
                 <String Id="FeatureAgentName">Devolutions Agent</String>
+                <String Id="FeatureAgentUpdaterDescription">Enable the Devolutions Gateway updater</String>
+                <String Id="FeatureAgentUpdaterName">Devolutions Gateway Updater</String>
                 <String Id="FeaturePedmDescription">Enable PEDM features and install the shell extension</String>
                 <String Id="FeaturePedmName">Devolutions PEDM</String>
                 <String Id="FeatureSessionDescription">Install the Devolutions Session application</String>

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
@@ -60,6 +60,8 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                     <!-- metadata.- -->
                 <String Id="FeatureAgentDescription">Install the Devolutions Agent service</String>
                 <String Id="FeatureAgentName">Devolutions Agent</String>
+                <String Id="FeatureAgentUpdaterDescription">Enable the Devolutions Gateway updater</String>
+                <String Id="FeatureAgentUpdaterName">Devolutions Gateway Updater</String>
                 <String Id="FeaturePedmDescription">Enable PEDM features and install the shell extension</String>
                 <String Id="FeaturePedmName">Devolutions PEDM</String>
                 <String Id="FeatureSessionDescription">Install the Devolutions Session application</String>

--- a/package/AgentWindowsManaged/Resources/Features.cs
+++ b/package/AgentWindowsManaged/Resources/Features.cs
@@ -1,26 +1,76 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Deployment.WindowsInstaller;
 using WixSharp;
 
 namespace DevolutionsAgent.Resources
 {
     internal static class Features
     {
+        internal const string FEATURE_ID_PREFIX = "F.";
+
         internal static IEnumerable<Feature> ExperimentalFeatures => [ PEDM_FEATURE, SESSION_FEATURE ];
+
+        internal static Feature AGENT_UPDATER_FEATURE = new("!(loc.FeatureAgentUpdaterName)", "!(loc.FeatureAgentUpdaterDescription)", true, true)
+        {
+            Id = $"{FEATURE_ID_PREFIX}Updater"
+        };
 
         internal static Feature AGENT_FEATURE = new("!(loc.FeatureAgentName)", true, false)
         {
-            Id = "F.Agent", 
-            Description = "!(loc.FeatureAgentDescription)"
+            Id = $"{FEATURE_ID_PREFIX}Agent", 
+            Description = "!(loc.FeatureAgentDescription)",
+            Children = [ AGENT_UPDATER_FEATURE ]
         };
 
         internal static Feature PEDM_FEATURE = new("!(loc.FeaturePedmName)", "!(loc.FeaturePedmDescription)", false)
         {
-            Id = "F.Pedm"
+            Id = $"{FEATURE_ID_PREFIX}Pedm"
         };
 
         internal static Feature SESSION_FEATURE = new("!(loc.FeatureSessionName)", "!(loc.FeatureSessionDescription)", false)
         {
-            Id = "F.Session"
+            Id = $"{FEATURE_ID_PREFIX}Session"
         };
+    }
+
+    internal class FeatureList
+    {
+        private readonly List<string> features;
+
+        public FeatureList(string features)
+        {
+            this.features = features.Split([','], StringSplitOptions.RemoveEmptyEntries).ToList();
+        }
+
+        public FeatureList(IEnumerable<string> features)
+        {
+            this.features = features.ToList();
+        }
+
+        public FeatureList(IEnumerable<FeatureInstallation> features)
+        {
+            this.features = features.Select(x => x.FeatureName).ToList();
+        }
+
+        public void Add(string feature)
+        {
+            if (!this.features.Contains(feature))
+            {
+                this.features.Add(feature);
+            }
+        }
+
+        public bool Contains(string feature) => this.features.Contains(feature);
+
+        public void Remove(string feature)
+        {
+            this.features.RemoveAll(x => x.Equals(feature));
+        }
+
+        public override string ToString() => this.features.JoinBy(",");
+
+        public string[] ToArray() => this.features.ToArray();
     }
 }

--- a/package/AgentWindowsManaged/Resources/Strings.g.cs
+++ b/package/AgentWindowsManaged/Resources/Strings.g.cs
@@ -33,6 +33,14 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string FeatureAgentDescription = "FeatureAgentDescription";		
 		/// <summary>
+		/// Devolutions Gateway Updater
+		/// </summary>
+		public const string FeatureAgentUpdaterName = "FeatureAgentUpdaterName";		
+		/// <summary>
+		/// Enable the Devolutions Gateway updater
+		/// </summary>
+		public const string FeatureAgentUpdaterDescription = "FeatureAgentUpdaterDescription";		
+		/// <summary>
 		/// Devolutions PEDM
 		/// </summary>
 		public const string FeaturePedmName = "FeaturePedmName";		

--- a/package/AgentWindowsManaged/Resources/Strings_en-US.json
+++ b/package/AgentWindowsManaged/Resources/Strings_en-US.json
@@ -27,6 +27,14 @@
           "text": "Install the Devolutions Agent service"
         },
         {
+          "id": "FeatureAgentUpdaterName",
+          "text": "Devolutions Gateway Updater"
+        },
+        {
+          "id": "FeatureAgentUpdaterDescription",
+          "text": "Enable the Devolutions Gateway updater"
+        },
+        {
           "id": "FeaturePedmName",
           "text": "Devolutions PEDM"
         },


### PR DESCRIPTION
Make the Gateway updater a selectable feature in the Agent MSI installer.

New installs will select the feature by default; upgrades will follow what is already installed. Note that since this a "new feature", upgrades from prior versions will _not_ automatically select the updater feature. I choose not to code around this because we don't have a public release yet.

I reworked the `StockIcon` helper but ended up not using the changes. However, I keep the improvements that may be useful in future.