### PR TITLE
fix(installer): don't fail an uninstall if the shell extension can't be unregistered

### DIFF
--- a/package/AgentWindowsManaged/Actions/AgentActions.cs
+++ b/package/AgentWindowsManaged/Actions/AgentActions.cs
@@ -282,7 +282,7 @@ internal static class AgentActions
         Id = new Id($"CA.{nameof(unregisterExplorerCommand)}"),
         Feature = Features.PEDM_FEATURE,
         Sequence = Sequence.InstallExecuteSequence,
-        Return = Return.check,
+        Return = Return.ignore,
         Execute = Execute.deferred,
         Impersonate = false,
         Step = Step.RemoveFiles,


### PR DESCRIPTION
An unexpected error unregistering the PEDM shell extension can cause an uninstall to fail; this leads to a bad posture on the user machine.

cc: @allan2 