### PR TITLE
fix(dgw): improve debug logs for recording path canonicalization

### DIFF
--- a/devolutions-gateway/src/api/heartbeat.rs
+++ b/devolutions-gateway/src/api/heartbeat.rs
@@ -83,6 +83,9 @@ pub(super) async fn get_heartbeat(
         trace!("System is supporting listing storage disks");
 
         let recording_path = dunce::canonicalize(&conf.recording_path)
+            .inspect_err(
+                |error| debug!(%error, recording_path = %conf.recording_path, "Failed to canonicalize recording path"),
+            )
             .unwrap_or_else(|_| conf.recording_path.clone().into_std_path_buf());
 
         let disks = Disks::new_with_refreshed_list();


### PR DESCRIPTION
It’s easier to diagnostic why canonicalization failed now.

Example:

> DEBUG listener{port=7171}:http{client=[::1]:60724}:request{method=GETpath=/jet /heartbeat}: devolutions_gateway::api::heartbeat: Failed to canonicalize recording path error=The system cannot find the file specified. (os error 2) recording_path=.\dvls\recordings