### PR TITLE
fix(dgw)!: drop the prx_usr, prx_pwd, dst_usr and dst_pwd claims

### DIFF
--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -332,7 +332,6 @@ pub(crate) async fn sign_session_token(
                 jet_ap: protocol,
                 jet_cm: ConnectionMode::Fwd {
                     targets: nonempty::NonEmpty::new(destination.clone()),
-                    creds: None,
                 },
                 jet_rec: RecordingPolicy::None,
                 jet_flt: false,

--- a/devolutions-gateway/src/generic_client.rs
+++ b/devolutions-gateway/src/generic_client.rs
@@ -88,7 +88,7 @@ where
             ConnectionMode::Rdv => {
                 anyhow::bail!("TCP rendezvous not supported");
             }
-            ConnectionMode::Fwd { targets, creds: None } => {
+            ConnectionMode::Fwd { targets } => {
                 match claims.jet_rec {
                     RecordingPolicy::None | RecordingPolicy::Stream => (),
                     RecordingPolicy::Proxy => anyhow::bail!("can't meet recording policy"),
@@ -166,10 +166,6 @@ where
                     .select_dissector_and_forward()
                     .await
                     .context("encountered a failure during plain tcp traffic proxying")
-            }
-            ConnectionMode::Fwd { creds: Some(_), .. } => {
-                // Credentials handling should be special cased (e.g.: RDP-TLS)
-                anyhow::bail!("unexpected credentials");
             }
         }
     }


### PR DESCRIPTION
The favored approach when pushing credentials is now to use the preflight route.