### PR TITLE
refactor(transport): use bytes crate for a payload handling instead of a plain Vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6601,6 +6601,7 @@ name = "transport"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytes 1.10.1",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -193,8 +193,8 @@ where
     let compat = stream.filter_map(|item| {
         let mapped = item
             .map(|msg| match msg {
-                tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into_bytes())),
-                tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data)),
+                tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into())),
+                tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data.into())),
                 tungstenite::Message::Ping(_) | tungstenite::Message::Pong(_) => None,
                 tungstenite::Message::Close(_) => Some(transport::WsReadMsg::Close),
                 tungstenite::Message::Frame(_) => unreachable!("raw frames are never returned when reading"),
@@ -233,8 +233,8 @@ where
         .filter_map(|item| {
             let mapped = item
                 .map(|msg| match msg {
-                    tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into_bytes())),
-                    tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data)),
+                    tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into())),
+                    tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data.into())),
                     tungstenite::Message::Ping(_) | tungstenite::Message::Pong(_) => None,
                     tungstenite::Message::Close(_) => Some(transport::WsReadMsg::Close),
                     tungstenite::Message::Frame(_) => unreachable!("raw frames are never returned when reading"),

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = { version = "0.3", features = ["sink"] }
 pin-project-lite = "0.2"
 parking_lot = "0.12"
 tracing = "0.1"
+bytes = { version = "1.10", default-features = false }
 
 [dev-dependencies]
 futures-util = "0.3"

--- a/crates/video-streamer/examples/stream/local_websocket.rs
+++ b/crates/video-streamer/examples/stream/local_websocket.rs
@@ -93,8 +93,8 @@ fn websocket_compat(ws: WebSocket) -> impl AsyncRead + AsyncWrite + Unpin + Send
         .filter_map(|item| {
             let mapped = item
                 .map(|msg| match msg {
-                    ws::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into_bytes())),
-                    ws::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data)),
+                    ws::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into())),
+                    ws::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data.into())),
                     ws::Message::Ping(_) | ws::Message::Pong(_) => None,
                     ws::Message::Close(_) => Some(transport::WsReadMsg::Close),
                 })

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -639,8 +639,8 @@ async fn fwd_http(
             .filter_map(|item| {
                 let mapped = item
                     .map(|msg| match msg {
-                        tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into_bytes())),
-                        tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data)),
+                        tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into())),
+                        tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data.into())),
                         tungstenite::Message::Ping(_) | tungstenite::Message::Pong(_) => None,
                         tungstenite::Message::Close(_) => Some(transport::WsReadMsg::Close),
                         tungstenite::Message::Frame(_) => unreachable!("raw frames are never returned when reading"),

--- a/devolutions-gateway/src/ws.rs
+++ b/devolutions-gateway/src/ws.rs
@@ -46,8 +46,8 @@ fn websocket_compat(ws: transport::Shared<WebSocket>) -> impl AsyncRead + AsyncW
     let ws_compat = ws
         .filter_map(|item| {
             item.map(|msg| match msg {
-                ws::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into_bytes())),
-                ws::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data)),
+                ws::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into())),
+                ws::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data.into())),
                 ws::Message::Ping(_) | ws::Message::Pong(_) => None,
                 ws::Message::Close(_) => Some(transport::WsReadMsg::Close),
             })

--- a/jetsocat/src/utils.rs
+++ b/jetsocat/src/utils.rs
@@ -193,8 +193,8 @@ where
         .filter_map(|item| {
             let mapped = item
                 .map(|msg| match msg {
-                    tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into_bytes())),
-                    tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data)),
+                    tungstenite::Message::Text(s) => Some(transport::WsReadMsg::Payload(s.into())),
+                    tungstenite::Message::Binary(data) => Some(transport::WsReadMsg::Payload(data.into())),
                     tungstenite::Message::Ping(_) | tungstenite::Message::Pong(_) => None,
                     tungstenite::Message::Close(_) => Some(transport::WsReadMsg::Close),
                     tungstenite::Message::Frame(_) => unreachable!("raw frames are never returned when reading"),


### PR DESCRIPTION
More information here - https://github.com/Devolutions/IronVNC/pull/747#discussion_r1932929207