### PR TITLE
fix(dgw): improve network interface information extraction

### DIFF
--- a/crates/network-scanner/examples/ipconfig.rs
+++ b/crates/network-scanner/examples/ipconfig.rs
@@ -1,10 +1,8 @@
-
 use anyhow::Context;
 use network_scanner::interfaces::{self, get_network_interfaces, Filter};
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
-    
     let interfaces = get_network_interfaces(Filter::default())
         .await
         .context("Failed to get network interfaces")?;

--- a/crates/network-scanner/examples/ipconfig.rs
+++ b/crates/network-scanner/examples/ipconfig.rs
@@ -1,15 +1,17 @@
-#![allow(unused_crate_dependencies)]
+
+use anyhow::Context;
+use network_scanner::interfaces::{self, get_network_interfaces, Filter};
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt::SubscriberBuilder::default()
-        .with_max_level(tracing::Level::DEBUG)
-        .with_line_number(true)
-        .init();
+pub async fn main() -> anyhow::Result<()> {
+    
+    let interfaces = get_network_interfaces(Filter::default())
+        .await
+        .context("Failed to get network interfaces")?;
 
-    let interfaces = network_scanner::interfaces::get_network_interfaces().await?;
     for interface in interfaces {
-        tracing::info!("{:?}", interface)
+        println!("{:#?}", interface);
     }
+
     Ok(())
 }

--- a/crates/network-scanner/examples/ipconfig.rs
+++ b/crates/network-scanner/examples/ipconfig.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use network_scanner::interfaces::{self, get_network_interfaces, Filter};
+use network_scanner::interfaces::{get_network_interfaces, Filter};
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {

--- a/crates/network-scanner/src/interfaces/filter.rs
+++ b/crates/network-scanner/src/interfaces/filter.rs
@@ -1,0 +1,42 @@
+use std::net::IpAddr;
+
+use super::NetworkInterface;
+
+#[derive(Debug, Clone)]
+pub struct Filter {
+    pub ignore_ipv6: bool,
+    pub include_loopback: bool,
+}
+
+impl Default for Filter {
+    fn default() -> Self {
+        Self {
+            ignore_ipv6: true,
+            include_loopback: false,
+        }
+    }
+}
+
+impl Filter {
+    pub fn matches(&self, interface: &NetworkInterface) -> bool {
+        // 1. Loopback exclusion
+        if !self.include_loopback {
+            for addr in &interface.addresses {
+                if let IpAddr::V4(ipv4) = addr.ip {
+                    if ipv4.octets()[0] == 127 {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        true
+    }
+
+    pub fn clean(&self, interfaces: &mut NetworkInterface) {
+        if self.ignore_ipv6 {
+            interfaces.addresses.retain(|addr| matches!(addr.ip, IpAddr::V4(_)));
+            interfaces.ip_adresses.retain(|addr| matches!(addr, IpAddr::V4(_)));
+        }
+    }
+}

--- a/crates/network-scanner/src/interfaces/filter.rs
+++ b/crates/network-scanner/src/interfaces/filter.rs
@@ -21,7 +21,7 @@ impl Filter {
     pub fn matches(&self, interface: &NetworkInterface) -> bool {
         // 1. Loopback exclusion
         if !self.include_loopback {
-            for addr in &interface.addresses {
+            for addr in &interface.routes {
                 if let IpAddr::V4(ipv4) = addr.ip {
                     if ipv4.octets()[0] == 127 {
                         return false;
@@ -35,7 +35,7 @@ impl Filter {
 
     pub fn clean(&self, interfaces: &mut NetworkInterface) {
         if self.ignore_ipv6 {
-            interfaces.addresses.retain(|addr| matches!(addr.ip, IpAddr::V4(_)));
+            interfaces.routes.retain(|addr| matches!(addr.ip, IpAddr::V4(_)));
             interfaces.ip_adresses.retain(|addr| matches!(addr, IpAddr::V4(_)));
         }
     }

--- a/crates/network-scanner/src/interfaces/filter.rs
+++ b/crates/network-scanner/src/interfaces/filter.rs
@@ -17,26 +17,23 @@ impl Default for Filter {
     }
 }
 
-impl Filter {
-    pub fn matches(&self, interface: &NetworkInterface) -> bool {
-        // 1. Loopback exclusion
-        if !self.include_loopback {
-            for addr in &interface.routes {
-                if let IpAddr::V4(ipv4) = addr.ip {
-                    if ipv4.octets()[0] == 127 {
-                        return false;
-                    }
-                }
+pub(crate) fn is_loop_back(interface: &NetworkInterface) -> bool {
+    for addr in &interface.routes {
+        if let IpAddr::V4(ipv4) = addr.ip {
+            if ipv4.octets()[0] == 127 {
+                return false;
             }
         }
-
-        true
     }
 
-    pub fn clean(&self, interfaces: &mut NetworkInterface) {
-        if self.ignore_ipv6 {
-            interfaces.routes.retain(|addr| matches!(addr.ip, IpAddr::V4(_)));
-            interfaces.ip_adresses.retain(|addr| matches!(addr, IpAddr::V4(_)));
-        }
+    return true;
+}
+
+pub(crate) fn filter_out_ipv6_if(ignore_ipv6: bool, mut interface: NetworkInterface) -> NetworkInterface {
+    if ignore_ipv6 {
+        interface.routes.retain(|addr| matches!(addr.ip, IpAddr::V4(_)));
+        interface.ip_adresses.retain(|addr| matches!(addr, IpAddr::V4(_)));
     }
+
+    interface
 }

--- a/crates/network-scanner/src/interfaces/linux.rs
+++ b/crates/network-scanner/src/interfaces/linux.rs
@@ -120,7 +120,6 @@ impl TryFrom<&LinkInfo> for NetworkInterface {
 }
 
 fn convert_link_info_to_network_interface(link_info: &LinkInfo) -> anyhow::Result<NetworkInterface> {
-
     let routes = link_info
         .routes
         .iter()

--- a/crates/network-scanner/src/interfaces/linux.rs
+++ b/crates/network-scanner/src/interfaces/linux.rs
@@ -47,7 +47,7 @@ pub(crate) async fn get_network_interfaces() -> anyhow::Result<Vec<NetworkInterf
 
         let address = addresses
             .iter()
-            .filter_map(|addr_msg| try_to_ip(addr_msg.clone()))
+            .filter_map(|addr_msg| extract_ip(addr_msg.clone()))
             .collect::<Vec<_>>();
 
         link.ip_addresses = address;
@@ -242,7 +242,7 @@ impl TryFrom<RouteMessage> for RouteInfo {
     }
 }
 
-fn try_to_ip(addr_msg: AddressMessage) -> Option<IpAddr> {
+fn extract_ip(addr_msg: AddressMessage) -> Option<IpAddr> {
     addr_msg.attributes.iter().find_map(|attr| {
         if let AddressAttribute::Address(addr) = attr {
             Some(*addr)

--- a/crates/network-scanner/src/interfaces/mod.rs
+++ b/crates/network-scanner/src/interfaces/mod.rs
@@ -24,11 +24,13 @@ pub async fn get_network_interfaces(filter: Filter) -> anyhow::Result<Vec<Networ
     result.map(|interfaces| {
         interfaces
             .into_iter()
-            .filter(|interface| filter.matches(interface))
-            .map(|mut interface| {
-                filter.clean(&mut interface);
-                interface
+            .filter(|interface| {
+                if !filter.include_loopback {
+                    return !filter::is_loop_back(interface);
+                }
+                true
             })
+            .map(|interface| filter::filter_out_ipv6_if(filter.ignore_ipv6, interface))
             .collect()
     })
 }

--- a/crates/network-scanner/src/interfaces/mod.rs
+++ b/crates/network-scanner/src/interfaces/mod.rs
@@ -26,7 +26,7 @@ pub async fn get_network_interfaces(filter: Filter) -> anyhow::Result<Vec<Networ
             .into_iter()
             .filter(|interface| {
                 if !filter.include_loopback {
-                    return !filter::is_loop_back(interface);
+                    return filter::is_loop_back(interface);
                 }
                 true
             })

--- a/crates/network-scanner/src/interfaces/mod.rs
+++ b/crates/network-scanner/src/interfaces/mod.rs
@@ -88,11 +88,12 @@ pub struct InterfaceAddress {
 
 #[derive(Debug, Clone)]
 pub struct NetworkInterface {
-    pub id: String,
+    // Linux interfaces does not come with an id
+    pub id: Option<String>,
     pub name: String,
     pub description: Option<String>,
     pub mac_address: Option<MacAddr>,
-    pub addresses: Vec<InterfaceAddress>,
+    pub routes: Vec<InterfaceAddress>,
     pub ip_adresses: Vec<IpAddr>,
     pub operational_status: bool,
     pub gateways: Vec<IpAddr>,

--- a/crates/network-scanner/src/interfaces/windows.rs
+++ b/crates/network-scanner/src/interfaces/windows.rs
@@ -3,7 +3,7 @@ use anyhow::Context;
 
 use super::MacAddr;
 
-pub async fn get_network_interfaces() -> anyhow::Result<Vec<NetworkInterface>> {
+pub(crate) async fn get_network_interfaces() -> anyhow::Result<Vec<NetworkInterface>> {
     ipconfig::get_adapters()
         .context("failed to get network interfaces")?
         .into_iter()
@@ -16,9 +16,11 @@ impl From<ipconfig::Adapter> for NetworkInterface {
         let mac_address: Option<MacAddr> = adapter.physical_address().and_then(|addr| addr.try_into().ok());
 
         NetworkInterface {
-            name: adapter.adapter_name().to_owned(),
+            id: adapter.adapter_name().to_owned(),
+            name: adapter.friendly_name().to_owned(),
             description: Some(adapter.description().to_owned()),
             mac_address,
+            ip_adresses: adapter.ip_addresses().iter().map(|ip| *ip).collect(),
             addresses: adapter
                 .prefixes()
                 .iter()

--- a/crates/network-scanner/src/interfaces/windows.rs
+++ b/crates/network-scanner/src/interfaces/windows.rs
@@ -16,12 +16,12 @@ impl From<ipconfig::Adapter> for NetworkInterface {
         let mac_address: Option<MacAddr> = adapter.physical_address().and_then(|addr| addr.try_into().ok());
 
         NetworkInterface {
-            id: adapter.adapter_name().to_owned(),
+            id: Some(adapter.adapter_name().to_owned()),
             name: adapter.friendly_name().to_owned(),
             description: Some(adapter.description().to_owned()),
             mac_address,
-            ip_adresses: adapter.ip_addresses().iter().map(|ip| *ip).collect(),
-            addresses: adapter
+            ip_adresses: adapter.ip_addresses().to_vec(),
+            routes: adapter
                 .prefixes()
                 .iter()
                 .map(|(ip, prefix)| super::InterfaceAddress {

--- a/devolutions-gateway/src/api/net.rs
+++ b/devolutions-gateway/src/api/net.rs
@@ -242,14 +242,18 @@ pub struct InterfaceAddress {
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[derive(Debug, Clone, Serialize)]
 pub struct NetworkInterface {
-    pub id: String,
+    /// The id is a Windows specific concept, does not exist in linux
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// The description of the interface, also Windows specific
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<MacAddr>,
+    // routes is the list of IP addresses and their prefix lengths that this interface routes to.
     #[cfg_attr(feature = "openapi", schema(value_type = Vec<InterfaceAddress>))]
-    pub addresses: Vec<InterfaceAddress>,
+    pub routes: Vec<InterfaceAddress>,
     #[cfg_attr(feature = "openapi", schema(value_type = bool))]
     pub is_up: bool,
     #[cfg_attr(feature = "openapi", schema(value_type = Vec<String>))]
@@ -258,6 +262,7 @@ pub struct NetworkInterface {
     pub nameservers: Vec<IpAddr>,
     #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub name: String,
+    // Assigned IP addresses to this interface
     #[cfg_attr(feature = "openapi", schema(value_type = Vec<IpAddr>))]
     pub ip_adresses: Vec<IpAddr>,
 }
@@ -270,8 +275,8 @@ impl From<interfaces::NetworkInterface> for NetworkInterface {
             description: iface.description,
             mac_address: iface.mac_address,
             ip_adresses: iface.ip_adresses,
-            addresses: iface
-                .addresses
+            routes: iface
+                .routes
                 .into_iter()
                 .map(|addr| InterfaceAddress {
                     ip: addr.ip,

--- a/devolutions-gateway/src/api/net.rs
+++ b/devolutions-gateway/src/api/net.rs
@@ -188,12 +188,9 @@ impl NetworkScanResponse {
     }
 }
 
-#[derive(Debug, Deserialize, utoipa::IntoParams)]
-#[into_params(parameter_in = Query)]
+#[derive(Debug, Deserialize)]
 pub struct NetworkConfigParams {
-    #[param(example = "false", default = "true")]
     pub ignore_ipv6: Option<bool>,
-    #[param(example = "false", default = "false")]
     pub include_loopback: Option<bool>,
 }
 
@@ -203,6 +200,10 @@ pub struct NetworkConfigParams {
     operation_id = "GetNetConfig",
     tag = "Net",
     path = "/jet/net/config",
+    params(
+        (name = "ignore_ipv6", description = "Ignore IPv6 addresses", type = "boolean", example = false),
+        (name = "include_loopback", description = "Include loopback interfaces", type = "boolean", example = true),
+    ),
     responses(
         (status = 200, description = "Network interfaces", body = [Vec<NetworkInterface>]),
         (status = 400, description = "Bad request"),

--- a/devolutions-gateway/src/api/net.rs
+++ b/devolutions-gateway/src/api/net.rs
@@ -188,7 +188,7 @@ impl NetworkScanResponse {
     }
 }
 
-#[derive(Debug, Deserialize,utoipa::IntoParams)]
+#[derive(Debug, Deserialize, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct NetworkConfigParams {
     #[param(example = "false", default = "true")]

--- a/devolutions-gateway/src/api/net.rs
+++ b/devolutions-gateway/src/api/net.rs
@@ -188,9 +188,12 @@ impl NetworkScanResponse {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize,utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct NetworkConfigParams {
+    #[param(example = "false", default = "true")]
     pub ignore_ipv6: Option<bool>,
+    #[param(example = "false", default = "false")]
     pub include_loopback: Option<bool>,
 }
 


### PR DESCRIPTION
Improved api/net/config end point, correctly return ip and routes for both windows and linux. Renamed struct field to better match it's semantices.

### Example output

From api request
```pwsh
id          : {B4488786-D294-448F-8D0A-D2573F2126C7}
description : Hyper-V Virtual Ethernet Adapter #3
mac_address : 00:15:5D:34:6E:07
routes      : {@{ip=10.10.0.0; prefixlen=24}, @{ip=10.10.0.1; prefixlen=32}, @{ip=10.10.0.255; 
              prefixlen=32}, @{ip=224.0.0.0; prefixlen=4}…}
is_up       : True
gateways    : {}
nameservers : {fec0:0:0:ffff::1, fec0:0:0:ffff::2, fec0:0:0:ffff::3}
name        : vEthernet (LAN Switch)
ip_adresses : {10.10.0.1}
```
from ipconfig
```
Ethernet adapter vEthernet (LAN Switch):

   Connection-specific DNS Suffix  . : 
   Link-local IPv6 Address . . . . . : fe80::f5f9:2d83:9342:2005%23
   IPv4 Address. . . . . . . . . . . : 10.10.0.1
   Subnet Mask . . . . . . . . . . . : 255.255.255.0
   Default Gateway . . . . . . . . . : 
```
