### PR TITLE
build: fix Agent MSI

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -13,14 +13,14 @@ This folder contains PowerShell scripts for CI, building, and packaging.
 |--------------------|---------------------|--------------------------------------------------------|
 | Gateway            | Windows (regular)   | `build.ps1 gateway`<br />`copy-ps-module.ps1`<br />`package-gateway-windows.ps1` |
 | Gateway            | Windows (assembled) | `build.ps1 gateway`<br />`copy-ps-module.ps1`<br />`package-gateway-windows.ps1 -Generate`<br />`package-assembled.ps1 gateway` |
-| Gateway            | Ubuntu/Debian       | `build.ps1 gateway`<br />`package-gateway-deb.ps1`     |
-| Gateway            | RHEL                | `build.ps1 gateway`<br />`package-gateway-rpm.ps1`     |
-| Agent       | Windows (regular)          | `build.ps1 agent`  <br />`build.ps1 pedm`<br />`build.ps1 session`<br />`package-agent-windows.ps1`          |
-| Agent       | Windows (assembled)        | `build.ps1 agent`  <br />`build.ps1 pedm`<br />`build.ps1 session`<br />`package-agent-windows.ps1 -Generate`<br />`package-assembled.ps1 agent` |
+| Gateway            | Linux               | `build.ps1 gateway`<br />`package-gateway-linux.ps1` (not available yet)  |
+| Agent       | Windows (regular)          | `build.ps1 agent`  <br />`build.ps1 pedm`<br />`build.ps1 session`<br />`..\dotnet\DesktopAgent\build.ps1`<br />`package-agent-windows.ps1`          |
+| Agent       | Windows (assembled)        | `build.ps1 agent`  <br />`build.ps1 pedm`<br />`build.ps1 session`<br />`..\dotnet\DesktopAgent\build.ps1`<br />`package-agent-windows.ps1 -Generate`<br />`package-assembled.ps1 agent` |
 | Jetsocat    | Windows/macOS/Linux        | `build.ps1 jetsocat`<br />Jetsocat is not packaged.           |
 | Session     | Windows/macOS/Linux        | `build.ps1 session` <br />Session is not packaged.            |
 | PEDM module        | Windows             | `build.ps1 pedm`                                              |
 | PowerShell module  | Windows             | `copy-ps-module.ps1`                                          |
+| Desktop Agent      | Windows             | `..\dotnet\DesktopAgent\build.ps1`                             |
 
 ## What is the difference between _Windows (regular)_ and _Windows (assembled)_?
 

--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -182,4 +182,3 @@ function Get-PackageName {
 }
 
 Invoke-Build -Product $Product -Target $Target -Profile $Profile -OutputDir $OutputDir -Static:($Static.IsPresent) -Symbols:($Symbols.IsPresent) -Strip:($Strip.IsPresent) -StripPath $StripPath
-

--- a/ci/package-agent-windows.ps1
+++ b/ci/package-agent-windows.ps1
@@ -8,7 +8,7 @@ param(
     [string] $PedmMsix,
     [parameter(Mandatory = $true)]
     [string] $SessionExe,
-    [string] $OutputDir
+    [string] $Outfile
 )
 
 # Use TLS 1.2
@@ -16,16 +16,63 @@ param(
 
 Import-Module (Join-Path $PSScriptRoot 'Build')
 
+
+# Renames a file to a specified name if it is not already.
+#
+# if the file needs to be renamed, a copy is made in the temp directory.
+# The path is returned.
+#
+# This is useful when we need our file to have a specific name for an intermediate step.
+function Set-FileNameAndCopy {
+    param (
+        [string]$Path,
+        [string]$NewName
+    )
+    
+    if (-Not (Test-Path $Path)) {
+        throw "File not found: $Path"
+    }
+
+    $dir = Split-Path -Path $Path -Parent
+    $currName = Split-Path -Path $Path -Leaf
+
+    # If the name is already correct, return the original path without copying
+    if ($currName -ieq $NewName) {
+        Write-Host "Using $Path without copying"
+        return $Path
+    }
+
+    # Copy to a temporary directory.
+    $tmpDir = [System.IO.Path]::GetTempPath()
+
+    # tmpFile is in the temp directory with the original file name
+    $tmpFile = Join-Path -Path $tmpDir -ChildPath (Split-Path -Path $Path -Leaf)
+    Copy-Item -Path $Path -Destination $tmpFile -Force -ErrorAction Stop
+
+    # Ensure the destination doesn't already exist so renaming will succeed.
+    $dest = Join-Path -Path $tmpDir -ChildPath $NewName
+    if (Test-Path $dest) {
+        Remove-Item -Path $dest -Force -ErrorAction Stop
+    }
+    # Rename the file in the temp dir.
+    Rename-Item -Path $tmpFile -NewName $NewName -Force -ErrorAction Stop
+    Write-Host "Copied $Path to $dest"
+    return $dest
+}
+
+# Normalizes the path to be Windows-style.
+function Convert-Path {
+    param (
+        [string]$Path
+    )
+    return $Path -replace '/', '\'
+}
+
+
 # Builds an MSI for Agent.
 #
-# Usage
-#
-# Regular build:
-# New-AgentMsi -Exe $Exe -PedmDll $PedmDll -PedmMsix $PedmMsix -SessionExe $SessionExe -OutputDir $OutputDir
-#
-# Generate:
-# New-AgentMsi -Generate -Exe $Exe -PedmDll $PedmDll -PedmMsix $PedmMsix -SessionExe $SessionExe
-function New-AgentMsi() {
+# Our .NET code expects environment variables so they are set by this function if they are not already set.
+# The package is particular about the input file names, but all of the proper renaming and linking is handled by this function.
     param(
         # Generates additional files for the MSI. The MSI is not copied to the output directory if this is set. This produces files `package\WindowsManaged\Release\en-US` and `package\WindowsManaged\Release\fr-FR`.
         [switch] $Generate,
@@ -42,35 +89,54 @@ function New-AgentMsi() {
         # The path to the devolutions-session.exe file.
         [string] $SessionExe,
         # Only required if `Generate` is not set.
-        [string] $OutputDir
+        [string] $Outfile
     )
 
     if ($Generate) {
-        if ($OutputDir) {
-            throw 'Output directory must not be specified when called with -Generate'
+        if ($Outfile) {
+            throw 'Output path must not be specified when called with -Generate'
         }
     }
-    else {
-        if (-not $OutputDir) {
-            throw 'Output directory must be specified when called without -Generate'
-        }
-        elseif (-not (Test-Path $OutputDir)) {
-            throw "Output directory does not exist: $OutputDir"
-        }
+    elseif (-not $Outfile) {
+        throw 'Output path must be specified when called without -Generate'
+    }
+
+    # Convert slashes. This does not affect function. It's just for display.
+    $Exe = Convert-Path -Path $Exe
+    $PedmDll = Convert-Path -Path $PedmDll
+    $PedmMsix = Convert-Path -Path $PedmMsix
+    $SessionExe = Convert-Path -Path $SessionExe
+    if ($Outfile) {
+        $Outfile = Convert-Path -Path $Outfile
     }
 
     $repoDir = Split-Path -Parent $PSScriptRoot # currently in `ci`
 
-    Set-EnvVarPath 'DAGENT_EXECUTABLE' $Exe
-    Set-EnvVarPath 'DAGENT_PEDM_SHELL_EXT_DLL' $PedmDll
-    Set-EnvVarPath 'DAGENT_PEDM_SHELL_EXT_MSIX' $PedmMsix
-    Set-EnvVarPath 'DAGENT_SESSION_EXECUTABLE' $SessionExe
-    Set-EnvVarPath 'DAGENT_DESKTOP_AGENT_PATH' "$repoDir\dotnet\DesktopAgent"
+    # The DLL and MSIX must have specifics name when passed to MSBuild.
+    $myPedmDll = Set-FileNameAndCopy -Path $PedmDll -NewName 'DevolutionsPedmShellExt.dll'
+    $myPedmMsix = Set-FileNameAndCopy -Path $PedmDll -NewName 'DevolutionsPedmShellExt.msix'
+
+    # These file names don't matter for building, but we will clean them up anyways for consistency. The names can be seen if inspecting the MSI.
+    # The Agent exe will get copied to `C:\Program Files\Devolutions\Agent\DevolutionsAgent.exe` after install.
+    $myExe = Set-FileNameAndCopy -Path $Exe -NewName 'DevolutionsAgent.exe'
+    # The session is a service that gets launched on demand.
+    $mySessionExe = Set-FileNameAndCopy -Path $SessionExe -NewName 'DevolutionsSession.exe'
+
+    Write-Output "$repoDir\dotnet\DesktopAgent\bin\Release\net48\DevolutionsDesktopAgent.exe"
+
+    Set-EnvVarPath 'DAGENT_EXECUTABLE' $myExe
+    Set-EnvVarPath 'DAGENT_PEDM_SHELL_EXT_DLL' $myPedmDll
+    Set-EnvVarPath 'DAGENT_PEDM_SHELL_EXT_MSIX' $myPedmMsix
+    Set-EnvVarPath 'DAGENT_SESSION_EXECUTABLE' $mySessionExe
+
+    # The actual DevolutionsDesktopAgent.exe will be `\dotnet\DesktopAgent\bin\Release\net48\DevolutionsDesktopAgent.exe`.
+    # After install, the contsnts of `net48` will be copied to `C:\Program Files\Devolutions\Agent\desktop\`. 
+    Set-EnvVarPath 'DAGENT_DESKTOP_AGENT_PATH' "$repoDir\dotnet\DesktopAgent\bin\Release\net48"
   
     $version = Get-Version
 
     Push-Location
-    Set-Location (Join-Path $repoDir 'package\AgentWindowsManaged')
+    Set-Location "$repoDir\package\AgentWindowsManaged"
 
     # Set the MSI version, which is read by `package/WindowsManaged/Program.cs`.
     $Env:DAGENT_VERSION = $version.Substring(2)
@@ -87,17 +153,17 @@ function New-AgentMsi() {
         }
     }
     else {
-        & 'MSBuild.exe' 'DevolutionsAgent.sln' '/t:restore,build' '/p:Configuration=Release' | Out-Host
+        & 'MSBuild.exe' 'DevolutionsAgent.sln' '/t:clean,restore,build' '/p:Configuration=Release' | Tee-Object -FilePath "msbuild_$(Get-Date -Format 'yyyyMMdd_HHmm').log"
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to build MSI"
         }
 
         # When called without `Generate` switch, such as in the regular CI flow, copy the MSI to the output directory.
-        $msi = Join-Path 'Release' 'DevolutionsAgent.msi'
-        Copy-Item -Path $msi -Destination $OutputDir -ErrorAction Stop
-        Write-Output "Copied MSI to $(Join-Path $OutputDir 'DevolutionsAgent.msi')"
+        Write-Output "Built MSI at $(Get-Location)\Release\DevolutionsAgent.msi"
+        Copy-Item -Path 'Release\DevolutionsAgent.msi' -Destination $Outfile -ErrorAction Stop
+        Write-Output "Copied MSI to $Outfile"
     }
     Pop-Location
 }
 
-New-AgentMsi -Generate:($Generate.IsPresent) -Exe $Exe -PedmDll $PedmDll -PedmMsix $PedmMsix -SessionExe $SessionExe -OutputDir $OutputDir
+New-AgentMsi -Generate:($Generate.IsPresent) -Exe $Exe -PedmDll $PedmDll -PedmMsix $PedmMsix -SessionExe $SessionExe -Outfile $Outfile

--- a/dotnet/DesktopAgent/build.ps1
+++ b/dotnet/DesktopAgent/build.ps1
@@ -7,3 +7,5 @@ Push-Location -Path $PSScriptRoot
 & 'MSBuild.exe' "/t:restore,build" "/p:Configuration=Release" | Out-Host
 
 Pop-Location
+
+Write-Output "Built MSI at $PSScriptRoot\bin\Release\net48\DevolutionsDesktopAgent.exe"

--- a/package/AgentWindowsManaged/.gitignore
+++ b/package/AgentWindowsManaged/.gitignore
@@ -3,3 +3,4 @@ Release
 wix
 fr-FR.*
 *_missing.json
+msbuild_*.log


### PR DESCRIPTION
This builds a working Agent MSI.

- fixes MSI internal file names that were breaking install
  - PedmShellExt.dll must be named exactly that
- fixes inclusion of DesktopAgent
  - previously was only inlcuding source files
- adds MSBuild logs (excluded from version control)
- `OutputDir` changed to `Outfile` to allow custom output name
  - for example, one can now build an MSI with a timestamped filename