### PR TITLE
fix(pedm): don't panic on missing log_elevation function

### DIFF
--- a/crates/devolutions-pedm/src/log.rs
+++ b/crates/devolutions-pedm/src/log.rs
@@ -2,5 +2,5 @@ use devolutions_pedm_shared::policy::ElevationResult;
 
 // The previous function was commented out. The function call for `log_elevation` in `validate_elevation` still remains.
 pub(crate) fn log_elevation(_res: &ElevationResult) -> anyhow::Result<()> {
-    unimplemented!();
+    Ok(())
 }


### PR DESCRIPTION
The `unimplemented!` macro causes us to panic here, which means elevation is not possible. This is counter productive to a minimum viable implementation (I do not know the current state of elevation logging).