### PR TITLE
feat(pedm): explicitly support elevating .msi files

### DIFF
--- a/crates/win-api-wrappers/Cargo.toml
+++ b/crates/win-api-wrappers/Cargo.toml
@@ -34,6 +34,7 @@ features = [
     "Win32_System_Environment",
     "Win32_System_GroupPolicy",
     "Win32_System_IO",
+    "Win32_System_SystemInformation",
     "Win32_System_Kernel",
     "Win32_System_LibraryLoader",
     "Win32_System_Memory",

--- a/crates/win-api-wrappers/src/fs.rs
+++ b/crates/win-api-wrappers/src/fs.rs
@@ -1,7 +1,11 @@
+use std::ffi::OsString;
+use std::os::windows::ffi::OsStringExt;
 use std::path::Path;
 
 use anyhow::Context as _;
+use windows::Win32::Foundation::MAX_PATH;
 use windows::Win32::Storage::FileSystem;
+use windows::Win32::System::SystemInformation::GetSystemDirectoryW;
 
 use crate::security::attributes::SecurityAttributes;
 use crate::str::{U16CStrExt as _, U16CString};
@@ -13,4 +17,25 @@ pub fn create_directory(path: &Path, security_attributes: Option<&SecurityAttrib
     unsafe { FileSystem::CreateDirectoryW(path.as_pcwstr(), security_attributes.map(|x| x.as_ptr())) }?;
 
     Ok(())
+}
+
+pub fn get_system32_path() -> anyhow::Result<String> {
+    let mut buffer = [0u16; MAX_PATH as usize];
+
+    // SAFETY:
+    // - `buffer.as_mut_ptr()` gives a valid writable pointer for MAX_PATH u16s.
+    // - `GetSystemDirectoryW` expects a valid mutable wide string buffer.
+    let len = unsafe { GetSystemDirectoryW(Some(std::slice::from_raw_parts_mut(buffer.as_mut_ptr(), buffer.len()))) };
+
+    if len == 0 {
+        anyhow::bail!("GetSystemDirectoryW failed");
+    }
+
+    if len as usize >= buffer.len() {
+        anyhow::bail!("buffer too small for system directory path");
+    }
+
+    Ok(OsString::from_wide(&buffer[..len as usize])
+        .to_string_lossy()
+        .into_owned())
 }

--- a/crates/win-api-wrappers/src/security/crypt.rs
+++ b/crates/win-api-wrappers/src/security/crypt.rs
@@ -172,7 +172,7 @@ impl CatalogAdminContext {
         let mut required_size = 0u32;
 
         // SAFETY: `hFile` must not be NULL and must be a valid file pointer. The `file` is not dropped so it should be valid.
-        let res = unsafe {
+        unsafe {
             CryptCATAdminCalcHashFromFileHandle2(
                 self.handle.0 as isize,
                 HANDLE(file.as_raw_handle().cast()),

--- a/package/AgentWindowsManaged/ExplorerCommand.ps1
+++ b/package/AgentWindowsManaged/ExplorerCommand.ps1
@@ -1,0 +1,160 @@
+<#
+    Register or unregister the shell extension from the system context menu.
+
+    This is useful for debugging: unregister the shell extension, swap in your debug DLL, and then re-register
+
+    Must run as administrator
+
+    e.g.
+
+    . ./ExplorerCommand.ps1
+    Register-ExplorerCommand -FilePath "$Env:ProgramFiles\Devolutions\Agent\DevolutionsPedmShellExt.dll" -CLSID "{0ba604fd-4a5a-4abb-92b1-09ac5c3bf356}" -Verb "RunElevated" -MenuText "Run Elevated"
+    Unregister-ExplorerCommand -CLSID "{0ba604fd-4a5a-4abb-92b1-09ac5c3bf356}" -Verb "RunElevated"
+#>
+
+function Register-ExplorerCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$CLSID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Verb,
+
+        [Parameter(Mandatory = $false)]
+        [string]$MenuText = "Run Elevated",
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$Extensions = @(".exe", ".msi", ".lnk", ".ps1", ".bat")  # Restrict to these
+    )
+
+    # Validate the DLL Path
+    if (!(Test-Path $FilePath)) {
+        Write-Error "ERROR: DLL path '$FilePath' does not exist. Exiting."
+        return
+    }
+
+    Write-Host "✅ DLL Path verified: $FilePath" -ForegroundColor Green
+
+    # Register CLSID in HKEY_CLASSES_ROOT\CLSID
+    $clsidPathHKCR = "Registry::HKEY_CLASSES_ROOT\CLSID\$CLSID"
+    if (Test-Path $clsidPathHKCR) {
+        Write-Host "⚠️ CLSID already exists in registry: $CLSID" -ForegroundColor Yellow
+    } else {
+        Write-Host "🆕 Registering CLSID: $CLSID" -ForegroundColor Cyan
+        New-Item -Path $clsidPathHKCR -Force | Out-Null
+        Set-ItemProperty -Path $clsidPathHKCR -Name "(Default)" -Value "PedmShellExt"
+        Write-Host "✅ CLSID registered in HKCR" -ForegroundColor Green
+    }
+
+    # Register InprocServer32
+    $inprocPathHKCR = "$clsidPathHKCR\InprocServer32"
+    if (!(Test-Path $inprocPathHKCR)) {
+        Write-Host "🆕 Registering InprocServer32..." -ForegroundColor Cyan
+        New-Item -Path $inprocPathHKCR -Force | Out-Null
+        Set-ItemProperty -Path $inprocPathHKCR -Name "(Default)" -Value $FilePath
+        Set-ItemProperty -Path $inprocPathHKCR -Name "ThreadingModel" -Value "Apartment"
+        Write-Host "✅ InprocServer32 registered" -ForegroundColor Green
+    }
+
+    # Register Explorer Command for Specific File Extensions
+    foreach ($ext in $Extensions) {
+        $extKeyPath = "Registry::HKEY_CLASSES_ROOT\$ext"
+
+        # Find the associated file class (e.g., exefile for .exe)
+        try {
+            $fileClass = (Get-ItemProperty -Path $extKeyPath -ErrorAction Stop)."(Default)"
+        } catch {
+            Write-Host "⚠️ No registry entry found for $ext. Skipping." -ForegroundColor Yellow
+            continue
+        }
+
+        # If no file class is found, assume the extension itself
+        if (-not $fileClass) { $fileClass = $ext }
+
+        $commandPath = "Registry::HKEY_CLASSES_ROOT\$fileClass\shell\$Verb"
+
+        Write-Host "🆕 Registering ExplorerCommand for: $ext -> $fileClass at $commandPath" -ForegroundColor Cyan
+
+        # Ensure the shell key exists
+        if (!(Test-Path "$commandPath")) {
+            New-Item -Path $commandPath -Force | Out-Null
+        }
+
+        # Set menu text and ExplorerCommandHandler CLSID
+        Set-ItemProperty -Path $commandPath -Name "(Default)" -Value $MenuText
+        Set-ItemProperty -Path $commandPath -Name "ExplorerCommandHandler" -Value $CLSID
+        Set-ItemProperty -Path $commandPath -Name "MUIVerb" -Value "@FilePath,-150"
+    }
+
+    Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+    [System.Runtime.InteropServices.DllImport("shell32.dll")]
+    public static extern void SHChangeNotify(int wEventId, int uFlags, IntPtr dwItem1, IntPtr dwItem2);
+"@
+
+    [Win32.NativeMethods]::SHChangeNotify(0x8000000, 0x1000, [IntPtr]::Zero, [IntPtr]::Zero)
+
+    Write-Host "✅ ExplorerCommand registered successfully for selected file types!" -ForegroundColor Green
+}
+
+function Unregister-ExplorerCommand {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$CLSID,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Verb,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]$Extensions = @(".exe", ".msi", ".lnk", ".ps1", ".bat")  # Restrict to these
+    )
+
+    Write-Host "Unregistering ExplorerCommand with CLSID: $CLSID" -ForegroundColor Yellow
+
+    # Remove CLSID registration
+    $clsidPathHKCR = "Registry::HKEY_CLASSES_ROOT\CLSID\$CLSID"
+    if (Test-Path $clsidPathHKCR) {
+        Remove-Item -Path $clsidPathHKCR -Force -Recurse -ErrorAction SilentlyContinue
+        Write-Host "✅ Removed CLSID from HKCR" -ForegroundColor Green
+    } else {
+        Write-Host "⚠️ CLSID not found in HKCR, skipping." -ForegroundColor Yellow
+    }
+
+    # Remove ExplorerCommand registry entry for specific file types
+    foreach ($ext in $Extensions) {
+        $extKeyPath = "Registry::HKEY_CLASSES_ROOT\$ext"
+
+        # Find the associated file class (e.g., exefile for .exe)
+        try {
+            $fileClass = (Get-ItemProperty -Path $extKeyPath -ErrorAction Stop)."(Default)"
+        } catch {
+            Write-Host "⚠️ No registry entry found for $ext. Skipping." -ForegroundColor Yellow
+            continue
+        }
+
+        # If no file class is found, assume the extension itself
+        if (-not $fileClass) { $fileClass = $ext }
+
+        $commandPath = "Registry::HKEY_CLASSES_ROOT\$fileClass\shell\$Verb"
+
+        if (Test-Path $commandPath) {
+            Write-Host "🗑 Removing ExplorerCommand for: $ext -> $fileClass at $commandPath" -ForegroundColor Cyan
+            Remove-Item -Path $commandPath -Force -Recurse -ErrorAction SilentlyContinue
+        } else {
+            Write-Host "⚠️ No registered menu for $ext ($fileClass), skipping." -ForegroundColor Yellow
+        }
+    }
+
+    Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+    [System.Runtime.InteropServices.DllImport("shell32.dll")]
+    public static extern void SHChangeNotify(int wEventId, int uFlags, IntPtr dwItem1, IntPtr dwItem2);
+"@
+
+    [Win32.NativeMethods]::SHChangeNotify(0x8000000, 0x1000, [IntPtr]::Zero, [IntPtr]::Zero)
+
+    Write-Host "✅ ExplorerCommand unregistered successfully!" -ForegroundColor Cyan
+}


### PR DESCRIPTION
By inspecting elevated .msi files launched from Explorer, we see that Explorer invokes %systemroot%\system32\msiexec, with the command line `"%systemroot%\system32\msiexec" /i "{path-to-msi}"`.

We achieve the same in the PEDM module by using the same command if the file extension is .msi. The .msi extension is already being trapped by the shell extension, but previously we would call `CreateProcess` on the .msi causing "file is not a valid Win32 executable".

Additionally, I polished and added @awakecoding's original "ExplorerCommand.ps1" script. This is useful for debugging, where the installed shell extension can't be overwritten as it's in use by Explorer. Install Devolutions Agent with the PEDM feature; then use the PowerShell to unregistered the shell extension. Swap in your development or debug DLL, then re-register the shell extension. If you supply the .pdb file as well it's possible to attach the debugger to Explorer.exe and debug the shell extension code.