### PR TITLE
fix(pedm): CryptCATAdminCalcHashFromFileHandle2 does not return error with NULL buffer

### DIFF
--- a/crates/win-api-wrappers/src/security/crypt.rs
+++ b/crates/win-api-wrappers/src/security/crypt.rs
@@ -180,20 +180,7 @@ impl CatalogAdminContext {
                 None,
                 0,
             )
-        };
-
-        let Err(err) = res else {
-            anyhow::bail!("first call to CryptCATAdminCalcHashFromFileHandle2 did not fail")
-        };
-
-        // SAFETY: FFI call with no outstanding precondition.
-        if unsafe { windows::Win32::Foundation::GetLastError() }
-            != windows::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER
-        {
-            return Err(anyhow::Error::new(err).context(
-                "first call to CryptCATAdminCalcHashFromFileHandle2 did not fail with ERROR_INSUFFICIENT_BUFFER",
-            ));
-        }
+        }?;
 
         let mut allocated_length = required_size;
         let mut hash = vec![0u8; allocated_length as usize];


### PR DESCRIPTION
The `CryptCATAdminCalcHashFromFileHandle2` [documentation](https://learn.microsoft.com/en-us/windows/win32/api/mscat/nf-mscat-cryptcatadmincalchashfromfilehandle2) says:


>Return value
>
>[...]
>
>ERROR_INSUFFICIENT_BUFFER | The buffer pointed to by the pbHash parameter was not NULL but was not large enough to be written. The correct size of the required buffer is contained in the value pointed to by the pcbHash parameter.

Ergo, the function will **not** return an error when passing a `NULL` value for `pbHash`, it will succeed. This is confusing because other similar Win32 APIs do not work the same way. 