### PR TITLE
fix(dgw): rename param addrs to addresses

### DIFF
--- a/devolutions-gateway/src/api/net.rs
+++ b/devolutions-gateway/src/api/net.rs
@@ -218,6 +218,7 @@ pub async fn get_net_config(_token: crate::extract::NetScanToken) -> Result<Json
 #[derive(Debug, Clone, Serialize)]
 pub struct NetworkInterface {
     pub name: String,
+    #[serde(rename = "addresses")]
     pub addrs: Vec<Addr>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_addr: Option<String>,


### PR DESCRIPTION
Up on the request for Paul.

Example output:
```
 {
        "name": "Ethernet",
        "addresses": [
            {
                "V6": {
                    "ip": "fe80::1a61:8798:d284:1e54"
                }
            },
            {
                "V4": {
                    "ip": "169.254.160.203",
                    "netmask": "255.255.0.0"
                }
            }
        ],
        "mac_addr": "AC:1A:3D:6F:56:6C",
        "index": 17
    },
```