### PR TITLE
fix(pedm): ensure get_last_request_time has a value

### DIFF
--- a/crates/devolutions-pedm/src/api/about.rs
+++ b/crates/devolutions-pedm/src/api/about.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 use aide::NoApi;
 use axum::extract::State;
 use axum::Json;
+use chrono::{TimeZone, Utc};
 
 use crate::db::Db;
 use crate::model::AboutData;
@@ -20,7 +21,10 @@ pub(crate) async fn about(
         start_time: state.startup_info.start_time,
         startup_request_count: state.startup_info.request_count,
         current_request_count: state.req_counter.load(Ordering::Relaxed),
-        last_request_time: db.get_last_request_time().await?,
+        last_request_time: db
+            .get_last_request_time()
+            .await?
+            .or_else(|| Some(Utc.timestamp_opt(0, 0).single().unwrap())),
         version: win_api_wrappers::utils::get_exe_version()?,
     }))
 }


### PR DESCRIPTION
The comments for [AboutData](https://github.com/Devolutions/devolutions-gateway/blob/668e0b43edd5ee2ce4cbf4692920c09d732eeb85/crates/devolutions-pedm/src/model.rs#L7) say

> This can be `None` if `/about` is the first request made.

Which is true and correct; but is causing a crash in the .NET OpenAPI client if /about is the first request made.

For whatever reason, the .NET OpenAPI [generator](https://github.com/Devolutions/devolutions-gateway/blob/668e0b43edd5ee2ce4cbf4692920c09d732eeb85/crates/devolutions-pedm/openapi/dotnet-client/src/Devolutions.Pedm.Client/Model/AboutData.cs#L74) is not creating a nullable property.

This may be related to the issues I had in #1164, but I don't have time to dig into it now. Since this is non-critical / non-user facing; I just force a value here for the first request (the UNIX epoch seems reasonable).