### PR TITLE
feat(dgw): proxy-based credentials injection support for RDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,12 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-util",
- "ironrdp-core 0.1.0",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf)",
+ "ironrdp-acceptor 0.5.0",
+ "ironrdp-connector 0.5.0",
+ "ironrdp-core",
+ "ironrdp-pdu 0.5.0",
  "ironrdp-rdcleanpath",
+ "ironrdp-tokio 0.4.0",
  "jmux-proxy",
  "job-queue",
  "job-queue-libsql",
@@ -1246,6 +1249,7 @@ dependencies = [
  "utoipa",
  "uuid",
  "video-streamer",
+ "x509-cert",
  "zeroize",
 ]
 
@@ -2544,7 +2548,7 @@ name = "ironrdp"
 version = "0.5.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
- "ironrdp-acceptor",
+ "ironrdp-acceptor 0.1.0",
  "ironrdp-server",
 ]
 
@@ -2553,10 +2557,24 @@ name = "ironrdp-acceptor"
 version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
- "ironrdp-async",
- "ironrdp-connector",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-svc",
+ "ironrdp-async 0.1.0",
+ "ironrdp-connector 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-acceptor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad348cb50d990c23b7c6f4f8f4c42b6678d5d0c6d7acd57f14685b41d77d9ff7"
+dependencies = [
+ "ironrdp-async 0.5.0",
+ "ironrdp-connector 0.5.0",
+ "ironrdp-core",
+ "ironrdp-pdu 0.5.0",
+ "ironrdp-svc 0.4.0",
  "tracing",
 ]
 
@@ -2567,7 +2585,7 @@ source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d89300
 dependencies = [
  "bitflags 2.9.0",
  "ironrdp-dvc",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
+ "ironrdp-pdu 0.1.0",
  "num-derive",
  "num-traits",
 ]
@@ -2578,8 +2596,21 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "bytes 1.10.1",
- "ironrdp-connector",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
+ "ironrdp-connector 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "ironrdp-async"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb8b3d345988b6791fd780befc08df35c81a030603e4588c6fb9bf4b14dd3ab"
+dependencies = [
+ "bytes 1.10.1",
+ "ironrdp-connector 0.5.0",
+ "ironrdp-core",
+ "ironrdp-pdu 0.5.0",
  "tracing",
 ]
 
@@ -2589,8 +2620,8 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "bitflags 2.9.0",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-svc",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -2600,29 +2631,40 @@ name = "ironrdp-connector"
 version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-svc",
+ "ironrdp-error 0.1.0",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "rand_core 0.6.4",
- "sspi",
+ "sspi 0.11.1",
  "tracing",
  "url",
  "winapi",
 ]
 
 [[package]]
-name = "ironrdp-core"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf#7c268d863048d0a9182b3f7bf778668de8db4ccf"
+name = "ironrdp-connector"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17af84fc181aa27c142459606ba4ada6f99cf1f4efed7ba622d7e7d20840b30f"
 dependencies = [
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf)",
+ "ironrdp-core",
+ "ironrdp-error 0.1.2",
+ "ironrdp-pdu 0.5.0",
+ "ironrdp-svc 0.4.0",
+ "picky",
+ "picky-asn1-der 0.5.2",
+ "picky-asn1-x509 0.14.3",
+ "rand_core 0.6.4",
+ "sspi 0.15.7",
+ "tracing",
+ "url",
 ]
 
 [[package]]
 name = "ironrdp-core"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c0fd3307a9cc576741cbcc1fdf4d94289ab127cb69692228cfb921829f0eb2"
+checksum = "b2db60a59716a84d09040d29c9e75e81545842510fccb0934c09b28e78b46680"
 dependencies = [
  "ironrdp-error 0.1.2",
 ]
@@ -2633,8 +2675,8 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "ironrdp-dvc",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-svc",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "tracing",
 ]
 
@@ -2643,8 +2685,8 @@ name = "ironrdp-dvc"
 version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-svc",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "slab",
  "tracing",
 ]
@@ -2653,11 +2695,6 @@ dependencies = [
 name = "ironrdp-error"
 version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
-
-[[package]]
-name = "ironrdp-error"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf#7c268d863048d0a9182b3f7bf778668de8db4ccf"
 
 [[package]]
 name = "ironrdp-error"
@@ -2674,8 +2711,8 @@ dependencies = [
  "bitflags 2.9.0",
  "bitvec",
  "byteorder",
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
+ "ironrdp-error 0.1.0",
+ "ironrdp-pdu 0.1.0",
  "lazy_static",
  "num-derive",
  "num-traits",
@@ -2691,7 +2728,7 @@ dependencies = [
  "bitflags 2.9.0",
  "byteorder",
  "der-parser",
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
+ "ironrdp-error 0.1.0",
  "md-5",
  "num-bigint",
  "num-derive",
@@ -2706,15 +2743,16 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-pdu"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf#7c268d863048d0a9182b3f7bf778668de8db4ccf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc69c5d6ad3399965e0d3762886857f5861d4d854efe8d2bfc3462eb2b2b555a"
 dependencies = [
  "bit_field",
  "bitflags 2.9.0",
  "byteorder",
  "der-parser",
- "ironrdp-core 0.1.0",
- "ironrdp-error 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf)",
+ "ironrdp-core",
+ "ironrdp-error 0.1.2",
  "md-5",
  "num-bigint",
  "num-derive",
@@ -2729,8 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "ironrdp-rdcleanpath"
-version = "0.1.0"
-source = "git+https://github.com/Devolutions/IronRDP?rev=7c268d863048d0a9182b3f7bf778668de8db4ccf#7c268d863048d0a9182b3f7bf778668de8db4ccf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3f5401de43e86384ac0f7f356af8c0bdc321671853f76095da5d480d6998e0"
 dependencies = [
  "der",
 ]
@@ -2741,8 +2780,8 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "bitflags 2.9.0",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
- "ironrdp-svc",
+ "ironrdp-pdu 0.1.0",
+ "ironrdp-svc 0.1.0",
  "tracing",
 ]
 
@@ -2753,16 +2792,16 @@ source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d89300
 dependencies = [
  "anyhow",
  "async-trait",
- "ironrdp-acceptor",
+ "ironrdp-acceptor 0.1.0",
  "ironrdp-ainput",
  "ironrdp-cliprdr",
  "ironrdp-displaycontrol",
  "ironrdp-dvc",
  "ironrdp-graphics",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
+ "ironrdp-pdu 0.1.0",
  "ironrdp-rdpsnd",
- "ironrdp-svc",
- "ironrdp-tokio",
+ "ironrdp-svc 0.1.0",
+ "ironrdp-tokio 0.1.0",
  "tokio 1.45.0",
  "tokio-rustls",
  "tracing",
@@ -2774,7 +2813,18 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "bitflags 2.9.0",
- "ironrdp-pdu 0.1.0 (git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861)",
+ "ironrdp-pdu 0.1.0",
+]
+
+[[package]]
+name = "ironrdp-svc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcca9d5182ebd60d888fac289480db1e1f1d53598108a8a5797e2013b8b2afe2"
+dependencies = [
+ "bitflags 2.9.0",
+ "ironrdp-core",
+ "ironrdp-pdu 0.5.0",
 ]
 
 [[package]]
@@ -2783,7 +2833,18 @@ version = "0.1.0"
 source = "git+https://github.com/Devolutions/IronRDP?rev=2e1a9ac88e38e7d92d893007bc25d0a05c365861#2e1a9ac88e38e7d92d893007bc25d0a05c365861"
 dependencies = [
  "bytes 1.10.1",
- "ironrdp-async",
+ "ironrdp-async 0.1.0",
+ "tokio 1.45.0",
+]
+
+[[package]]
+name = "ironrdp-tokio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55e49a72da0632d87a456a21f70e0ae276122ff43484929f1028fb70c355c7b4"
+dependencies = [
+ "bytes 1.10.1",
+ "ironrdp-async 0.5.0",
  "tokio 1.45.0",
 ]
 
@@ -3701,7 +3762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063dca685ea8efa62d1a3566332b08be0198922f1d8aced1ead413c9f02fd89e"
 dependencies = [
  "bitflags 2.9.0",
- "ironrdp-core 0.1.4",
+ "ironrdp-core",
  "ironrdp-error 0.1.2",
 ]
 
@@ -4082,6 +4143,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hmac",
+ "http 1.3.1",
  "md-5",
  "num-bigint-dig",
  "p256",
@@ -4179,6 +4241,7 @@ dependencies = [
  "picky-asn1 0.10.1",
  "picky-asn1-der 0.5.2",
  "serde",
+ "widestring 1.2.0",
  "zeroize",
 ]
 
@@ -4987,6 +5050,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha1",
  "signature",
  "spki",
  "subtle",
@@ -5671,6 +5735,50 @@ dependencies = [
  "windows 0.51.1",
  "windows-sys 0.48.0",
  "winreg 0.51.0",
+ "zeroize",
+]
+
+[[package]]
+name = "sspi"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334391dc5b51751fd80c960b8a40dc8862b903ce41d3b848f154b72ac47ed119"
+dependencies = [
+ "async-dnssd",
+ "async-recursion",
+ "bitflags 2.9.0",
+ "byteorder",
+ "cfg-if",
+ "crypto-mac",
+ "futures",
+ "hmac",
+ "lazy_static",
+ "md-5",
+ "md4",
+ "num-bigint-dig",
+ "num-derive",
+ "num-traits",
+ "oid",
+ "picky",
+ "picky-asn1 0.10.1",
+ "picky-asn1-der 0.5.2",
+ "picky-asn1-x509 0.14.3",
+ "picky-krb 0.9.4",
+ "rand 0.8.5",
+ "rsa",
+ "rustls 0.23.27",
+ "serde",
+ "serde_derive",
+ "sha1",
+ "sha2",
+ "time",
+ "tokio 1.45.0",
+ "tracing",
+ "url",
+ "uuid",
+ "windows 0.61.1",
+ "windows-sys 0.59.0",
+ "winreg 0.55.0",
  "zeroize",
 ]
 
@@ -6739,7 +6847,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -7084,6 +7194,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.0",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.0",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7125,6 +7257,16 @@ dependencies = [
  "windows-link",
  "windows-result 0.3.2",
  "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1d6bbefcb7b60acd19828e1bc965da6fcf18a7e39490c5f8be71e54a19ba32"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -7176,6 +7318,16 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.0",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -7589,6 +7741,16 @@ checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -26,9 +26,12 @@ devolutions-gateway-task = { path = "../crates/devolutions-gateway-task" }
 devolutions-log = { path = "../crates/devolutions-log" }
 job-queue = { path = "../crates/job-queue" }
 job-queue-libsql = { path = "../crates/job-queue-libsql" }
-ironrdp-pdu = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "7c268d863048d0a9182b3f7bf778668de8db4ccf", features = ["std"] }
-ironrdp-core = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "7c268d863048d0a9182b3f7bf778668de8db4ccf", features = ["std"] }
-ironrdp-rdcleanpath = { version = "0.1", git = "https://github.com/Devolutions/IronRDP", rev = "7c268d863048d0a9182b3f7bf778668de8db4ccf" }
+ironrdp-pdu = { version = "0.5", features = ["std"] }
+ironrdp-core = { version = "0.1", features = ["std"] }
+ironrdp-rdcleanpath = "0.1"
+ironrdp-tokio = { version = "0.4", default-features = false }
+ironrdp-connector = { version = "0.5" }
+ironrdp-acceptor = { version = "0.5" }
 ceviche = "0.6.1"
 picky-krb = "0.9"
 network-scanner = { version = "0.0.0", path = "../crates/network-scanner" }
@@ -65,6 +68,7 @@ picky = { version = "7.0.0-rc.10", default-features = false, features = ["jose",
 zeroize = { version = "1.8", features = ["derive"] }
 multibase = "0.9"
 argon2 = { version = "0.5", features = ["std"] }
+x509-cert = { version = "0.2", default-features = false, features = ["std"] }
 
 # Logging
 tracing = "0.1"

--- a/devolutions-gateway/src/api/fwd.rs
+++ b/devolutions-gateway/src/api/fwd.rs
@@ -249,7 +249,7 @@ where
 
             // Establish TLS connection with server
 
-            let server_stream = crate::tls::connect(selected_target.host(), server_stream)
+            let server_stream = crate::tls::connect(selected_target.host().to_owned(), server_stream)
                 .await
                 .context("TLS connect")
                 .map_err(ForwardError::BadGateway)?;

--- a/devolutions-gateway/src/api/preflight.rs
+++ b/devolutions-gateway/src/api/preflight.rs
@@ -124,6 +124,8 @@ pub(crate) enum PreflightAlertStatus {
     GeneralFailure,
     #[serde(rename = "info")]
     Info,
+    #[serde(rename = "warn")]
+    Warn,
     #[serde(rename = "unsupported-operation")]
     UnsupportedOperation,
     #[serde(rename = "invalid-parameters")]
@@ -336,6 +338,17 @@ async fn handle_operation(
                     kind: PreflightOutputKind::Alert {
                         status: PreflightAlertStatus::Info,
                         message: "an existing credential entry was replaced".to_owned(),
+                    },
+                });
+            }
+
+            if conf.tls.is_none() && operation.kind.as_str() == OP_PROVISION_CREDENTIALS {
+                outputs.push(PreflightOutput {
+                    operation_id: operation.id,
+                    kind: PreflightOutputKind::Alert {
+                        status: PreflightAlertStatus::Warn,
+                        message: "no TLS certificate configured, this may cause problems with credentials injection"
+                            .to_owned(),
                     },
                 });
             }

--- a/devolutions-gateway/src/api/rdp.rs
+++ b/devolutions-gateway/src/api/rdp.rs
@@ -69,7 +69,7 @@ async fn handle_socket(
         Duration::from_secs(conf.debug.ws_keep_alive_interval),
     );
 
-    let result = crate::rdp_extension::handle(
+    let result = crate::rd_clean_path::handle(
         stream,
         source_addr,
         conf,

--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -7,12 +7,13 @@ use tracing::field;
 use typed_builder::TypedBuilder;
 
 use crate::config::Conf;
+use crate::credential::CredentialStoreHandle;
 use crate::proxy::Proxy;
 use crate::rdp_pcb::{extract_association_claims, read_pcb};
 use crate::recording::ActiveRecordings;
 use crate::session::{ConnectionModeDetails, SessionInfo, SessionMessageSender};
 use crate::subscriber::SubscriberSender;
-use crate::token::{ConnectionMode, CurrentJrl, RecordingPolicy, TokenCache};
+use crate::token::{self, ConnectionMode, CurrentJrl, RecordingPolicy, TokenCache};
 use crate::utils;
 
 #[derive(TypedBuilder)]
@@ -25,11 +26,12 @@ pub struct GenericClient<S> {
     sessions: SessionMessageSender,
     subscriber_tx: SubscriberSender,
     active_recordings: Arc<ActiveRecordings>,
+    credential_store: CredentialStoreHandle,
 }
 
 impl<S> GenericClient<S>
 where
-    S: AsyncWrite + AsyncRead + Unpin,
+    S: AsyncWrite + AsyncRead + Unpin + Send + Sync,
 {
     #[instrument(
         "generic_client",
@@ -46,6 +48,7 @@ where
             sessions,
             subscriber_tx,
             active_recordings,
+            credential_store,
         } = self;
 
         let span = tracing::Span::current();
@@ -53,7 +56,7 @@ where
         let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(10));
         let read_pcb_fut = read_pcb(&mut client_stream);
 
-        let (pdu, mut leftover_bytes) = tokio::select! {
+        let (pcb, mut leftover_bytes) = tokio::select! {
             () = timeout => {
                 info!("Timed out at preconnection blob reception");
                 return Ok(())
@@ -69,8 +72,14 @@ where
             }
         };
 
+        let token = pcb.v2_payload.as_deref().context("V2 payload missing from RDP PCB")?;
+
+        if conf.debug.dump_tokens {
+            debug!(token, "**DEBUG OPTION**");
+        }
+
         let source_ip = client_addr.ip();
-        let claims = extract_association_claims(&pdu, source_ip, &conf, &token_cache, &jrl, &active_recordings)?;
+        let claims = extract_association_claims(token, source_ip, &conf, &token_cache, &jrl, &active_recordings)?;
 
         span.record("session_id", claims.jet_aid.to_string())
             .record("protocol", claims.jet_ap.to_string());
@@ -93,12 +102,7 @@ where
                 trace!(%selected_target, "Connected");
                 span.record("target", selected_target.to_string());
 
-                info!("TCP forwarding");
-
-                server_stream
-                    .write_buf(&mut leftover_bytes)
-                    .await
-                    .context("failed to write leftover bytes")?;
+                let is_rdp = claims.jet_ap == token::ApplicationProtocol::Known(token::Protocol::Rdp);
 
                 let info = SessionInfo::builder()
                     .association_id(claims.jet_aid)
@@ -110,6 +114,44 @@ where
                     .recording_policy(claims.jet_rec)
                     .filtering_policy(claims.jet_flt)
                     .build();
+
+                // We support proxy-based credential injection for RDP.
+                // If a credential mapping has been pushed, we automatically switch to this mode.
+                // Otherwise, we continue the generic procedure.
+                if is_rdp {
+                    let token_id = token::extract_jti(token).context("failed to extract jti claim from token")?;
+
+                    if let Some(entry) = credential_store.get(token_id) {
+                        anyhow::ensure!(token == entry.token, "token mismatch");
+
+                        // NOTE: In the future, we could imagine performing proxy-based recording as well using RdpProxy.
+                        if entry.mapping.is_some() {
+                            return crate::rdp_proxy::RdpProxy::builder()
+                                .conf(conf)
+                                .session_info(info)
+                                .client_addr(client_addr)
+                                .client_stream(client_stream)
+                                .server_addr(server_addr)
+                                .server_stream(server_stream)
+                                .sessions(sessions)
+                                .subscriber_tx(subscriber_tx)
+                                .credential_entry(entry)
+                                .client_stream_leftover_bytes(leftover_bytes)
+                                .server_dns_name(selected_target.host().to_owned())
+                                .build()
+                                .run()
+                                .await
+                                .context("encountered a failure during RDP proxying (credential injection)");
+                        }
+                    }
+                }
+
+                info!("TCP forwarding");
+
+                server_stream
+                    .write_buf(&mut leftover_bytes)
+                    .await
+                    .context("failed to write leftover bytes")?;
 
                 Proxy::builder()
                     .conf(conf)

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -28,7 +28,7 @@ pub mod middleware;
 pub mod ngrok;
 pub mod plugin_manager;
 pub mod proxy;
-pub mod rdp_extension;
+pub mod rd_clean_path;
 pub mod rdp_pcb;
 pub mod recording;
 pub mod session;

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -30,6 +30,7 @@ pub mod plugin_manager;
 pub mod proxy;
 pub mod rd_clean_path;
 pub mod rdp_pcb;
+pub mod rdp_proxy;
 pub mod recording;
 pub mod session;
 pub mod streaming;

--- a/devolutions-gateway/src/listener.rs
+++ b/devolutions-gateway/src/listener.rs
@@ -155,6 +155,7 @@ async fn handle_tcp_peer(stream: TcpStream, state: DgwState, peer_addr: SocketAd
                 .sessions(state.sessions)
                 .subscriber_tx(state.subscriber_tx)
                 .active_recordings(state.recordings.active_recordings)
+                .credential_store(state.credential_store)
                 .build()
                 .serve()
                 .await?;

--- a/devolutions-gateway/src/ngrok.rs
+++ b/devolutions-gateway/src/ngrok.rs
@@ -233,6 +233,7 @@ async fn run_tcp_tunnel(mut tunnel: ngrok::tunnel::TcpTunnel, state: DgwState) {
                         .sessions(state.sessions)
                         .subscriber_tx(state.subscriber_tx)
                         .active_recordings(state.recordings.active_recordings)
+                        .credential_store(state.credential_store)
                         .build()
                         .serve()
                         .await

--- a/devolutions-gateway/src/rd_clean_path.rs
+++ b/devolutions-gateway/src/rd_clean_path.rs
@@ -237,7 +237,7 @@ async fn process_cleanpath(
 
     // Establish TLS connection with server
 
-    let server_stream = crate::tls::connect(selected_target.host(), server_stream)
+    let server_stream = crate::tls::connect(selected_target.host().to_owned(), server_stream)
         .await
         .map_err(|source| CleanPathError::TlsHandshake {
             source,
@@ -321,7 +321,7 @@ pub async fn handle(
         .recording_policy(claims.jet_rec)
         .build();
 
-    info!("RDP-TLS forwarding");
+    info!("RDP-TLS forwarding (RDCleanPath)");
 
     Proxy::builder()
         .conf(conf)

--- a/devolutions-gateway/src/rdp_pcb.rs
+++ b/devolutions-gateway/src/rdp_pcb.rs
@@ -11,19 +11,13 @@ use crate::recording::ActiveRecordings;
 use crate::token::{AccessTokenClaims, AssociationTokenClaims, CurrentJrl, TokenCache, TokenValidator};
 
 pub fn extract_association_claims(
-    pcb: &PreconnectionBlob,
+    token: &str,
     source_ip: IpAddr,
     conf: &Conf,
     token_cache: &TokenCache,
     jrl: &CurrentJrl,
     active_recordings: &ActiveRecordings,
 ) -> anyhow::Result<AssociationTokenClaims> {
-    let token = pcb.v2_payload.as_deref().context("V2 payload missing from RDP PCB")?;
-
-    if conf.debug.dump_tokens {
-        debug!(token, "**DEBUG OPTION**");
-    }
-
     let delegation_key = conf.delegation_private_key.as_ref();
 
     let claims = if conf.debug.disable_token_validation {

--- a/devolutions-gateway/src/rdp_proxy.rs
+++ b/devolutions-gateway/src/rdp_proxy.rs
@@ -1,0 +1,573 @@
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use crate::config::Conf;
+use crate::credential::{AppCredentialMapping, ArcCredentialEntry};
+use crate::proxy::Proxy;
+use crate::session::{SessionInfo, SessionMessageSender};
+use crate::subscriber::SubscriberSender;
+
+use anyhow::Context as _;
+use ironrdp_pdu::{mcs, nego, x224};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use typed_builder::TypedBuilder;
+
+#[derive(TypedBuilder)]
+pub struct RdpProxy<C, S> {
+    conf: Arc<Conf>,
+    session_info: SessionInfo,
+    client_stream: C,
+    client_addr: SocketAddr,
+    server_stream: S,
+    server_addr: SocketAddr,
+    credential_entry: ArcCredentialEntry,
+    client_stream_leftover_bytes: bytes::BytesMut,
+    sessions: SessionMessageSender,
+    subscriber_tx: SubscriberSender,
+    server_dns_name: String,
+}
+
+impl<A, B> RdpProxy<A, B>
+where
+    A: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+    B: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+{
+    pub async fn run(self) -> anyhow::Result<()> {
+        handle(self).await
+    }
+}
+
+#[instrument("rdp_proxy", skip_all, fields(session_id = proxy.session_info.association_id.to_string(), target = proxy.server_addr.to_string()))]
+async fn handle<C, S>(proxy: RdpProxy<C, S>) -> anyhow::Result<()>
+where
+    C: AsyncRead + AsyncWrite + Unpin + Send + Sync,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync,
+{
+    let RdpProxy {
+        conf,
+        session_info,
+        client_stream,
+        client_addr,
+        server_stream,
+        server_addr,
+        credential_entry,
+        client_stream_leftover_bytes,
+        sessions,
+        subscriber_tx,
+        server_dns_name,
+    } = proxy;
+
+    let tls_conf = conf
+        .tls
+        .as_ref()
+        .context("TLS configuration required for credential injection feature")?;
+
+    let credential_mapping = credential_entry.mapping.as_ref().context("no credential mapping")?;
+
+    // -- Retrieve the Gateway TLS public key that must be used for client-proxy CredSSP later on -- //
+
+    let gateway_public_key_handle = tokio::spawn(get_cached_gateway_public_key(
+        conf.hostname.clone(),
+        tls_conf.acceptor.clone(),
+    ));
+
+    // -- Dual handshake with the client and the server until the TLS security upgrade -- //
+
+    let mut client_framed = ironrdp_tokio::TokioFramed::new_with_leftover(client_stream, client_stream_leftover_bytes);
+    let mut server_framed = ironrdp_tokio::TokioFramed::new(server_stream);
+
+    let handshake_result =
+        dual_handshake_until_tls_upgrade(&mut client_framed, &mut server_framed, credential_mapping).await?;
+
+    let client_stream = client_framed.into_inner_no_leftover();
+    let server_stream = server_framed.into_inner_no_leftover();
+
+    // -- Perform the TLS upgrading for both the client and the server, effectively acting as a man-in-the-middle -- //
+
+    let client_tls_upgrade_fut = tls_conf.acceptor.accept(client_stream);
+    let server_tls_upgrade_fut = crate::tls::connect(server_dns_name.clone(), server_stream);
+
+    let (client_stream, server_stream) = tokio::join!(client_tls_upgrade_fut, server_tls_upgrade_fut);
+
+    let client_stream = client_stream.context("TLS upgrade with client failed")?;
+    let server_stream = server_stream.context("TLS upgrade with server failed")?;
+
+    let server_public_key =
+        extract_tls_server_public_key(&server_stream).context("extract target server TLS public key")?;
+    let gateway_public_key = gateway_public_key_handle.await??;
+
+    // -- Perform the CredSSP authentication with the client (acting as a server) and the server (acting as a client) -- //
+
+    let mut client_framed = ironrdp_tokio::TokioFramed::new(client_stream);
+    let mut server_framed = ironrdp_tokio::TokioFramed::new(server_stream);
+
+    let client_credssp_fut = perform_credssp_with_client(
+        &mut client_framed,
+        client_addr.ip(),
+        gateway_public_key,
+        handshake_result.client_security_protocol,
+        &credential_mapping.proxy,
+    );
+
+    let server_credssp_fut = perform_credssp_with_server(
+        &mut server_framed,
+        server_dns_name,
+        server_public_key,
+        handshake_result.server_security_protocol,
+        &credential_mapping.target,
+    );
+
+    let (client_credssp_res, server_credssp_res) = tokio::join!(client_credssp_fut, server_credssp_fut);
+    client_credssp_res.context("CredSSP with client")?;
+    server_credssp_res.context("CredSSP with server")?;
+
+    // -- Intercept the Connect Confirm PDU, to override the server_security_protocol field -- //
+
+    intercept_connect_confirm(
+        &mut client_framed,
+        &mut server_framed,
+        handshake_result.server_security_protocol,
+    )
+    .await?;
+
+    let (mut client_stream, client_leftover) = client_framed.into_inner();
+    let (mut server_stream, server_leftover) = server_framed.into_inner();
+
+    // -- At this point, proceed to the usual two-way forwarding -- //
+
+    info!("RDP-TLS forwarding (credential injection)");
+
+    client_stream
+        .write_all(&server_leftover)
+        .await
+        .context("write server leftover to client")?;
+
+    server_stream
+        .write_all(&client_leftover)
+        .await
+        .context("write client leftover to server")?;
+
+    Proxy::builder()
+        .conf(conf)
+        .session_info(session_info)
+        .address_a(client_addr)
+        .transport_a(client_stream)
+        .address_b(server_addr)
+        .transport_b(server_stream)
+        .sessions(sessions)
+        .subscriber_tx(subscriber_tx)
+        .build()
+        .select_dissector_and_forward()
+        .await
+        .context("RDP-TLS traffic proxying failed")?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct HandshakeResult {
+    client_security_protocol: nego::SecurityProtocol,
+    server_security_protocol: nego::SecurityProtocol,
+}
+
+#[instrument(level = "debug", ret, skip_all)]
+async fn intercept_connect_confirm<C, S>(
+    client_framed: &mut ironrdp_tokio::TokioFramed<C>,
+    server_framed: &mut ironrdp_tokio::TokioFramed<S>,
+    server_security_protocol: nego::SecurityProtocol,
+) -> anyhow::Result<()>
+where
+    C: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+    S: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+{
+    let (_, received_frame) = client_framed
+        .read_pdu()
+        .await
+        .context("read MCS Connect Initial from client")?;
+    let received_connect_initial: x224::X224<x224::X224Data<'_>> =
+        ironrdp_core::decode(&received_frame).context("decode PDU from client")?;
+    let mut received_connect_initial: mcs::ConnectInitial =
+        ironrdp_core::decode(&received_connect_initial.0.data).context("decode Connect Initial PDU")?;
+    trace!(message = ?received_connect_initial, "Received Connect Initial PDU from client");
+
+    received_connect_initial
+        .conference_create_request
+        .gcc_blocks
+        .core
+        .optional_data
+        .server_selected_protocol = Some(server_security_protocol);
+    trace!(message = ?received_connect_initial, "Send Connection Request PDU to server");
+    let x224_msg_buf = ironrdp_core::encode_vec(&received_connect_initial)?;
+    let pdu = x224::X224Data {
+        data: std::borrow::Cow::Owned(x224_msg_buf),
+    };
+    send_pdu(server_framed, &x224::X224(pdu))
+        .await
+        .context("send connection request to server")?;
+
+    Ok(())
+}
+
+#[instrument(name = "dual_handshake", level = "debug", ret, skip_all)]
+async fn dual_handshake_until_tls_upgrade<C, S>(
+    client_framed: &mut ironrdp_tokio::TokioFramed<C>,
+    server_framed: &mut ironrdp_tokio::TokioFramed<S>,
+    mapping: &AppCredentialMapping,
+) -> anyhow::Result<HandshakeResult>
+where
+    C: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+    S: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+{
+    let (_, received_frame) = client_framed.read_pdu().await.context("read PDU from client")?;
+    let received_connection_request: x224::X224<nego::ConnectionRequest> =
+        ironrdp_core::decode(&received_frame).context("decode PDU from client")?;
+    trace!(message = ?received_connection_request, "Received Connection Request PDU from client");
+
+    // Choose the security protocol to use with the client.
+    let client_security_protocol = if received_connection_request
+        .0
+        .protocol
+        .contains(nego::SecurityProtocol::HYBRID_EX)
+    {
+        nego::SecurityProtocol::HYBRID_EX
+    } else if received_connection_request
+        .0
+        .protocol
+        .contains(nego::SecurityProtocol::HYBRID)
+    {
+        nego::SecurityProtocol::HYBRID
+    } else {
+        anyhow::bail!(
+            "client does not support CredSSP (received {})",
+            received_connection_request.0.protocol
+        )
+    };
+
+    let connection_request_to_send = nego::ConnectionRequest {
+        nego_data: match &mapping.target {
+            crate::credential::AppCredential::UsernamePassword { username, .. } => {
+                Some(nego::NegoRequestData::cookie(username.to_owned()))
+            }
+        },
+        flags: received_connection_request.0.flags,
+        // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/902b090b-9cb3-4efc-92bf-ee13373371e3
+        // The spec is stating that `PROTOCOL_SSL` "SHOULD" also be set when using `PROTOCOL_HYBRID`.
+        // > PROTOCOL_HYBRID (0x00000002)
+        // > Credential Security Support Provider protocol (CredSSP) (section 5.4.5.2).
+        // > If this flag is set, then the PROTOCOL_SSL (0x00000001) flag SHOULD also be set
+        // > because Transport Layer Security (TLS) is a subset of CredSSP.
+        // However, crucially, it’s not strictly required (not "MUST").
+        // In fact, we purposefully choose to not set `PROTOCOL_SSL` unless `enable_winlogon` is `true`.
+        // This tells the server that we are not going to accept downgrading NLA to TLS security.
+        protocol: nego::SecurityProtocol::HYBRID | nego::SecurityProtocol::HYBRID_EX,
+    };
+    trace!(?connection_request_to_send, "Send Connection Request PDU to server");
+    send_pdu(server_framed, &x224::X224(connection_request_to_send))
+        .await
+        .context("send connection request to server")?;
+
+    let (_, received_frame) = server_framed.read_pdu().await.context("read PDU from server")?;
+    let received_connection_confirm: x224::X224<nego::ConnectionConfirm> =
+        ironrdp_core::decode(&received_frame).context("decode PDU from server")?;
+    trace!(message = ?received_connection_confirm, "Received Connection Confirm PDU from server");
+
+    let (connection_confirm_to_send, handshake_result) = match &received_connection_confirm.0 {
+        nego::ConnectionConfirm::Response {
+            flags,
+            protocol: server_security_protocol,
+        } => {
+            debug!(?server_security_protocol, ?flags, "Server confirmed connection");
+
+            let result = if !server_security_protocol
+                .intersects(nego::SecurityProtocol::HYBRID | nego::SecurityProtocol::HYBRID_EX)
+            {
+                Err(anyhow::anyhow!(
+                    "server selected security protocol {server_security_protocol}, which is not supported for credential injection"
+                ))
+            } else {
+                Ok(HandshakeResult {
+                    client_security_protocol,
+                    server_security_protocol: *server_security_protocol,
+                })
+            };
+
+            (
+                x224::X224(nego::ConnectionConfirm::Response {
+                    flags: *flags,
+                    protocol: client_security_protocol,
+                }),
+                result,
+            )
+        }
+        nego::ConnectionConfirm::Failure { code } => (
+            x224::X224(received_connection_confirm.0.clone()),
+            Err(anyhow::anyhow!("RDP session initiation failed with code {code}")),
+        ),
+    };
+
+    trace!(?connection_confirm_to_send, "Send Connection Request PDU to client");
+    send_pdu(client_framed, &connection_confirm_to_send)
+        .await
+        .context("send connection confirm to client")?;
+
+    handshake_result
+}
+
+#[instrument(name = "server_credssp", level = "debug", ret, skip_all)]
+async fn perform_credssp_with_server<S>(
+    framed: &mut ironrdp_tokio::Framed<S>,
+    server_name: String,
+    server_public_key: Vec<u8>,
+    security_protocol: nego::SecurityProtocol,
+    credentials: &crate::credential::AppCredential,
+) -> anyhow::Result<()>
+where
+    S: ironrdp_tokio::FramedRead + ironrdp_tokio::FramedWrite,
+{
+    use ironrdp_tokio::FramedWrite as _;
+
+    let credentials = match credentials {
+        crate::credential::AppCredential::UsernamePassword { username, password } => {
+            ironrdp_connector::Credentials::UsernamePassword {
+                username: username.clone(),
+                password: password.expose_secret().to_owned(),
+            }
+        }
+    };
+
+    let (mut sequence, mut ts_request) = ironrdp_connector::credssp::CredsspSequence::init(
+        credentials,
+        None,
+        security_protocol,
+        ironrdp_connector::ServerName::new(server_name),
+        server_public_key,
+        None,
+    )?;
+
+    let mut buf = ironrdp_pdu::WriteBuf::new();
+
+    loop {
+        let mut generator = sequence.process_ts_request(ts_request);
+        let client_state = generator.resolve_to_result().context("sspi generator resolve")?;
+        drop(generator);
+
+        buf.clear();
+        let written = sequence.handle_process_result(client_state, &mut buf)?;
+
+        if let Some(response_len) = written.size() {
+            let response = &buf[..response_len];
+            framed
+                .write_all(response)
+                .await
+                .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+        }
+
+        let Some(next_pdu_hint) = sequence.next_pdu_hint() else {
+            break;
+        };
+
+        let pdu = framed.read_by_hint(next_pdu_hint).await.context("read frame by hint")?;
+
+        if let Some(next_request) = sequence.decode_server_message(&pdu)? {
+            ts_request = next_request;
+        } else {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+#[instrument(name = "client_credssp", level = "debug", ret, skip_all)]
+async fn perform_credssp_with_client<S>(
+    framed: &mut ironrdp_tokio::Framed<S>,
+    client_addr: IpAddr,
+    gateway_public_key: Vec<u8>,
+    security_protocol: nego::SecurityProtocol,
+    credentials: &crate::credential::AppCredential,
+) -> anyhow::Result<()>
+where
+    S: ironrdp_tokio::FramedRead + ironrdp_tokio::FramedWrite,
+{
+    use ironrdp_connector::sspi::credssp::EarlyUserAuthResult;
+    use ironrdp_tokio::FramedWrite as _;
+
+    let mut buf = ironrdp_pdu::WriteBuf::new();
+
+    // Are we supposed to use the actual computer name of the client?
+    // But this does not seem to matter so far, so we stringify the IP address of the client instead.
+    let client_computer_name = ironrdp_connector::ServerName::new(client_addr.to_string());
+
+    let result = credssp_loop(framed, &mut buf, client_computer_name, gateway_public_key, credentials).await;
+
+    if security_protocol.intersects(nego::SecurityProtocol::HYBRID_EX) {
+        trace!(?result, "HYBRID_EX");
+
+        let result = if result.is_ok() {
+            EarlyUserAuthResult::Success
+        } else {
+            EarlyUserAuthResult::AccessDenied
+        };
+
+        buf.clear();
+        result.to_buffer(&mut buf).context("write early user auth result")?;
+        let response = &buf[..result.buffer_len()];
+        framed.write_all(response).await.context("write_all")?;
+    }
+
+    return result;
+
+    async fn credssp_loop<S>(
+        framed: &mut ironrdp_tokio::Framed<S>,
+        buf: &mut ironrdp_pdu::WriteBuf,
+        client_computer_name: ironrdp_connector::ServerName,
+        public_key: Vec<u8>,
+        credentials: &crate::credential::AppCredential,
+    ) -> anyhow::Result<()>
+    where
+        S: ironrdp_tokio::FramedRead + ironrdp_tokio::FramedWrite,
+    {
+        let crate::credential::AppCredential::UsernamePassword { username, password } = credentials;
+
+        let username = ironrdp_connector::sspi::Username::new(username, None).context("invalid username")?;
+
+        let identity = ironrdp_connector::sspi::AuthIdentity {
+            username,
+            password: password.expose_secret().to_owned().into(),
+        };
+
+        let mut sequence =
+            ironrdp_acceptor::credssp::CredsspSequence::init(&identity, client_computer_name, public_key, None)?;
+
+        loop {
+            let Some(next_pdu_hint) = sequence.next_pdu_hint()? else {
+                break;
+            };
+
+            let pdu = framed
+                .read_by_hint(next_pdu_hint)
+                .await
+                .map_err(|e| ironrdp_connector::custom_err!("read frame by hint", e))?;
+
+            let Some(ts_request) = sequence.decode_client_message(&pdu)? else {
+                break;
+            };
+
+            let result = sequence.process_ts_request(ts_request);
+            buf.clear();
+            let written = sequence.handle_process_result(result, buf)?;
+
+            if let Some(response_len) = written.size() {
+                let response = &buf[..response_len];
+                framed
+                    .write_all(response)
+                    .await
+                    .map_err(|e| ironrdp_connector::custom_err!("write all", e))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+async fn get_cached_gateway_public_key(
+    hostname: String,
+    acceptor: tokio_rustls::TlsAcceptor,
+) -> anyhow::Result<Vec<u8>> {
+    const LIFETIME_SECS: i64 = 300;
+
+    static CACHE: tokio::sync::Mutex<Cache> = tokio::sync::Mutex::const_new(Cache {
+        key: Vec::new(),
+        update_timestamp: 0,
+    });
+
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+
+    let mut guard = CACHE.lock().await;
+
+    if now < guard.update_timestamp + LIFETIME_SECS {
+        return Ok(guard.key.clone());
+    }
+
+    let key = retrieve_gateway_public_key(hostname, acceptor).await?;
+
+    *guard = Cache {
+        key: key.clone(),
+        update_timestamp: now,
+    };
+
+    return Ok(key);
+
+    struct Cache {
+        key: Vec<u8>,
+        update_timestamp: i64,
+    }
+}
+
+async fn retrieve_gateway_public_key(hostname: String, acceptor: tokio_rustls::TlsAcceptor) -> anyhow::Result<Vec<u8>> {
+    let (client_side, server_side) = tokio::io::duplex(4096);
+
+    let connect_fut = crate::tls::connect(hostname, client_side);
+    let accept_fut = acceptor.accept(server_side);
+
+    let (connect_res, _) = tokio::join!(connect_fut, accept_fut);
+
+    let tls_stream = connect_res.context("connect")?;
+
+    let public_key =
+        extract_tls_server_public_key(&tls_stream).context("extract Devolutions Gateway TLS public key")?;
+
+    Ok(public_key)
+}
+
+fn extract_tls_server_public_key(tls_stream: &impl GetPeerCert) -> anyhow::Result<Vec<u8>> {
+    use x509_cert::der::Decode as _;
+
+    let cert = tls_stream.get_peer_certificate().context("certificate is missing")?;
+
+    let cert = x509_cert::Certificate::from_der(cert).context("parse X509 certificate")?;
+
+    let server_public_key = cert
+        .tbs_certificate
+        .subject_public_key_info
+        .subject_public_key
+        .as_bytes()
+        .context("subject public key BIT STRING is not aligned")?
+        .to_owned();
+
+    Ok(server_public_key)
+}
+
+trait GetPeerCert {
+    fn get_peer_certificate(&self) -> Option<&tokio_rustls::rustls::pki_types::CertificateDer<'static>>;
+}
+
+impl<S> GetPeerCert for tokio_rustls::client::TlsStream<S> {
+    fn get_peer_certificate(&self) -> Option<&tokio_rustls::rustls::pki_types::CertificateDer<'static>> {
+        self.get_ref()
+            .1
+            .peer_certificates()
+            .and_then(|certificates| certificates.first())
+    }
+}
+
+impl<S> GetPeerCert for tokio_rustls::server::TlsStream<S> {
+    fn get_peer_certificate(&self) -> Option<&tokio_rustls::rustls::pki_types::CertificateDer<'static>> {
+        self.get_ref()
+            .1
+            .peer_certificates()
+            .and_then(|certificates| certificates.first())
+    }
+}
+
+async fn send_pdu<S, P>(framed: &mut ironrdp_tokio::TokioFramed<S>, pdu: &P) -> anyhow::Result<()>
+where
+    S: AsyncWrite + Unpin + Send + Sync,
+    P: ironrdp_core::Encode,
+{
+    use ironrdp_tokio::FramedWrite as _;
+
+    let payload = ironrdp_core::encode_vec(pdu).context("failed to encode PDU")?;
+    framed.write_all(&payload).await.context("failed to write PDU")?;
+    Ok(())
+}

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -1085,6 +1085,20 @@ fn validate_token_impl(
     Ok(claims)
 }
 
+pub fn extract_jti(token: &str) -> anyhow::Result<Uuid> {
+    use anyhow::Context as _;
+
+    let jws = RawJws::decode(token)
+        .context("failed to parse the provided JWS")?
+        .discard_signature();
+    let payload = serde_json::from_slice::<serde_json::Value>(&jws.payload).context("parse JWS payload")?;
+    let jti = payload.get("jti").context("jti is missing from the token")?;
+    let jti = jti.as_str().context("jti value is malformed")?;
+    let jti = Uuid::from_str(jti).context("jti is not a valid UUID string")?;
+
+    Ok(jti)
+}
+
 #[deprecated = "make sure this is never used without a deliberate action"]
 pub mod unsafe_debug {
     // Any function in this module should only be used at development stage when deliberately

--- a/devolutions-gateway/tests/preflight.rs
+++ b/devolutions-gateway/tests/preflight.rs
@@ -87,9 +87,9 @@ async fn test_provision_credentials_success() -> anyhow::Result<()> {
 
     let body = response.into_body().collect().await?.to_bytes();
     let body: serde_json::Value = serde_json::from_slice(&body)?;
-    assert_eq!(body.as_array().expect("an array").len(), 1);
-    assert_eq!(body[0]["operation_id"], op_id.to_string());
-    assert_eq!(body[0]["kind"], "ack", "{:?}", body[0]);
+    assert_eq!(body.as_array().expect("an array").len(), 2);
+    assert_eq!(body[1]["operation_id"], op_id.to_string());
+    assert_eq!(body[1]["kind"], "ack", "{:?}", body[1]);
 
     let entry = state.credential_store.get(token_id).expect("the provisioned entry");
     assert_eq!(entry.token, token);


### PR DESCRIPTION
## Consumer side

- Provide and associate the proxy-target credential mapping with the association token using a preflight API call.
- Connect using the fake (proxy) credentials to the Devolutions Gateway as usual, with a PCB containing the association token.

## How it works

- Perform two-way forwarding between the client and the target until the TLS security upgrade.
- Separately perform the TLS upgrade for both the client and the server, effectively acting as a man-in-the-middle.
  -  The client must trust the TLS certificate configured in the Devolutions Gateway.
- Separately perform CredSSP authentification as server with the client, and as client with the target.
  - The fake, proxy credentials are used with the client.
  - The real, target credentials are used with the target.
- Proceed with the usual two-way forwarding (expect we can actually see and inspect all the traffic)

## Demo

[proxy-based-credentials-injection-prototype.webm](https://github.com/user-attachments/assets/d5380053-810d-4529-b3f9-1ed84c2d77c4)