### PR TITLE
fix(installer): ensure NetworkService has proper file permissions

### DIFF
--- a/package/WindowsManaged/Resources/Includes.cs
+++ b/package/WindowsManaged/Resources/Includes.cs
@@ -32,25 +32,22 @@ namespace DevolutionsGateway.Resources
         /// Easiest way to generate an SDDL is to configure the required access, and then query the path with PowerShell: `Get-Acl | Format-List`
         /// </summary>
         /// <remarks>
-        /// Owner  : NT AUTHORITY\SYSTEM
-        /// Group  : NT AUTHORITY\SYSTEM
-        /// Access :
-        ///    NT AUTHORITY\SYSTEM Allow  FullControl
-        ///    NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize
-        ///    NT AUTHORITY\NETWORK SERVICE Allow Modify, Synchronize
-        ///    BUILTIN\Administrators Allow  FullControl
-        ///    BUILTIN\Users Allow ReadAndExecute, Synchronize
+            /// Local System (SY)	Full Access (FA)
+            /// Local Service (LS)	Read, Execute
+            /// Network Service (NS)	Read, Execute, Write, Delete Subfolders and Files
+            /// Administrators (BA)	Full Access (FA)
+            /// Users (BU)	Read, Execute
         /// </remarks>
-        internal static string PROGRAM_DATA_SDDL = "O:SYG:SYD:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;0x1301bf;;;NS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)";
+        internal static string PROGRAM_DATA_SDDL = "O:SYG:SYD:PAI(A;OICI;FA;;;SY)(A;OICI;0x1201bf;;;LS)(A;OICI;0x1301ff;;;NS)(A;OICI;FA;;;BA)(A;OICI;0x1200a9;;;BU)";
 
         /// <remarks>
         /// Owner  : NT AUTHORITY\SYSTEM
         /// Group  : NT AUTHORITY\SYSTEM
         /// Access :
-        ///    NT AUTHORITY\SYSTEM Allow  FullControl
-        ///    NT AUTHORITY\LOCAL SERVICE Allow Write, ReadAndExecute, Synchronize
-        ///    NT AUTHORITY\NETWORK SERVICE Allow Write, ReadAndExecute, Synchronize
-        ///    BUILTIN\Administrators Allow  FullControl
+            /// Local System (SY)	Full Access (FA)
+            /// Local Service (LS)	Read, Execute, Modify (Write)
+            /// Network Service (NS)	Read, Execute, Modify (Write)
+            /// Administrators (BA)	Full Access (FA)
         /// </remarks>
         internal static string USERS_FILE_SDDL = "O:SYG:SYD:PAI(A;;FA;;;SY)(A;;0x1201bf;;;LS)(A;;0x1201bf;;;NS)(A;;FA;;;BA)";
     }


### PR DESCRIPTION
We've had sporadic issues where users cannot update the revocation list due to a permissions error on the .jrl file (access denied deleting the original file).

While investigating logs, I've seen similar errors where the service is not able to delete old log files while performing a log rotation.

My theory is:

- Gateway was installed and created this file(s) at or before version 2024.1.5
- In subsequent versions, we switched the service account to `NetworkService` and updated the DACL applied to the top-level %programdata%\Devolutions\Gateway directory
- However, files created previously did not retroactively inherit `NetworkService`'s new ACL
- This doesn't matter for most files where `Users` has read and execute permission
- Files that need `Modify` permission won't have it (for example, the .jrl and existing log files)

This PR:

- Updates the SDDL set on the top-level %programdata%\Devolutions\Gateway directory to ensure that `NetworkService` can delete subfolders and files
- Forcibly resets the ACL on files in the program data directory

Result (2024.1.5):

```
PS C:\Users\rmarkiewicz> icacls C:\ProgramData\Devolutions\Gateway
C:\ProgramData\Devolutions\Gateway NT AUTHORITY\SYSTEM:(OI)(CI)(F)
                                   NT AUTHORITY\LOCAL SERVICE:(OI)(CI)(RX,W)
                                   BUILTIN\Administrators:(OI)(CI)(F)
                                   BUILTIN\Users:(OI)(CI)(RX)

Successfully processed 1 files; Failed processing 0 files
PS C:\Users\rmarkiewicz> icacls C:\ProgramData\Devolutions\Gateway\gateway.2025-03-04.0.log
C:\ProgramData\Devolutions\Gateway\gateway.2025-03-04.0.log NT AUTHORITY\SYSTEM:(I)(F)
                                                            NT AUTHORITY\LOCAL SERVICE:(I)(RX,W)
                                                            BUILTIN\Administrators:(I)(F)
                                                            BUILTIN\Users:(I)(RX)
```

Result (updated to 2025.1.1:

```
PS C:\Users\rmarkiewicz> icacls C:\ProgramData\Devolutions\Gateway
C:\ProgramData\Devolutions\Gateway NT AUTHORITY\SYSTEM:(OI)(CI)(F)
                                   NT AUTHORITY\LOCAL SERVICE:(OI)(CI)(RX,W)
                                   NT AUTHORITY\NETWORK SERVICE:(OI)(CI)(M)
                                   BUILTIN\Administrators:(OI)(CI)(F)
                                   BUILTIN\Users:(OI)(CI)(RX)

Successfully processed 1 files; Failed processing 0 files
PS C:\Users\rmarkiewicz> icacls C:\ProgramData\Devolutions\Gateway\gateway.2025-03-04.0.log
C:\ProgramData\Devolutions\Gateway\gateway.2025-03-04.0.log NT AUTHORITY\SYSTEM:(I)(F)
                                                            NT AUTHORITY\LOCAL SERVICE:(I)(RX,W)
                                                            BUILTIN\Administrators:(I)(F)
                                                            BUILTIN\Users:(I)(RX)
```

Result (updated to 2025.1.2 _including this patch_):

```
PS C:\Users\rmarkiewicz> icacls C:\ProgramData\Devolutions\Gateway
C:\ProgramData\Devolutions\Gateway NT AUTHORITY\SYSTEM:(OI)(CI)(F)
                                   NT AUTHORITY\LOCAL SERVICE:(OI)(CI)(RX,W)
                                   NT AUTHORITY\NETWORK SERVICE:(OI)(CI)(M,DC)
                                   BUILTIN\Administrators:(OI)(CI)(F)
                                   BUILTIN\Users:(OI)(CI)(RX)

Successfully processed 1 files; Failed processing 0 files
PS C:\Users\rmarkiewicz> icacls C:\ProgramData\Devolutions\Gateway\gateway.2025-03-04.0.log
C:\ProgramData\Devolutions\Gateway\gateway.2025-03-04.0.log NT AUTHORITY\SYSTEM:(I)(F)
                                                            NT AUTHORITY\LOCAL SERVICE:(I)(RX,W)
                                                            NT AUTHORITY\NETWORK SERVICE:(I)(M,DC)
                                                            BUILTIN\Administrators:(I)(F)
                                                            BUILTIN\Users:(I)(RX)
```