### PR TITLE
ci: fix configuration of arm64 linux runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,10 +217,8 @@ jobs:
       - name: Configure Linux (arm) runner
         if: matrix.os == 'linux' && matrix.arch == 'arm64'
         run: |
-          sudo dpkg --add-architecture arm64
-          sudo apt-get -o Acquire::Retries=3 install -qy binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user
           rustup target add aarch64-unknown-linux-gnu
-          echo "STRIP_EXECUTABLE=aarch64-linux-gnu-strip" >> $GITHUB_ENV
+          echo "STRIP_EXECUTABLE=llvm-strip" >> $GITHUB_ENV
 
       - name: Configure Windows runner
         if: runner.os == 'Windows'


### PR DESCRIPTION
`apt` is failing to install packages for arm64; however as per @awakecoding we actually don't need these packages anymore since everything we want is inside our custom sysroot.