### PR TITLE
build: target Ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,8 @@ jobs:
         if: runner.os == 'Linux'
         with:
           sysroots: |
-            - ubuntu-20.04-amd64
-            - ubuntu-20.04-arm64
+            - ubuntu-18.04-amd64
+            - ubuntu-18.04-arm64
           cargo_env_scripts: true
 
       - name: Configure Linux (arm) runner
@@ -270,7 +270,7 @@ jobs:
             $LinuxArch = @{'x86_64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
             $RustArch = @{'x86_64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
             $RustTarget = "$RustArch-unknown-linux-gnu"
-            $Env:SYSROOT_NAME = "ubuntu-20.04-$LinuxArch"
+            $Env:SYSROOT_NAME = "ubuntu-18.04-$LinuxArch"
             . "$HOME/.cargo/cbake/${RustTarget}-enter.ps1"
             $Env:AWS_LC_SYS_CMAKE_BUILDER="true"
           }
@@ -556,8 +556,8 @@ jobs:
         if: runner.os == 'Linux'
         with:
           sysroots: |
-            - ubuntu-20.04-amd64
-            - ubuntu-20.04-arm64
+            - ubuntu-18.04-amd64
+            - ubuntu-18.04-arm64
           cargo_env_scripts: true
 
       - name: Configure Linux runner
@@ -605,7 +605,7 @@ jobs:
             $LinuxArch = @{'x86_64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
             $RustArch = @{'x86_64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
             $RustTarget = "$RustArch-unknown-linux-gnu"
-            $Env:SYSROOT_NAME = "ubuntu-20.04-$LinuxArch"
+            $Env:SYSROOT_NAME = "ubuntu-18.04-$LinuxArch"
             . "$HOME/.cargo/cbake/${RustTarget}-enter.ps1"
             $Env:AWS_LC_SYS_CMAKE_BUILDER="true"
           }
@@ -752,8 +752,8 @@ jobs:
         if: runner.os == 'Linux'
         with:
           sysroots: |
-            - ubuntu-20.04-amd64
-            - ubuntu-20.04-arm64
+            - ubuntu-18.04-amd64
+            - ubuntu-18.04-arm64
           cargo_env_scripts: true
 
       - name: Configure Linux runner
@@ -820,7 +820,7 @@ jobs:
             $LinuxArch = @{'x86_64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
             $RustArch = @{'x86_64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
             $RustTarget = "$RustArch-unknown-linux-gnu"
-            $Env:SYSROOT_NAME = "ubuntu-20.04-$LinuxArch"
+            $Env:SYSROOT_NAME = "ubuntu-18.04-$LinuxArch"
             . "$HOME/.cargo/cbake/${RustTarget}-enter.ps1"
             $Env:AWS_LC_SYS_CMAKE_BUILDER="true"
           }

--- a/ci/download-cadeau.ps1
+++ b/ci/download-cadeau.ps1
@@ -18,7 +18,7 @@ $tmpFolder = [System.IO.Path]::GetTempPath() + [System.Guid]::NewGuid()
 Write-Host "Temporary directory: $tmpFolder"
 New-Item -ItemType Directory -Path "$tmpFolder" | Out-Null
 
-$downloadUrl = "https://github.com/Devolutions/cadeau/releases/download/v2024.11.22.0/cadeau-$Platform-$Architecture.zip"
+$downloadUrl = "https://github.com/Devolutions/cadeau/releases/download/v2025.2.21.0/cadeau-$Platform-$Architecture.zip"
 Write-Host "Download URL: $downloadUrl"
 
 try


### PR DESCRIPTION
Properly target ubuntu-18.04, including for the cadeau library which was just released with ubuntu-18.04 targeting as well. By targeting ubuntu-18.04, we are forward-compatible with ubuntu 20.04, 22.04, 24.04 but we are also finally compatible with RHEL8, which uses a version of glibc older than ubuntu 20.04.