### PR TITLE
wip(pedm): log elevation results

### DIFF
--- a/crates/devolutions-pedm/schema/libsql.sql
+++ b/crates/devolutions-pedm/schema/libsql.sql
@@ -36,4 +36,11 @@ CREATE TABLE IF NOT EXISTS elevate_tmp_request
     seconds integer NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS jit_elevation_result
+(
+    id  integer PRIMARY KEY,
+    success integer NOT NULL,
+    at integer NOT NULL DEFAULT ( CAST(strftime('%s', 'now') AS integer) * 1000000 + CAST(strftime('%f', 'now') * 1000000 AS integer) % 1000000)
+);
+
 INSERT INTO version (version) VALUES (0) ON CONFLICT DO NOTHING;

--- a/crates/devolutions-pedm/src/db/libsql.rs
+++ b/crates/devolutions-pedm/src/db/libsql.rs
@@ -106,6 +106,10 @@ impl Database for LibsqlConn {
         .await?;
         Ok(())
     }
+
+    async fn insert_jit_elevation_result(&self) -> Result<(), DbError> {
+        Ok(())
+    }
 }
 
 /// Converts a timestamp in microseconds to a `DateTime<Utc>`.

--- a/crates/devolutions-pedm/src/db/mod.rs
+++ b/crates/devolutions-pedm/src/db/mod.rs
@@ -197,4 +197,6 @@ pub(crate) trait Database: Send + Sync {
     async fn log_http_request(&self, req_id: i32, method: &str, path: &str, status_code: i16) -> Result<(), DbError>;
 
     async fn insert_elevate_tmp_request(&self, req_id: i32, seconds: i32) -> Result<(), DbError>;
+
+    async fn insert_jit_elevation_result(&self) -> Result<(), DbError>;
 }

--- a/crates/devolutions-pedm/src/db/pg.rs
+++ b/crates/devolutions-pedm/src/db/pg.rs
@@ -98,4 +98,8 @@ impl Database for PgPool {
             .await?;
         Ok(())
     }
+
+    async fn insert_jit_elevation_result(&self) -> Result<(), DbError> {
+        unimplemented!()
+    }
 }

--- a/crates/devolutions-pedm/src/log.rs
+++ b/crates/devolutions-pedm/src/log.rs
@@ -1,6 +1,14 @@
+use std::sync::Arc;
+
 use devolutions_pedm_shared::policy::ElevationResult;
 
+use crate::db;
+
 // The previous function was commented out. The function call for `log_elevation` in `validate_elevation` still remains.
-pub(crate) fn log_elevation(_res: &ElevationResult) -> anyhow::Result<()> {
+pub(crate) fn log_elevation(
+    db: &Arc<(dyn db::Database + Send + Sync + 'static)>,
+    _res: &ElevationResult,
+) -> anyhow::Result<()> {
+    let _ = db.insert_jit_elevation_result();
     Ok(())
 }


### PR DESCRIPTION
### WIP ### 

**Do not merge!**

I want to write the elevation results to a table in the database

I'm trying to pass the `Db` object up to the `log` module so I can record the elevation result.

The final call site looks like this:

```
pub(crate) fn log_elevation(
     db: &Arc<(dyn db::Database + Send + Sync + 'static)>,
     _res: &ElevationResult,
 ) -> anyhow::Result<()> {
     let _ = db.insert_jit_elevation_result();
     Ok(())
 }
```

Because the function `insert_jit_elevation_result` is asynchronous, I don't know how to propagate the result back to the caller without also making this function (and, all the intermediate functions) async as well.