### PR TITLE
fix(installer): resolve potential null reference installing PEDM shell extension

### DIFF
--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -318,8 +318,14 @@ namespace DevolutionsAgent.Actions
 
                 foreach (string extension in explorerCommandExtensions)
                 {
-                    string fileClass = Registry.GetValue($"{Registry.ClassesRoot.Name}\\{extension}", "", extension)
-                        .ToString();
+                    object fileClass = Registry.GetValue($"{Registry.ClassesRoot.Name}\\{extension}", "", extension);
+
+                    if (fileClass is null)
+                    {
+                        session.Log($"couldn't find file class for extension {extension}");
+                        continue;
+                    }
+
                     using RegistryKey commandPath =
                         Registry.ClassesRoot.CreateSubKey($"{fileClass}\\shell\\{EXPLORER_COMMAND_VERB}");
 
@@ -578,8 +584,14 @@ namespace DevolutionsAgent.Actions
 
                 foreach (string extension in explorerCommandExtensions)
                 {
-                    string fileClass = Registry.GetValue($"{Registry.ClassesRoot.Name}\\{extension}", "", extension)
-                        .ToString();
+                    object fileClass = Registry.GetValue($"{Registry.ClassesRoot.Name}\\{extension}", "", extension);
+
+                    if (fileClass is null)
+                    {
+                        session.Log($"couldn't find file class for extension {extension}");
+                        continue;
+                    }
+
                     Registry.ClassesRoot.DeleteSubKeyTree($"{fileClass}\\shell\\{EXPLORER_COMMAND_VERB}", false);
                 }
             }


### PR DESCRIPTION
The top-level file extension keys may not all exist (in the case of QA, `HKEY_CLASSES_ROOT\\.ps1` was not present). Although we check for an empty default _value_, we don't check for the presence of the top-level key which could cause a null-reference exception and force the installer to roll back.