### PR TITLE
refactor(pedm): modify `serve` arguments

### DIFF
--- a/crates/devolutions-pedm/src/lib.rs
+++ b/crates/devolutions-pedm/src/lib.rs
@@ -1,14 +1,16 @@
 use async_trait::async_trait;
 use camino::Utf8PathBuf;
 
-pub use config::Config;
 use devolutions_gateway_task::{ShutdownSignal, Task};
+
+mod config;
+pub use config::Config;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
         mod api;
         mod db;
-        mod config;
+
         mod elevations;
         mod elevator;
         mod error;

--- a/crates/devolutions-pedm/src/lib.rs
+++ b/crates/devolutions-pedm/src/lib.rs
@@ -8,7 +8,7 @@ pub use config::Config;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
-        mod api;
+        pub mod api;
         mod db;
 
         mod elevations;

--- a/crates/devolutions-pedm/src/lib.rs
+++ b/crates/devolutions-pedm/src/lib.rs
@@ -1,11 +1,12 @@
 use async_trait::async_trait;
 use camino::Utf8PathBuf;
 
+pub use config::Config;
 use devolutions_gateway_task::{ShutdownSignal, Task};
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
-        pub mod api;
+        mod api;
         mod db;
         mod config;
         mod elevations;
@@ -14,8 +15,10 @@ cfg_if::cfg_if! {
         mod log;
         mod policy;
         mod utils;
-        use tokio::select;
 
+        pub use api::serve;
+
+        use tokio::select;
         use tracing::error;
     }
 }
@@ -39,7 +42,7 @@ impl Task for PedmTask {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "windows")] {
                 select! {
-                    res = api::serve(r"\\.\pipe\DevolutionsPEDM", None) => {
+                    res = serve(Config::standard()) => {
                         if let Err(error) = &res {
                             error!(%error, "Named pipe server got error");
                         }


### PR DESCRIPTION
- `serve` now takes a `Config` struct rather than a path
  - pipe name is now part of `Config` rather than a direct argument
- `Config` struct is now exported as `devolutions_pedm::Config`
- `serve` is now exported as `devolutions_pedm::serve`