### PR TITLE
fix(pedm): don't use Windows file namespace in paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,7 @@ dependencies = [
  "devolutions-gateway-task",
  "devolutions-pedm-shared",
  "digest",
+ "dunce",
  "hyper 1.5.0",
  "hyper-util",
  "parking_lot",
@@ -1305,6 +1306,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "devolutions-pedm-client-http",
+ "dunce",
  "glob",
  "hyper 0.14.31",
  "pin-project 1.1.7",

--- a/crates/devolutions-pedm-shared/Cargo.toml
+++ b/crates/devolutions-pedm-shared/Cargo.toml
@@ -22,6 +22,7 @@ devolutions-pedm-client-http = { path = "./devolutions-pedm-client-http", option
 tower = { version = "0.3", optional = true } # old version required for OpenAPI generator
 pin-project = { version = "1.1", optional = true }
 uuid = { version = "1", features = ["v4", "serde"]}
+dunce = "1.0"
 
 [features]
 pedm_client = ["hyper", "serde_json", "tokio", "win-api-wrappers", "policy", "serde", "devolutions-pedm-client-http", "tower", "pin-project", "anyhow"]

--- a/crates/devolutions-pedm-shared/src/policy.rs
+++ b/crates/devolutions-pedm-shared/src/policy.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -147,8 +146,8 @@ where
     for<'a> PathBuf: From<&'a T>,
 {
     fn is_match(&self, base: &T) -> bool {
-        let base = fs::canonicalize(PathBuf::from(base));
-        let data = self.data.canonicalize();
+        let base = dunce::canonicalize(PathBuf::from(base));
+        let data = dunce::canonicalize(&self.data);
 
         match (base, data) {
             (Ok(base), Ok(data)) => match &self.kind {

--- a/crates/devolutions-pedm/Cargo.toml
+++ b/crates/devolutions-pedm/Cargo.toml
@@ -38,6 +38,7 @@ tower-http = { version = "0.5", features = ["timeout"] }
 parking_lot = "0.12"
 cfg-if = "1.0"
 uuid = "1"
+dunce = "1.0"
 
 [lints]
 workspace = true

--- a/crates/devolutions-pedm/src/api/launch.rs
+++ b/crates/devolutions-pedm/src/api/launch.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use axum::{Extension, Json};
@@ -77,8 +76,7 @@ fn win_canonicalize(path: &Path, token: Option<&Token>) -> Result<PathBuf, Error
     let environment = environment_block(token, false)?;
 
     let path = expand_environment_path(path, &environment)?;
-
-    Ok(fs::canonicalize(path)?)
+    Ok(dunce::canonicalize(path)?)
 }
 
 pub(crate) async fn post_launch(


### PR DESCRIPTION
I've noticed that nearly every .NET application I elevate with PEDM, crashes (sometimes immediately, sometimes after running for a while).

The crashes seem centred around paths (for example, IISCrypto crashes on startup complaining of a invalid path; RDM crashes after some time when a third party component tries to interact with the shell by passing a path to the application, etc)

When elevating an executable, PEDM first expands environment variables in the executable path and then calls `fs::canonicalize` which has a side-effect of prefixing the canonical path with the Windows file namespace (`\\?\`).

It turns out, that not a single .NET application that I tested works when launched from a path with a Windows file namespace prefix.

This PR uses `dunce` in the same was as Devolutions Gateway to workaround the issue.