### PR TITLE
feat(dgw): improve system store certificate selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4101,6 +4101,7 @@ dependencies = [
  "sha2",
  "sha3",
  "thiserror 1.0.69",
+ "time",
  "x25519-dalek",
  "zeroize",
 ]
@@ -4126,6 +4127,7 @@ dependencies = [
  "oid",
  "serde",
  "serde_bytes",
+ "time",
  "zeroize",
 ]
 

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -61,7 +61,7 @@ sysinfo = "0.30"
 dunce = "1.0"
 
 # Security, crypto…
-picky = { version = "7.0.0-rc.10", default-features = false, features = ["jose", "x509", "pkcs12"] }
+picky = { version = "7.0.0-rc.10", default-features = false, features = ["jose", "x509", "pkcs12", "time_conversion"] }
 zeroize = { version = "1.8", features = ["derive"] }
 multibase = "0.9"
 argon2 = { version = "0.5", features = ["std"] }


### PR DESCRIPTION
The selection is now discriminating based on the extended key usage and the not valid before date.

- Discriminate based on the extended key usage: certificate is ignored when the "Server Authentication" (1.3.6.1.5.5.7.3.1) key usage is not specified.
- Discriminate based on the "not valid before" date: certificates not yet valid are ignored.
- Added generous logging to observe the selection process in details.

A test was conducted in a setup with the following certificates available in the system store:
- (`0`) A certificate valid between today and April 2027 without the server authentication extended usage.
- (`1`) A certificate valid between today and April 2027 with the server authentication extended usage.
- (`2`) A certificate valid between today and January 2027 with the server authentication extended usage.
- (`3`) A certificate valid between May 2027 and May 2028.
- (`4`) A certificate expired, not valid anymore.

Here is an execution trace:

```
2025-05-15T10:16:53.072540Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Received ClientHello server_name=Some("dgw1.deliciousoden.ninja")
2025-05-15T10:16:53.083720Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Found certificate contexts subject_name=*.deliciousoden.ninja count=5
2025-05-15T10:16:53.084723Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Parsed store certificate idx=0 serial_number=17F4FCBC9ED95867E9ADB1144F23EB67258FDA1F subject=CN=*.deliciousoden.ninja issuer=CN=*.deliciousoden.ninja not_before=2025-05-15 09:28:30 not_after=2027-04-15 09:28:30
2025-05-15T10:16:53.084832Z DEBUG listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Filtered out certificate because it does not have the server auth extended usage idx=0 serial_number=17F4FCBC9ED95867E9ADB1144F23EB67258FDA1F
2025-05-15T10:16:53.085087Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Parsed store certificate idx=1 serial_number=5D3A2C414AF424BE4FCECFADA3327311111EA1D3 subject=CN=*.deliciousoden.ninja issuer=CN=*.deliciousoden.ninja not_before=2025-05-15 09:03:31 not_after=2027-04-15 09:03:31
2025-05-15T10:16:53.085642Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Parsed store certificate idx=2 serial_number=117130DDD5B7BFC1EABB174A9F3149D8AF8F394 subject=CN=*.deliciousoden.ninja issuer=CN=*.deliciousoden.ninja not_before=2025-05-15 09:26:52 not_after=2027-01-05 09:26:52
2025-05-15T10:16:53.085912Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Parsed store certificate idx=3 serial_number=517F0A43874140E7BAB258E6CC67533C78B3B6 subject=CN=*.deliciousoden.ninja issuer=CN=*.deliciousoden.ninja not_before=2027-05-01 00:00:00 not_after=2028-05-01 00:00:00
2025-05-15T10:16:53.085956Z DEBUG listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Filtered out certificate based on not before validity date idx=3 serial_number=517F0A43874140E7BAB258E6CC67533C78B3B6 not_before=2027-05-01 00:00:00
2025-05-15T10:16:53.086144Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Parsed store certificate idx=4 serial_number=4892457B4BA8FC4A476FABEB61E1A322FC2E41A subject=CN=*.deliciousoden.ninja issuer=CN=*.deliciousoden.ninja not_before=2022-01-01 00:00:00 not_after=2023-01-01 00:00:00
2025-05-15T10:16:53.086226Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Sorted certificate sorted_idx=0 idx=1 not_after=2027-04-15 09:03:31
2025-05-15T10:16:53.086258Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Sorted certificate sorted_idx=1 idx=2 not_after=2027-01-05 09:26:52
2025-05-15T10:16:53.086289Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Sorted certificate sorted_idx=2 idx=4 not_after=2023-01-01 00:00:00
2025-05-15T10:16:53.091366Z TRACE listener{port=7171}:https{client=127.0.0.1:56835}: devolutions_gateway::tls::windows: Selected certificate idx=1 not_after=2027-04-15 09:03:31 key_algorithm_group=Ok(Rsa) key_algorithm=Ok("RSA")
```

First (`0`) is disregarded because it is missing the server authentication extended usage, and (`3`) is disregarded because it is not yet valid.
Then certificates are sorted based on the farthest not after validity date: (`1`), (`2`) and (`4`).
Since (`4`) is expired, it ends up at the end of the list.
Ultimately (`1`) is selected because it has the farthest validity date.

For the sake of completeness, here are the certificates: [deliciousoden.ninja_certificates.zip](https://github.com/user-attachments/files/20226597/deliciousoden.ninja_certificates.zip)
The password on the PFX files is `abc`.

Issue: DGW-262