### PR TITLE
fix(dgw): Make gateway to send proper close frame when WebSocket connection closes.

### DIFF
--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -152,7 +152,8 @@ pub struct CloseWebSocketHandle {
 // Note: Never sends 1005 and 1006 manually, as specified in RFC6455, section 7.4.1
 impl CloseWebSocketHandle {
     pub async fn normal_close(self) {
-        let _ = self.sender
+        let _ = self
+            .sender
             .send(WsCloseFrame {
                 code: 1000,
                 message: String::new(),
@@ -160,34 +161,20 @@ impl CloseWebSocketHandle {
             .await;
     }
 
-    pub async fn server_error(self, message: String) -> Result<(), CloseError> {
-        self.sender
-            .send(WsCloseFrame { code: 1011, message })
-            .await
-            .map_err(|_| CloseError)
+    pub async fn server_error(self, message: String) {
+        let _ = self.sender.send(WsCloseFrame { code: 1011, message }).await;
     }
 
-    pub async fn bad_gateway(self) -> Result<(), CloseError> {
-        self.sender
+    pub async fn bad_gateway(self) {
+        let _ = self
+            .sender
             .send(WsCloseFrame {
                 code: 1014,
                 message: String::new(),
             })
-            .await
-            .map_err(|_| CloseError)
+            .await;
     }
 }
-
-#[derive(Debug)]
-pub struct CloseError;
-
-impl Display for CloseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "WebSocket already closed")
-    }
-}
-
-impl std::error::Error for CloseError {}
 
 /// Spawns a task running the WebSocket keep-alive logic and returns a shared handle to the WebSocket for the actual user payload
 pub fn spawn_websocket_keep_alive_logic<S>(

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -155,10 +155,10 @@ impl CloseWebsocketHandle {
         self.sender
             .send(WsCloseFrame {
                 code: 1000,
-                message: "EOF".to_string(),
+                message: String::new(),
             })
             .await
-            .map_err(|e| CloseError(e))
+            .map_err(CloseError)
     }
 
     pub async fn server_error(self, message: &str) -> Result<(), CloseError> {
@@ -168,7 +168,7 @@ impl CloseWebsocketHandle {
                 message: message.to_owned(),
             })
             .await
-            .map_err(|e| CloseError(e))
+            .map_err(CloseError)
     }
 }
 

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -170,7 +170,6 @@ impl CloseWebsocketHandle {
             .await
             .map_err(|e| CloseError(e))
     }
-
 }
 
 #[derive(Debug)]

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -151,14 +151,13 @@ pub struct CloseWebSocketHandle {
 
 // Note: Never sends 1005 and 1006 manually, as specified in RFC6455, section 7.4.1
 impl CloseWebSocketHandle {
-    pub async fn normal_close(self) -> Result<(), CloseError> {
-        self.sender
+    pub async fn normal_close(self) {
+        let _ = self.sender
             .send(WsCloseFrame {
                 code: 1000,
                 message: String::new(),
             })
-            .await
-            .map_err(|_| CloseError)
+            .await;
     }
 
     pub async fn server_error(self, message: String) -> Result<(), CloseError> {

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -129,6 +129,7 @@ pub struct WsCloseFrame {
     pub code: u16,
     pub message: String,
 }
+
 pub enum WsWriteMsg {
     Ping,
     Close(WsCloseFrame),

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -173,11 +173,11 @@ impl CloseWebsocketHandle {
 }
 
 #[derive(Debug)]
-pub struct CloseError(tokio::sync::mpsc::error::SendError<WsCloseFrame>);
+pub struct CloseError;
 
 impl Display for CloseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "WebSocket already closed")
     }
 }
 

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -144,7 +144,7 @@ impl KeepAliveShutdown for std::sync::Arc<tokio::sync::Notify> {
     }
 }
 
-pub struct CloseWebsocketHandle {
+pub struct CloseWebSocketHandle {
     sender: tokio::sync::mpsc::Sender<WsCloseFrame>,
 }
 

--- a/crates/transport/src/ws.rs
+++ b/crates/transport/src/ws.rs
@@ -209,7 +209,7 @@ where
                     }
                     frame = close_frame_receiver.recv() => {
                         if let Some(frame) = frame {
-                            let _ =ws.send(WsWriteMsg::Close(frame)).await;
+                            let _ = ws.send(WsWriteMsg::Close(frame)).await;
                         }
                         break;
                     }

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -164,7 +164,7 @@ async fn handle_fwd(
             error!(error = format!("{error:#}"), "WebSocket forwarding failure");
         });
     } else {
-        let _ = close_handle.normal_close();
+        let _ = close_handle.normal_close().await;
     }
 }
 
@@ -477,8 +477,8 @@ async fn fwd_http(
                         error!(error = format!("{error:#}"), "WebSocket forwarding failure");
                     });
                 } else {
-                    let _ = client_close_handle.normal_close();
-                    let _ = server_close_handle.normal_close();
+                    let _ = client_close_handle.normal_close().await;
+                    let _ = server_close_handle.normal_close().await;
                 }
             }
         })

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -471,8 +471,8 @@ async fn fwd_http(
                     .context("encountered a failure during WebSocket traffic proxying");
 
                 if let Err(error) = result {
-                    let _ = client_close_handle.server_error("WebSocket failure").await;
-                    let _ = server_close_handle.server_error("WebSocket failure").await;
+                    let _ = client_close_handle.server_error("proxy failure").await;
+                    let _ = server_close_handle.server_error("proxy failure").await;
                     span.in_scope(|| {
                         error!(error = format!("{error:#}"), "WebSocket forwarding failure");
                     });

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -218,7 +218,7 @@ where
         }
 
         let ConnectionMode::Fwd { targets, .. } = claims.jet_cm else {
-            Err(ForwardError::Other(anyhow::anyhow!("connection mode not supported")))?
+            return Err(ForwardError::Other(anyhow::anyhow!("connection mode not supported")))
         };
 
         let span = tracing::Span::current();

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -159,22 +159,15 @@ async fn handle_fwd(
         .await;
 
     match &result {
-        Ok(_) => {
-            let _ = close_handle.normal_close().await;
-        }
-        Err(ForwardError::BadGateway(_)) => {
-            let _ = close_handle.bad_gateway().await;
-        }
-        Err(ForwardError::Other(_)) => {
-            let _ = close_handle.server_error("internal error".to_owned()).await;
-        }
+        Ok(_) => close_handle.normal_close().await,
+        Err(ForwardError::BadGateway(_)) => close_handle.bad_gateway().await,
+        Err(ForwardError::Other(_)) => close_handle.server_error("internal error".to_owned()).await,
     };
 
     if let Err(error) = result {
         span.in_scope(|| {
             error!(error = format!("{error:#}"), "WebSocket forwarding failure");
         });
-    } else {
     }
 }
 
@@ -500,14 +493,14 @@ async fn fwd_http(
                     .context("encountered a failure during WebSocket traffic proxying");
 
                 if let Err(error) = result {
-                    let _ = client_close_handle.server_error("proxy failure".to_owned()).await;
-                    let _ = server_close_handle.server_error("proxy failure".to_owned()).await;
+                    client_close_handle.server_error("proxy failure".to_owned()).await;
+                    server_close_handle.server_error("proxy failure".to_owned()).await;
                     span.in_scope(|| {
                         error!(error = format!("{error:#}"), "WebSocket forwarding failure");
                     });
                 } else {
-                    let _ = client_close_handle.normal_close().await;
-                    let _ = server_close_handle.normal_close().await;
+                    client_close_handle.normal_close().await;
+                    server_close_handle.normal_close().await;
                 }
             }
         })

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -191,7 +191,7 @@ pub enum ForwardError {
 impl std::fmt::Display for ForwardError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::BadGateway(error) => write!(f, "Bad Gateway: {}", error),
+            Self::BadGateway(error) => write!(f, "bad gateway: {error}"),
             Self::Other(error) => write!(f, "{}", error),
         }
     }

--- a/devolutions-gateway/src/api/jmux.rs
+++ b/devolutions-gateway/src/api/jmux.rs
@@ -61,9 +61,9 @@ async fn handle_socket(
         .await;
 
     if let Err(error) = result {
-        close_handle.server_error("JMUX failure");
+        let _ = close_handle.server_error("JMUX failure").await;
         error!(client = %source_addr, error = format!("{error:#}"), "JMUX failure");
     } else {
-        close_handle.normal_close();
+        let _ = close_handle.normal_close().await;
     }
 }

--- a/devolutions-gateway/src/api/jmux.rs
+++ b/devolutions-gateway/src/api/jmux.rs
@@ -61,9 +61,9 @@ async fn handle_socket(
         .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("JMUX failure".to_owned()).await;
+        close_handle.server_error("JMUX failure".to_owned()).await;
         error!(client = %source_addr, error = format!("{error:#}"), "JMUX failure");
     } else {
-        let _ = close_handle.normal_close().await;
+        close_handle.normal_close().await;
     }
 }

--- a/devolutions-gateway/src/api/jmux.rs
+++ b/devolutions-gateway/src/api/jmux.rs
@@ -61,7 +61,7 @@ async fn handle_socket(
         .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("JMUX failure").await;
+        let _ = close_handle.server_error("JMUX failure".to_owned()).await;
         error!(client = %source_addr, error = format!("{error:#}"), "JMUX failure");
     } else {
         let _ = close_handle.normal_close().await;

--- a/devolutions-gateway/src/api/jmux.rs
+++ b/devolutions-gateway/src/api/jmux.rs
@@ -50,7 +50,7 @@ async fn handle_socket(
     source_addr: SocketAddr,
     keep_alive_interval: Duration,
 ) {
-    let stream = crate::ws::handle(
+    let (stream, close_handle) = crate::ws::handle(
         ws,
         crate::ws::KeepAliveShutdownSignal(shutdown_signal),
         keep_alive_interval,
@@ -61,6 +61,9 @@ async fn handle_socket(
         .await;
 
     if let Err(error) = result {
+        close_handle.server_error("JMUX failure");
         error!(client = %source_addr, error = format!("{error:#}"), "JMUX failure");
+    } else {
+        close_handle.normal_close();
     }
 }

--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -112,10 +112,10 @@ async fn handle_jrec_push(
         .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("forwarding failure".to_owned()).await;
+        close_handle.server_error("forwarding failure".to_owned()).await;
         error!(client = %source_addr, error = format!("{error:#}"), "WebSocket-JREC failure");
     } else {
-        let _ = close_handle.normal_close().await;
+        close_handle.normal_close().await;
     }
 }
 

--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -93,7 +93,7 @@ async fn handle_jrec_push(
     source_addr: SocketAddr,
     keep_alive_interval: Duration,
 ) {
-    let stream = crate::ws::handle(
+    let (stream, close_handle) = crate::ws::handle(
         ws,
         crate::ws::KeepAliveShutdownSignal(shutdown_signal.clone()),
         keep_alive_interval,
@@ -112,7 +112,10 @@ async fn handle_jrec_push(
         .await;
 
     if let Err(error) = result {
+        let _ = close_handle.server_error("WebSocket-JREC failure").await;
         error!(client = %source_addr, error = format!("{error:#}"), "WebSocket-JREC failure");
+    } else {
+        let _ = close_handle.normal_close().await;
     }
 }
 

--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -112,7 +112,7 @@ async fn handle_jrec_push(
         .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("forwarding failure").await;
+        let _ = close_handle.server_error("forwarding failure".to_owned()).await;
         error!(client = %source_addr, error = format!("{error:#}"), "WebSocket-JREC failure");
     } else {
         let _ = close_handle.normal_close().await;

--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -112,7 +112,7 @@ async fn handle_jrec_push(
         .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("WebSocket-JREC failure").await;
+        let _ = close_handle.server_error("forwarding failure").await;
         error!(client = %source_addr, error = format!("{error:#}"), "WebSocket-JREC failure");
     } else {
         let _ = close_handle.normal_close().await;

--- a/devolutions-gateway/src/api/rdp.rs
+++ b/devolutions-gateway/src/api/rdp.rs
@@ -82,7 +82,7 @@ async fn handle_socket(
     .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("forwarding failure").await;
+        let _ = close_handle.server_error("forwarding failure".to_owned()).await;
         error!(client = %source_addr, error = format!("{error:#}"), "RDP failure");
     } else {
         let _ = close_handle.normal_close().await;

--- a/devolutions-gateway/src/api/rdp.rs
+++ b/devolutions-gateway/src/api/rdp.rs
@@ -82,7 +82,7 @@ async fn handle_socket(
     .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("RDP failure").await;
+        let _ = close_handle.server_error("forwarding failure").await;
         error!(client = %source_addr, error = format!("{error:#}"), "RDP failure");
     } else {
         let _ = close_handle.normal_close().await;

--- a/devolutions-gateway/src/api/rdp.rs
+++ b/devolutions-gateway/src/api/rdp.rs
@@ -82,9 +82,9 @@ async fn handle_socket(
     .await;
 
     if let Err(error) = result {
-        let _ = close_handle.server_error("forwarding failure".to_owned()).await;
+        close_handle.server_error("forwarding failure".to_owned()).await;
         error!(client = %source_addr, error = format!("{error:#}"), "RDP failure");
     } else {
-        let _ = close_handle.normal_close().await;
+        close_handle.normal_close().await;
     }
 }

--- a/devolutions-gateway/src/api/rdp.rs
+++ b/devolutions-gateway/src/api/rdp.rs
@@ -85,6 +85,6 @@ async fn handle_socket(
         let _ = close_handle.server_error("RDP failure").await;
         error!(client = %source_addr, error = format!("{error:#}"), "RDP failure");
     } else {
-        let _ = close_handle.normal_close();
+        let _ = close_handle.normal_close().await;
     }
 }

--- a/devolutions-gateway/src/streaming.rs
+++ b/devolutions-gateway/src/streaming.rs
@@ -10,6 +10,7 @@ use futures::SinkExt;
 use terminal_streamer::terminal_stream;
 use tokio::fs::OpenOptions;
 use tokio::sync::Notify;
+use transport::WsCloseFrame;
 use uuid::Uuid;
 use video_streamer::config::CpuCount;
 use video_streamer::{webm_stream, ReOpenableFile};
@@ -159,7 +160,8 @@ async fn setup_webm_streaming(
         encoder_threads: CpuCount::default(),
     };
 
-    let websocket_stream = crate::ws::handle(socket, Arc::clone(&shutdown_notify), Duration::from_secs(45));
+    let (websocket_stream, close_handle) =
+        crate::ws::handle(socket, Arc::clone(&shutdown_notify), Duration::from_secs(45));
     let streaming_result = tokio::task::spawn_blocking(move || {
         webm_stream(
             websocket_stream,
@@ -179,9 +181,13 @@ async fn setup_webm_streaming(
             Err(anyhow::anyhow!("Streaming task failed"))
         }
         Ok(Err(e)) => {
+            let _ = close_handle.server_error("Streaming file failed").await?;
             error!(error = format!("{e:#}"), "Streaming file failed");
             Err(e)
         }
-        Ok(Ok(())) => Ok(()),
+        Ok(Ok(())) => {
+            let _ = close_handle.normal_close().await?;
+            Ok(())
+        }
     }
 }

--- a/devolutions-gateway/src/streaming.rs
+++ b/devolutions-gateway/src/streaming.rs
@@ -180,12 +180,12 @@ async fn setup_webm_streaming(
             Err(anyhow::anyhow!("Streaming task failed"))
         }
         Ok(Err(e)) => {
-            let _ = close_handle.server_error("Streaming file failed".to_owned()).await;
+            close_handle.server_error("webm streaming failure".to_owned()).await;
             error!(error = format!("{e:#}"), "Streaming file failed");
             Err(e)
         }
         Ok(Ok(())) => {
-            let _ = close_handle.normal_close().await;
+            close_handle.normal_close().await;
             Ok(())
         }
     }

--- a/devolutions-gateway/src/streaming.rs
+++ b/devolutions-gateway/src/streaming.rs
@@ -10,7 +10,6 @@ use futures::SinkExt;
 use terminal_streamer::terminal_stream;
 use tokio::fs::OpenOptions;
 use tokio::sync::Notify;
-use transport::WsCloseFrame;
 use uuid::Uuid;
 use video_streamer::config::CpuCount;
 use video_streamer::{webm_stream, ReOpenableFile};
@@ -181,12 +180,12 @@ async fn setup_webm_streaming(
             Err(anyhow::anyhow!("Streaming task failed"))
         }
         Ok(Err(e)) => {
-            let _ = close_handle.server_error("Streaming file failed").await?;
+            let _ = close_handle.server_error("Streaming file failed").await;
             error!(error = format!("{e:#}"), "Streaming file failed");
             Err(e)
         }
         Ok(Ok(())) => {
-            let _ = close_handle.normal_close().await?;
+            let _ = close_handle.normal_close().await;
             Ok(())
         }
     }

--- a/devolutions-gateway/src/streaming.rs
+++ b/devolutions-gateway/src/streaming.rs
@@ -180,7 +180,7 @@ async fn setup_webm_streaming(
             Err(anyhow::anyhow!("Streaming task failed"))
         }
         Ok(Err(e)) => {
-            let _ = close_handle.server_error("Streaming file failed").await;
+            let _ = close_handle.server_error("Streaming file failed".to_owned()).await;
             error!(error = format!("{e:#}"), "Streaming file failed");
             Err(e)
         }

--- a/devolutions-gateway/src/ws.rs
+++ b/devolutions-gateway/src/ws.rs
@@ -21,7 +21,10 @@ pub fn handle(
     ws: WebSocket,
     shutdown_signal: impl transport::KeepAliveShutdown,
     keep_alive_interval: time::Duration,
-) -> (impl AsyncRead + AsyncWrite + Unpin + Send + 'static, transport::CloseWebsocketHandle) {
+) -> (
+    impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    transport::CloseWebsocketHandle,
+) {
     let ws = transport::Shared::new(ws);
 
     let close_handle = transport::spawn_websocket_keep_alive_logic(

--- a/devolutions-gateway/src/ws.rs
+++ b/devolutions-gateway/src/ws.rs
@@ -23,7 +23,7 @@ pub fn handle(
     keep_alive_interval: time::Duration,
 ) -> (
     impl AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    transport::CloseWebsocketHandle,
+    transport::CloseWebSocketHandle,
 ) {
     let ws = transport::Shared::new(ws);
 
@@ -33,7 +33,7 @@ pub fn handle(
                 transport::WsWriteMsg::Ping => ws::Message::Ping(vec![]),
                 transport::WsWriteMsg::Close(frame) => ws::Message::Close(Some(CloseFrame {
                     code: frame.code,
-                    reason: std::borrow::Cow::Owned(frame.message),
+                    reason: frame.message.into(),
                 })),
             }))
         }),


### PR DESCRIPTION
Fix Gateway WebSocket connection hanging when server has already closed the tcp connection.
Added new structure to have Gateway send proper close frame to indicates it's close state, and can be further extended with more senmantic close frames.