### PR TITLE
ci: switch to nightly for cargo fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,9 @@ jobs:
 
       - name: Check formatting
         run: |
-          cargo fmt --all -- --check
+          cargo +nightly fmt --all -- --check
           if ! [ $? -eq 0 ] ; then
-              echo "::error::Bad formatting, please run 'cargo +stable fmt --all'"
+              echo "::error::Bad formatting, please run 'cargo +nightly fmt --all'"
               exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
           $Version = Get-Content VERSION -TotalCount 1
           echo "version=$Version" >> $Env:GITHUB_OUTPUT
 
+      - name: Install nightly rustfmt
+        run: rustup component add --toolchain nightly rustfmt
+
       - name: Check formatting
         run: |
           cargo +nightly fmt --all -- --check

--- a/crates/devolutions-pedm-shared/devolutions-pedm-client-http/src/apis/default_api.rs
+++ b/crates/devolutions-pedm-shared/devolutions-pedm-client-http/src/apis/default_api.rs
@@ -17,8 +17,7 @@ use std::rc::Rc;
 use futures::Future;
 use hyper;
 
-use super::request as __internal_request;
-use super::{configuration, Error};
+use super::{configuration, request as __internal_request, Error};
 use crate::models;
 
 pub struct DefaultApiClient<C: hyper::client::connect::Connect>

--- a/crates/devolutions-pedm-shared/devolutions-pedm-client-http/src/apis/mod.rs
+++ b/crates/devolutions-pedm-shared/devolutions-pedm-client-http/src/apis/mod.rs
@@ -1,6 +1,4 @@
-use http;
-use hyper;
-use serde_json;
+use {http, hyper, serde_json};
 
 #[derive(Debug)]
 pub enum Error {

--- a/crates/devolutions-pedm-shared/devolutions-pedm-client-http/src/apis/request.rs
+++ b/crates/devolutions-pedm-shared/devolutions-pedm-client-http/src/apis/request.rs
@@ -1,13 +1,10 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 
-use futures;
 use futures::future::*;
 use futures::Future;
-use hyper;
 use hyper::header::{HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT};
-use serde;
-use serde_json;
+use {futures, hyper, serde, serde_json};
 
 use super::{configuration, Error};
 

--- a/crates/terminal-streamer/src/lib.rs
+++ b/crates/terminal-streamer/src/lib.rs
@@ -4,12 +4,11 @@ pub mod trp_decoder;
 #[macro_use]
 extern crate tracing;
 
-use std::{future::Future, sync::Arc};
+use std::future::Future;
+use std::sync::Arc;
 
-use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, BufReader},
-    sync::Notify,
-};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::sync::Notify;
 
 pub trait TerminalStreamSocket {
     fn send(&mut self, value: String) -> impl Future<Output = anyhow::Result<()>> + Send;

--- a/crates/terminal-streamer/src/trp_decoder.rs
+++ b/crates/terminal-streamer/src/trp_decoder.rs
@@ -1,7 +1,5 @@
-use std::{
-    pin::Pin,
-    task::{Context, Poll},
-};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 

--- a/crates/video-streamer/examples/read_from.rs
+++ b/crates/video-streamer/examples/read_from.rs
@@ -1,6 +1,9 @@
 //! For debugging webm video iterators
 
-use std::{env, io::Seek, path::Path, process::exit};
+use std::env;
+use std::io::Seek;
+use std::path::Path;
+use std::process::exit;
 use tracing::*;
 use video_streamer::debug;
 use webm_iterable::matroska_spec::MatroskaSpec;

--- a/crates/video-streamer/examples/stream/local_websocket.rs
+++ b/crates/video-streamer/examples/stream/local_websocket.rs
@@ -1,20 +1,14 @@
-use axum::{
-    extract::ws::{self, WebSocket, WebSocketUpgrade},
-    routing::get,
-    Router,
-};
-use futures::{stream::StreamExt, SinkExt};
-use std::{
-    io::{Error as IoError, ErrorKind},
-    sync::{Arc, Mutex},
-};
-use tokio::{
-    io::{AsyncRead, AsyncWrite},
-    net::{TcpListener, TcpStream},
-};
-use tokio_tungstenite::{
-    connect_async, tungstenite::protocol::Message as TungsteniteMessage, MaybeTlsStream, WebSocketStream,
-};
+use axum::extract::ws::{self, WebSocket, WebSocketUpgrade};
+use axum::routing::get;
+use axum::Router;
+use futures::stream::StreamExt;
+use futures::SinkExt;
+use std::io::{Error as IoError, ErrorKind};
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::tungstenite::protocol::Message as TungsteniteMessage;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use tracing::info;
 
 pub(crate) struct WebSocketClient {

--- a/crates/video-streamer/examples/stream/main.rs
+++ b/crates/video-streamer/examples/stream/main.rs
@@ -1,17 +1,20 @@
 #![allow(clippy::print_stdout)]
 #![allow(clippy::unwrap_used)]
 
-use std::{env, path::Path, process::exit, sync::Arc};
+use std::env;
+use std::path::Path;
+use std::process::exit;
+use std::sync::Arc;
 
 use anyhow::Context;
 use cadeau::xmf;
 use local_websocket::create_local_websocket;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::{watch::Sender, Notify},
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::watch::Sender;
+use tokio::sync::Notify;
 use tracing::{error, info};
-use video_streamer::{config::CpuCount, webm_stream, ReOpenableFile, StreamingConfig};
+use video_streamer::config::CpuCount;
+use video_streamer::{webm_stream, ReOpenableFile, StreamingConfig};
 
 pub struct TokioSignal {
     signal: tokio::sync::watch::Receiver<()>,

--- a/crates/video-streamer/src/streamer/iter.rs
+++ b/crates/video-streamer/src/streamer/iter.rs
@@ -3,11 +3,9 @@ use std::io::Seek;
 use anyhow::Context;
 use cadeau::xmf::vpx::is_key_frame;
 use thiserror::Error;
-use webm_iterable::{
-    errors::TagIteratorError,
-    matroska_spec::{Block, Master, MatroskaSpec, SimpleBlock},
-    WebmIterator,
-};
+use webm_iterable::errors::TagIteratorError;
+use webm_iterable::matroska_spec::{Block, Master, MatroskaSpec, SimpleBlock};
+use webm_iterable::WebmIterator;
 
 use crate::reopenable::Reopenable;
 

--- a/crates/video-streamer/src/streamer/mod.rs
+++ b/crates/video-streamer/src/streamer/mod.rs
@@ -6,14 +6,13 @@ use futures_util::SinkExt;
 use iter::{IteratorError, WebmPositionedIterator};
 use protocol::{ProtocolCodeC, UserFriendlyError};
 use tag_writers::{EncodeWriterConfig, HeaderWriter, WriterResult};
-use tokio::sync::{mpsc, oneshot::error::RecvError, Mutex, Notify};
+use tokio::sync::oneshot::error::RecvError;
+use tokio::sync::{mpsc, Mutex, Notify};
 use tokio_util::codec::Framed;
 use tracing::Instrument;
-use webm_iterable::{
-    errors::{TagIteratorError, TagWriterError},
-    matroska_spec::{Master, MatroskaSpec},
-    WebmIterator,
-};
+use webm_iterable::errors::{TagIteratorError, TagWriterError};
+use webm_iterable::matroska_spec::{Master, MatroskaSpec};
+use webm_iterable::WebmIterator;
 
 pub(crate) mod block_tag;
 pub(crate) mod channel_writer;
@@ -23,7 +22,8 @@ pub(crate) mod reopenable_file;
 pub(crate) mod signal_writer;
 pub(crate) mod tag_writers;
 
-use crate::{reopenable::Reopenable, StreamingConfig};
+use crate::reopenable::Reopenable;
+use crate::StreamingConfig;
 use tokio::io::AsyncWriteExt;
 
 #[instrument(skip_all)]

--- a/crates/video-streamer/src/streamer/protocol.rs
+++ b/crates/video-streamer/src/streamer/protocol.rs
@@ -1,7 +1,5 @@
-use tokio_util::{
-    bytes::{self, Buf, BufMut},
-    codec,
-};
+use tokio_util::bytes::{self, Buf, BufMut};
+use tokio_util::codec;
 
 #[derive(Debug)]
 pub(crate) enum Codec {

--- a/crates/video-streamer/src/streamer/reopenable_file.rs
+++ b/crates/video-streamer/src/streamer/reopenable_file.rs
@@ -1,5 +1,5 @@
-use std::io::{self, Read};
-use std::{io::Seek, path::PathBuf};
+use std::io::{self, Read, Seek};
+use std::path::PathBuf;
 
 use crate::reopenable::Reopenable;
 

--- a/crates/video-streamer/src/streamer/signal_writer.rs
+++ b/crates/video-streamer/src/streamer/signal_writer.rs
@@ -1,4 +1,5 @@
-use std::{sync::Arc, task::Poll};
+use std::sync::Arc;
+use std::task::Poll;
 
 pub struct SignalWriter<W> {
     writer: W,

--- a/crates/video-streamer/src/streamer/tag_writers.rs
+++ b/crates/video-streamer/src/streamer/tag_writers.rs
@@ -1,12 +1,11 @@
 use anyhow::Context;
 use cadeau::xmf::vpx::{VpxCodec, VpxDecoder, VpxEncoder};
-use webm_iterable::{
-    errors::TagWriterError,
-    matroska_spec::{Master, MatroskaSpec, SimpleBlock},
-    WebmWriter, WriteOptions,
-};
+use webm_iterable::errors::TagWriterError;
+use webm_iterable::matroska_spec::{Master, MatroskaSpec, SimpleBlock};
+use webm_iterable::{WebmWriter, WriteOptions};
 
-use crate::{debug::mastroka_spec_name, StreamingConfig};
+use crate::debug::mastroka_spec_name;
+use crate::StreamingConfig;
 
 use super::block_tag::VideoBlock;
 

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
-use std::env;
-use std::fmt;
 use std::fs::File;
 use std::io::BufReader;
 use std::sync::Arc;
+use std::{env, fmt};
 
 use anyhow::Context;
 use camino::{Utf8Path, Utf8PathBuf};

--- a/devolutions-gateway/src/ws.rs
+++ b/devolutions-gateway/src/ws.rs
@@ -1,8 +1,6 @@
-use core::future;
-use core::time;
+use core::{future, time};
 
-use axum::extract::ws::CloseFrame;
-use axum::extract::ws::{self, WebSocket};
+use axum::extract::ws::{self, CloseFrame, WebSocket};
 use devolutions_gateway_task::ShutdownSignal;
 use futures::{SinkExt as _, StreamExt as _};
 use tap::Pipe as _;


### PR DESCRIPTION
I encountered a warning in the "Check formatting" step of the preflight job.

```
Warning: can't set `imports_granularity = Module`, unstable features are only available in nightly channel.
```

Switching to nightly resolves this issue.