### PR TITLE
build(deps): bump libsql to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.6"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
+checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -304,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77926887776171ced7d662120a75998e444d3750c951abfe07f90da130514b1f"
+checksum = "b9f7720b74ed28ca77f90769a71fd8c637a0137f6fae4ae947e1050229cff57f"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -3087,9 +3087,8 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b9df6f5cc08ca4bb2467793926470210d3d8a916ea28260d6cd892bba6d8b4"
+version = "0.9.1"
+source = "git+https://github.com/allan2/libsql?rev=9364e90#9364e90ea1ffcd91509607abc00756581d619bda"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3120,9 +3119,8 @@ dependencies = [
 
 [[package]]
 name = "libsql-ffi"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1dcc2bf91e8511ece5bc2bac502b78bcbcecef80635dacb30020a40419e5d6"
+version = "0.9.1"
+source = "git+https://github.com/allan2/libsql?rev=9364e90#9364e90ea1ffcd91509607abc00756581d619bda"
 dependencies = [
  "bindgen 0.66.1",
  "cc",
@@ -3131,9 +3129,8 @@ dependencies = [
 
 [[package]]
 name = "libsql-rusqlite"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b3e3f05c8d3f22be9ccfa4f6a56ad25165a5458615aba8b7586558c694965"
+version = "0.9.1"
+source = "git+https://github.com/allan2/libsql?rev=9364e90#9364e90ea1ffcd91509607abc00756581d619bda"
 dependencies = [
  "bitflags 2.9.0",
  "fallible-iterator 0.2.0",
@@ -3146,8 +3143,7 @@ dependencies = [
 [[package]]
 name = "libsql-sqlite3-parser"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
+source = "git+https://github.com/allan2/libsql?rev=9364e90#9364e90ea1ffcd91509607abc00756581d619bda"
 dependencies = [
  "bitflags 2.9.0",
  "cc",
@@ -3163,9 +3159,8 @@ dependencies = [
 
 [[package]]
 name = "libsql-sys"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edae249cc733bb10e134d3c1522b408631f6a8741855caf7179927fd296f5715"
+version = "0.9.1"
+source = "git+https://github.com/allan2/libsql?rev=9364e90#9364e90ea1ffcd91509607abc00756581d619bda"
 dependencies = [
  "bytes 1.10.1",
  "libsql-ffi",
@@ -3177,9 +3172,8 @@ dependencies = [
 
 [[package]]
 name = "libsql_replication"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c30add5755085fffd616190ff67703a391ae8324001738d7e6f00d6ea1b180"
+version = "0.9.1"
+source = "git+https://github.com/allan2/libsql?rev=9364e90#9364e90ea1ffcd91509607abc00756581d619bda"
 dependencies = [
  "aes",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lto = true
 strip = "symbols"
 
 [patch.crates-io]
+libsql = { git = "https://github.com/allan2/libsql", rev = "9364e90" }
 tracing-appender = { git = "https://github.com/CBenoit/tracing.git", rev = "42097daf92e683cf18da7639ddccb056721a796c" }
 
 [workspace.lints.rust]

--- a/crates/job-queue-libsql/Cargo.toml
+++ b/crates/job-queue-libsql/Cargo.toml
@@ -19,6 +19,3 @@ tracing = "0.1"
 typed-builder = "0.19"
 ulid = { version = "1.1", features = ["uuid"] }
 uuid = "1.11"
-
-[patch.crates-io]
-libsql = { git = "https://github.com/allan2/libsql", branch = "ffi-windows-cp" }


### PR DESCRIPTION
0.9.x is still broken on Windows, but I will make a patch fix where needed, i.e., PEDM PR.