### PR TITLE
fix(pedm): write default config when not present

### DIFF
--- a/crates/devolutions-pedm/src/config.rs
+++ b/crates/devolutions-pedm/src/config.rs
@@ -46,6 +46,8 @@ impl Config {
     }
 
     /// Loads the config file from the specified path.
+    /// 
+    /// If the config file is not found, it will be written to disk at the specified path.
     pub fn load_from_path(path: &Utf8Path) -> Result<Self, ConfigError> {
         match fs::read_to_string(path) {
             Ok(s) => {
@@ -66,7 +68,7 @@ impl Config {
 
     /// Loads the config file from the default path.
     pub fn load_from_default_path() -> Result<Self, ConfigError> {
-        let path = data_dir().join("config.toml");
+        let path = data_dir().join("config.json");
         Self::load_from_path(&path)
     }
 

--- a/crates/devolutions-pedm/src/config.rs
+++ b/crates/devolutions-pedm/src/config.rs
@@ -46,7 +46,7 @@ impl Config {
     }
 
     /// Loads the config file from the specified path.
-    /// 
+    ///
     /// If the config file is not found, it will be written to disk at the specified path.
     pub fn load_from_path(path: &Utf8Path) -> Result<Self, ConfigError> {
         match fs::read_to_string(path) {

--- a/crates/devolutions-pedm/src/lib.rs
+++ b/crates/devolutions-pedm/src/lib.rs
@@ -45,7 +45,7 @@ impl Task for PedmTask {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "windows")] {
                 select! {
-                    res = serve(Config::standard()) => {
+                    res = serve(Config::load_from_default_path()?) => {
                         if let Err(error) = &res {
                             error!(%error, "Named pipe server got error");
                         }


### PR DESCRIPTION
The wrong function was being called when initializing the config. No default config was actually being written to disk.

This commit fixes it.