### PR TITLE
chore: use workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ exclude = [
     "crates/sogar-registry"
 ]
 
+[workspace.package]
+version = "2025.1.5"
+
+
 [profile.profiling]
 inherits = "release"
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ exclude = [
 [workspace.package]
 version = "2025.1.5"
 
-
 [profile.profiling]
 inherits = "release"
 debug = 1

--- a/crates/devolutions-pedm-shell-ext/Cargo.toml
+++ b/crates/devolutions-pedm-shell-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-pedm-shell-ext"
-version = "2025.1.5"
+version.workspace = true
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Devolutions Inc. <infos@devolutions.net>"]

--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-agent"
-version = "2025.1.5"
+version.workspace = true
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Devolutions Inc. <infos@devolutions.net>"]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-gateway"
-version = "2025.1.5"
+version.workspace = true
 edition = "2021"
 readme = "README.md"
 license = "MIT/Apache-2.0"

--- a/devolutions-session/Cargo.toml
+++ b/devolutions-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devolutions-session"
-version = "2025.1.5"
+version.workspace = true
 edition = "2021"
 license = "MIT/Apache-2.0"
 authors = ["Devolutions Inc. <infos@devolutions.net>"]

--- a/jetsocat/Cargo.toml
+++ b/jetsocat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetsocat"
-version = "2025.1.5"
+version.workspace = true
 authors = ["Devolutions Inc. <infos@devolutions.net>"]
 edition = "2021"
 description = "(Web)Socket toolkit for jet protocol related operations"


### PR DESCRIPTION
This sets the version in one place.

This will make endpoints that return the version, such as `/about` in PEDM, return a consistent version based on `CARGO_PKG_VERSION`.

A PR will follow to bump the `devolutions-pedm` version (currently 0.0.0).