### PR TITLE
chore: clippy fixes for win-api-wrappers

### DIFF
--- a/crates/win-api-wrappers/src/identity/account.rs
+++ b/crates/win-api-wrappers/src/identity/account.rs
@@ -347,8 +347,10 @@ pub fn lookup_account_by_name(account_name: &U16CStr) -> windows::core::Result<A
 pub fn enumerate_account_rights(sid: &Sid) -> anyhow::Result<Vec<U16CString>> {
     // Open the local security policy (LSA Policy)
 
-    let mut object_attrs = Identity::LSA_OBJECT_ATTRIBUTES::default();
-    object_attrs.Length = u32size_of::<Identity::LSA_OBJECT_ATTRIBUTES>();
+    let object_attrs = Identity::LSA_OBJECT_ATTRIBUTES {
+        Length: u32size_of::<Identity::LSA_OBJECT_ATTRIBUTES>(),
+        ..Default::default()
+    };
 
     let mut policy_handle = ScopeGuard::new(Identity::LSA_HANDLE::default(), |handle| {
         // FIXME: maybe we should log the error here.

--- a/crates/win-api-wrappers/src/utils.rs
+++ b/crates/win-api-wrappers/src/utils.rs
@@ -457,7 +457,7 @@ pub fn expand_environment_path(src: &Path, environment: &HashMap<String, String>
     ))?)
 }
 
-use windows::Win32::Foundation::{BOOL, HMODULE};
+use windows::Win32::Foundation::HMODULE;
 use windows::Win32::Storage::FileSystem::{
     GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
 };
@@ -514,9 +514,9 @@ pub fn get_exe_version() -> Result<String, anyhow::Error> {
     }
 
     let major = (info.dwFileVersionMS >> 16) & 0xffff;
-    let minor = (info.dwFileVersionMS >> 0) & 0xffff;
+    let minor = info.dwFileVersionMS & 0xffff;
     let build = (info.dwFileVersionLS >> 16) & 0xffff;
-    let revision = (info.dwFileVersionLS >> 0) & 0xffff;
+    let revision = info.dwFileVersionLS & 0xffff;
 
     Ok(format!("{}.{}.{}.{}", major, minor, build, revision))
 }


### PR DESCRIPTION
This fixes a few but not all Clippy lints.