### PR TITLE
build: separate Debian and RPM packaging

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -13,7 +13,8 @@ This folder contains PowerShell scripts for CI, building, and packaging.
 |--------------------|---------------------|--------------------------------------------------------|
 | Gateway            | Windows (regular)   | `build.ps1 gateway`<br />`copy-ps-module.ps1`<br />`package-gateway-windows.ps1` |
 | Gateway            | Windows (assembled) | `build.ps1 gateway`<br />`copy-ps-module.ps1`<br />`package-gateway-windows.ps1 -Generate`<br />`package-assembled.ps1 gateway` |
-| Gateway            | Linux               | `build.ps1 gateway`<br />`package-gateway-linux.ps1` (not available yet)  |
+| Gateway            | Ubuntu/Debian       | `build.ps1 gateway`<br />`package-gateway-deb.ps1`     |
+| Gateway            | RHEL                | `build.ps1 gateway`<br />`package-gateway-rpm.ps1`     |
 | Agent       | Windows (regular)          | `build.ps1 agent`  <br />`build.ps1 pedm`<br />`build.ps1 session`<br />`package-agent-windows.ps1`          |
 | Agent       | Windows (assembled)        | `build.ps1 agent`  <br />`build.ps1 pedm`<br />`build.ps1 session`<br />`package-agent-windows.ps1 -Generate`<br />`package-assembled.ps1 agent` |
 | Jetsocat    | Windows/macOS/Linux        | `build.ps1 jetsocat`<br />Jetsocat is not packaged.           |

--- a/ci/package-gateway-deb.ps1
+++ b/ci/package-gateway-deb.ps1
@@ -117,7 +117,7 @@ function New-GatewayDeb() {
         -Packager 'Benoît Cortier' `
         -Email 'bcortier@devolutions.net' `
         -PackageName 'devolutions-gateway' `
-        -Distro 'flocal'
+        -Distro 'focal'
     Set-Content -Path "$debDir/changelog" -Value $s
 
     # Assets to be included in the package.

--- a/ci/package-gateway-deb.ps1
+++ b/ci/package-gateway-deb.ps1
@@ -1,11 +1,11 @@
 param(
     [string] $Bin,
     [parameter(Mandatory = $true)]
-    [string]$LibxmfFile,
+    [string] $LibxmfFile,
     [parameter(Mandatory = $true)]
-    [string]$WebClientDir,
+    [string] $WebClientDir,
     [parameter(Mandatory = $true)]
-    [string]$WebPlayerDir,
+    [string] $WebPlayerDir,
     [parameter(Mandatory = $true)]
     [string] $OutputDir
 )
@@ -97,7 +97,7 @@ function New-GatewayDeb() {
     # debian/copyright
     Merge-Tokens -TemplateFile 'package/Linux/template/copyright' -Tokens @{
         package = 'devolutions-gateway'
-        year         = $(Get-Date).Year
+        year    = $(Get-Date).Year
     } -OutputFile $(Join-Path $debDir 'copyright')
 
     # Upstream changelog. Eventually included as /usr/share/doc/devolutions-gateway/changelog.gz.
@@ -139,3 +139,5 @@ function New-GatewayDeb() {
 }
 
 New-GatewayDeb -Bin $Bin -LibXmfFile $LibXmfFile -WebClientDir $WebClientDir -WebPlayerDir $WebPlayerDir -OutputDir $OutputDir
+
+

--- a/ci/package-gateway-deb.ps1
+++ b/ci/package-gateway-deb.ps1
@@ -1,0 +1,141 @@
+param(
+    [string] $Bin,
+    [parameter(Mandatory = $true)]
+    [string]$LibxmfFile,
+    [parameter(Mandatory = $true)]
+    [string]$WebClientDir,
+    [parameter(Mandatory = $true)]
+    [string]$WebPlayerDir,
+    [parameter(Mandatory = $true)]
+    [string] $OutputDir
+)
+
+Import-Module (Join-Path $PSScriptRoot 'Build')
+. (Join-Path $PSScriptRoot "linux-changelog.ps1")
+
+# Creates a Debian package for Gateway. Sources are not included.
+#
+# Usage
+# New-GatewayDeb -Bin $Bin -LibXmfFile $LibXmfFile -WebClientDir $WebClientDir -WebPlayerDir $WebPlayerDir -OutputDir $OutputDir
+function New-GatewayDeb() {
+    param(
+        [parameter(Mandatory = $true)]
+        # The path to the devolutions-gateway binary.
+        [string] $Bin,
+        [parameter(Mandatory = $true)]
+        # The path to libxmf.so.
+        [string]$LibxmfFile,
+        [parameter(Mandatory = $true)]
+        # The path to the Angular-built web app client.
+        [string]$WebClientDir,
+        [parameter(Mandatory = $true)]
+        # The path to the Angular-built web app player.
+        [string]$WebPlayerDir,
+        # The path to the output directory. The intermediate build files will be storedcreated in gateway-deb inside of this output directory. The generated package will be in the root of the output directory.
+        [parameter(Mandatory = $true)]
+        [string] $OutputDir
+    )
+
+    # Disable dpkg-buildpackage stripping as the binary is already stripped.
+    $Env:DEB_BUILD_OPTIONS = "nostrip"
+
+    $version = Get-Version
+    $repoDir = Split-Path -Parent $PSScriptRoot
+
+    # dh_make
+    & 'dh_make' @('-e', 'bcortier@devolutions.net',
+        '-n', '-s', '-p', "devolutions-gateway_$version-1",
+        '-y', '-c', 'custom',
+        "--copyrightfile=$repoDir/package/Linux/template/copyright") | Out-Host
+
+    # the directory containing intermediate build files related to Debian packaging
+    $pkgDir = "$OutputDir/gateway-deb"
+    # the Debian archive folder, a component of a Debian package
+    $debDir = "$pkgDir/debian"
+
+    if (-not (Test-Path $pkgDir)) {
+        New-Item -ItemType Directory -Path $pkgDir | Out-Null
+        Write-Output "Created directory: $pkgDir"
+    }
+    if (Test-Path $debDir) {
+        # Delete all contents of the directory. This is because dh_make will try not to overwrite existing files if it detects the debian subdirectory.
+        Remove-Item -Path $debDir -Recurse -Force -ErrorAction 'Stop'
+        # Create
+        New-Item -ItemType Directory -Path $debDir | Out-Null
+        Write-Output "Cleared directory: $debDir"
+    }
+    else {
+        New-Item -ItemType Directory -Path $debDir | Out-Null
+    }
+
+    # debian/docs
+    Set-Content -Path "$debDir/docs" -Value "" -ErrorAction 'Stop'
+
+    # debian/rules
+    $generatedUpstreamChangelog = "$pkgDir/upstream_changelog"
+    Merge-Tokens -TemplateFile 'package/Linux/gateway/template/rules' -Tokens @{
+        upstream_changelog = $generatedUpstreamChangelog
+    } -OutputFile "$debDir/rules"
+    chmod  +x "$debDir/rules"
+
+    # debian/control
+
+    # If the system architecture is aarch64, we assume that the binary is aarch64.
+    # If the binary path contains `aarch64`, we assume the same.
+    $nativeTarget = $(Get-NativeTarget $Target).NativeTarget
+    if ($nativeTarget -Eq 'aarch64-unknown-linux-gnu' -Or $Bin -Like '*aarch64*') {
+        $arch = 'arm64'  # use Debian naming
+    }
+    else {
+        $arch = 'amd64'
+    }
+    
+    Merge-Tokens -TemplateFile 'package/Linux/gateway/template/control' -Tokens @{
+        arch = $arch
+    } -OutputFile "$debDir/control"
+
+    # debian/copyright
+    Merge-Tokens -TemplateFile 'package/Linux/template/copyright' -Tokens @{
+        package = 'devolutions-gateway'
+        year         = $(Get-Date).Year
+    } -OutputFile $(Join-Path $debDir 'copyright')
+
+    # Upstream changelog. Eventually included as /usr/share/doc/devolutions-gateway/changelog.gz.
+    $s = New-Changelog `
+        -Format 'Deb' `
+        -InputFile "$repoDir/CHANGELOG.md" `
+        -Packager 'Benoît Cortier' `
+        -Email 'bcortier@devolutions.net' `
+        -PackageName 'devolutions-gateway' `
+        -Distro 'focal'
+    Set-Content -Path $generatedUpstreamChangelog -Value $s
+
+    # Package changelog. Eventually included as /usr/share/doc/devolutions-gateway/changelog.Debian.gz.
+    $s = New-Changelog `
+        -Format 'Deb' `
+        -InputFile 'package/Linux/CHANGELOG.md' `
+        -Packager 'Benoît Cortier' `
+        -Email 'bcortier@devolutions.net' `
+        -PackageName 'devolutions-gateway' `
+        -Distro 'flocal'
+    Set-Content -Path "$debDir/changelog" -Value $s
+
+    # Assets to be included in the package.
+    # These paths must matchpackage/Linux/gateway/debian/install.
+
+    # Copy scripts over. These are the install file, postinst, and service file.
+    Copy-Item 'package/Linux/gateway/debian' $pkgDir -Recurse -Force -ErrorAction 'Stop'
+
+    Copy-Item $Bin "$pkgDir/devolutions-gateway" -Force -ErrorAction 'Stop'
+    Copy-Item $WebClientDir $pkgDir -Force -ErrorAction 'Stop'
+    Copy-Item $WebPlayerDir $pkgDir -Force -ErrorAction 'Stop'
+    Copy-Item $LibxmfFile $pkgDir -Force -ErrorAction 'Stop'
+
+    Push-Location
+    Set-Location $pkgDir
+    # Change into the package directory. dpkg-buildpackage will output the package in the parent directory.
+    & 'dpkg-buildpackage' @('-b', '-us', '-uc', '-a', $arch)
+    Pop-Location
+}
+
+New-GatewayDeb -Bin $Bin -LibXmfFile $LibXmfFile -WebClientDir $WebClientDir -WebPlayerDir $WebPlayerDir -OutputDir $OutputDir

--- a/ci/package-gateway-rpm.ps1
+++ b/ci/package-gateway-rpm.ps1
@@ -1,0 +1,90 @@
+param(
+    [string] $Bin,
+    [parameter(Mandatory = $true)]
+    [string]$LibxmfFile,
+    [parameter(Mandatory = $true)]
+    [string]$WebClientDir,
+    [parameter(Mandatory = $true)]
+    [string]$WebPlayerDir,
+    [parameter(Mandatory = $true)]
+    [string] $OutputDir
+)
+
+Import-Module (Join-Path $PSScriptRoot 'Build')
+. (Join-Path $PSScriptRoot "linux-changelog.ps1")
+
+# Creates an RPM package for Gateway. Sources are not included.
+#
+# Usage
+# New-GatewayRpm -Bin $Bin -LibXmfFile $LibXmfFile -WebClientDir $WebClientDir -WebPlayerDir $WebPlayerDir -OutputDir $OutputDir
+function New-GatewayRpm() {
+    param(
+        [parameter(Mandatory = $true)]
+        # The path to the devolutions-gateway binary.
+        [string] $Bin,
+        [parameter(Mandatory = $true)]
+        # The path to libxmf.so.
+        [string]$LibxmfFile,
+        [parameter(Mandatory = $true)]
+        # The path to the Angular-built web app client.
+        [string]$WebClientDir,
+        [parameter(Mandatory = $true)]
+        # The path to the Angular-built web app player.
+        [string]$WebPlayerDir,
+        # The path to the output directory. The intermediate build files will be storedcreated in gateway-rpm inside of this output directory. The generated package will be in the root of the output directory.
+        [parameter(Mandatory = $true)]
+        [string] $OutputDir
+    )
+
+    $version = Get-Version
+    $repoDir = Split-Path -Parent $PSScriptRoot
+    $pkgDir = "$OutputDir/gateway-rpm"
+
+    if (-not (Test-Path $pkgDir)) {
+        New-Item -ItemType Directory -Path $pkgDir | Out-Null
+        Write-Output "Created directory: $pkgDir"
+    }
+
+    $generatedUpstreamChangelog = "$pkgDir/upstream_changelog"
+    $s = New-Changelog -Format 'RpmUpstream' -InputFile "$repoDir/CHANGELOG.md" -Packager 'Benoît Cortier' -Email 'bcortier@devolutions.net'
+    Set-Content -Path $generatedUpstreamChangelog -Value $s
+
+    $pkgChangelog = "$pkgDir/packaging_changelog"
+    $s = New-Changelog -Format 'RpmPackaging' -InputFile 'package/Linux/CHANGELOG.md' -Packager 'Benoît Cortier' -Email 'bcortier@devolutions.net'
+    Set-Content -Path $pkgChangelog -Value $s
+
+    "Copyright $($(Get-Date).Year) Devolutions Inc. All rights reserved." | Set-Content -Path "$pkgDir/copyright"
+
+    $args = @(
+        '--force'
+        '--verbose'
+        '-s', 'dir'
+        '-t', 'rpm'
+        '-p', "$OutputDir/devolutions-gateway_$version-1.rpm"
+        '-n', 'devolutions-gateway'
+        '-v', $version
+        '-d', 'glibc'
+        '--maintainer', 'Benoît Cortier <bcortier@devolutions.net>'
+        '--description', 'Blazing fast relay server with desired levels of traffic inspection'
+        '--url', 'https://devolutions.net'
+        '--license', 'Apache-2.0 OR MIT'
+        '--rpm-attr', '755,root,root:/usr/bin/devolutions-gateway'
+        '--rpm-changelog', $pkgChangelog
+        '--after-install', 'package/Linux/gateway/rpm/postinst'
+        '--before-remove', 'package/Linux/gateway/rpm/prerm'
+        '--after-remove', 'package/Linux/gateway/rpm/postrm'
+        '--'
+        "$Bin=/usr/bin/devolutions-gateway"
+        "$generatedUpstreamChangelog=/usr/share/doc/devolutions-gateway/ChangeLog"
+        "$pkgDir/copyright=/usr/share/doc/devolutions-gateway/copyright"
+        "$LibxmfFile=/usr/lib/devolutions-gateway/libxmf.so"
+        "$WebClientDir=/usr/share/devolutions-gateway/webapp"
+        "$WebPlayerDir=/usr/share/devolutions-gateway/webapp"
+    )
+    & 'fpm' @args | Out-Host
+}
+
+New-GatewayRpm -Bin $Bin -LibXmfFile $LibXmfFile -WebClientDir $WebClientDir -WebPlayerDir $WebPlayerDir -OutputDir $OutputDir
+
+
+

--- a/package/AgentLinux/agent/template/control
+++ b/package/AgentLinux/agent/template/control
@@ -1,13 +1,12 @@
 Source: devolutions-agent
 Section: non-free/net
 Priority: optional
-Maintainer: {{ packager }} <{{ email }}>
+Maintainer: Benoît Cortier <bcortier@devolutions.net>
 Build-Depends: debhelper-compat (= 10)
 Standards-Version: 3.9.4
-Homepage: {{ website }}
+Homepage: https://devolutions.net
 
 Package: devolutions-agent
 Architecture: {{ arch }}
-Depends: {{ deps }}
-Description: {{ description }}
- {{ website }}
+Depends: libc6 (>= 2.31)
+Description: Agent companion service for Devolutions Gateway

--- a/package/Linux/gateway/template/control
+++ b/package/Linux/gateway/template/control
@@ -1,13 +1,12 @@
 Source: devolutions-gateway
 Section: non-free/net
 Priority: optional
-Maintainer: {{ packager }} <{{ email }}>
+Maintainer: Benoît Cortier <bcortier@devolutions.net>
 Build-Depends: debhelper-compat (= 10)
 Standards-Version: 3.9.4
-Homepage: {{ website }}
+Homepage: https://devolutions.net
 
 Package: devolutions-gateway
 Architecture: {{ arch }}
-Depends: {{ deps }}
-Description: {{ description }}
- {{ website }}
+Depends: libc6 (>= 2.31)
+Description: Blazing fast relay server with desired levels of traffic inspection

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@ --with-shlibdepends
 
 override_dh_shlibdeps:
 	{{ dh_shlibdeps }}

--- a/package/Linux/gateway/template/rules
+++ b/package/Linux/gateway/template/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --with-shlibdepends
+	dh $@
 
 override_dh_shlibdeps:
 	{{ dh_shlibdeps }}

--- a/package/Linux/template/copyright
+++ b/package/Linux/template/copyright
@@ -5,4 +5,3 @@ Source:  https://devolutions.net
 Files: *
 Copyright: {{ year }} Devolutions Inc.
 License: non-free
- .

--- a/package/Linux/template/copyright
+++ b/package/Linux/template/copyright
@@ -1,9 +1,8 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: {{ package }}
-Source: {{ website }}
+Source:  https://devolutions.net
 
 Files: *
-Copyright: {{ year }} {{ packager }}
+Copyright: {{ year }} Devolutions Inc.
 License: non-free
  .
-


### PR DESCRIPTION
- separation of Debian and RPM generation
- removes unused tokens in templates
- fixes a warning where debian/rules was missing the execution bit
- changes the intermediate build directories to 'gateway-deb` and `gateway-rpm`
- uses parameters instead of environment variables
- local use of `Set-Location`
- removes single-use string variables
- custom copyright file for RPM instead of the Debian-generated copyright