### PR TITLE
refactor(webapp): update calls to onSessionEvent

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser-dynamic": "18.2.1",
         "@angular/router": "18.2.1",
         "@devolutions/icons": "4.0.8",
-        "@devolutions/iron-remote-desktop": "^0.4.0",
+        "@devolutions/iron-remote-desktop": "^0.5.0",
         "@devolutions/iron-remote-desktop-rdp": "^0.2.0",
         "@devolutions/iron-remote-desktop-vnc": "^0.3.0",
         "@devolutions/web-ssh-gui": "0.3.1",
@@ -2947,24 +2947,6 @@
       }
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
-    "node_modules/@devolutions/iron-remote-desktop/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -2893,38 +2893,14 @@
       }
     },
     "node_modules/@devolutions/iron-remote-desktop": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop/-/iron-remote-desktop-0.4.0.tgz",
-      "integrity": "sha512-lOmXJa0MAgMVp+W8BTPxfXugTYSs4Vq4TbpLFVv8drUNqklEoz2yQLuiLWyZJh6fc7lpzO/+2EV0ysfBTGY5+g==",
-      "dependencies": {
-        "rxjs": "^6.6.7"
-      }
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop/-/iron-remote-desktop-0.5.0.tgz",
+      "integrity": "sha512-vObHavV5pWqygskdvKk6lvUoJcyGE5M4ZNyR/gUBTn6U00UGvEacI/QGf/zu2hWcyoZLSkX4q9DBhwX9mwi0/w=="
     },
     "node_modules/@devolutions/iron-remote-desktop-rdp": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop-rdp/-/iron-remote-desktop-rdp-0.2.0.tgz",
-      "integrity": "sha512-fNpRzqBWPGNzLr5bVOGpMqf7HShvzbIn1crfi66JSzpZETpap9gJw/B5BSKJ02l3EsZ6gXLIJsr4QqO/1yYtQw==",
-      "dependencies": {
-        "rxjs": "^6.6.7"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-rdp/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-rdp/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop-rdp/-/iron-remote-desktop-rdp-0.2.1.tgz",
+      "integrity": "sha512-CxsItk9Y1kupqGbHANBGOKcVO/be93tsGWaO7yHXjEDNwdc/qs++rwTb9Dcce7+P2wy2l4gsCIGMKKEq7Cnk1g=="
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc": {
       "version": "0.3.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,7 +28,7 @@
     "@angular/platform-browser-dynamic": "18.2.1",
     "@angular/router": "18.2.1",
     "@devolutions/icons": "4.0.8",
-    "@devolutions/iron-remote-desktop": "^0.4.0",
+    "@devolutions/iron-remote-desktop": "^0.5.0",
     "@devolutions/iron-remote-desktop-rdp": "^0.2.0",
     "@devolutions/iron-remote-desktop-vnc": "^0.3.0",
     "@devolutions/web-ssh-gui": "0.3.1",

--- a/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts
+++ b/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts
@@ -372,20 +372,19 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
   }
 
   private initSessionEventHandler(): void {
-    this.remoteClient.onSessionEvent({
-      next: (event: SessionEvent): void => {
-        switch (event.type) {
-          case SessionEventType.STARTED:
-            this.handleSessionStarted(event);
-            break;
-          case SessionEventType.TERMINATED:
-          case SessionEventType.ERROR:
-            this.handleSessionEndedOrError(event);
-            break;
-        }
-      },
-      error: (err) => this.handleSubscriptionError(err),
-    });
+    const handler = (event: SessionEvent): void => {
+      switch (event.type) {
+        case SessionEventType.STARTED:
+          this.handleSessionStarted(event);
+          break;
+        case SessionEventType.TERMINATED:
+        case SessionEventType.ERROR:
+          this.handleSessionEndedOrError(event);
+          break;
+      }
+    };
+
+    this.remoteClient.onSessionEvent(handler);
   }
 
   private handleSessionStarted(event: SessionEvent): void {
@@ -421,10 +420,6 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
       eventType === SessionEventType.TERMINATED || SessionEventType.ERROR ? DVL_WARNING_ICON : DVL_ARD_ICON;
 
     void this.webSessionService.updateWebSessionIcon(this.webSessionId, icon);
-  }
-
-  private handleSubscriptionError(error): void {
-    console.error('Error in session event subscription', error);
   }
 
   private handleIronRDPError(error: IronError | string): void {

--- a/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.ts
+++ b/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.ts
@@ -420,20 +420,19 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
   }
 
   private initSessionEventHandler(): void {
-    this.remoteClient.onSessionEvent({
-      next: (event: SessionEvent): void => {
-        switch (event.type) {
-          case SessionEventType.STARTED:
-            this.handleSessionStarted(event);
-            break;
-          case SessionEventType.TERMINATED:
-          case SessionEventType.ERROR:
-            this.handleSessionEndedOrError(event);
-            break;
-        }
-      },
-      error: (err) => this.handleSubscriptionError(err),
-    });
+    const handler = (event: SessionEvent): void => {
+      switch (event.type) {
+        case SessionEventType.STARTED:
+          this.handleSessionStarted(event);
+          break;
+        case SessionEventType.TERMINATED:
+        case SessionEventType.ERROR:
+          this.handleSessionEndedOrError(event);
+          break;
+      }
+    };
+
+    this.remoteClient.onSessionEvent(handler);
   }
 
   private handleSessionStarted(event: SessionEvent): void {
@@ -469,10 +468,6 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
       eventType === SessionEventType.TERMINATED || SessionEventType.ERROR ? DVL_WARNING_ICON : DVL_RDP_ICON;
 
     void this.webSessionService.updateWebSessionIcon(this.webSessionId, icon);
-  }
-
-  private handleSubscriptionError(error): void {
-    console.error('Error in session event subscription', error);
   }
 
   private handleIronRDPError(error: IronError | string): void {

--- a/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
+++ b/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
@@ -437,20 +437,19 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
   }
 
   private initSessionEventHandler(): void {
-    this.remoteClient.onSessionEvent({
-      next: (event: SessionEvent): void => {
-        switch (event.type) {
-          case SessionEventType.STARTED:
-            this.handleSessionStarted(event);
-            break;
-          case SessionEventType.TERMINATED:
-          case SessionEventType.ERROR:
-            this.handleSessionEndedOrError(event);
-            break;
-        }
-      },
-      error: (err) => this.handleSubscriptionError(err),
-    });
+    const handler = (event: SessionEvent): void => {
+      switch (event.type) {
+        case SessionEventType.STARTED:
+          this.handleSessionStarted(event);
+          break;
+        case SessionEventType.TERMINATED:
+        case SessionEventType.ERROR:
+          this.handleSessionEndedOrError(event);
+          break;
+      }
+    };
+
+    this.remoteClient.onSessionEvent(handler);
   }
 
   private handleSessionStarted(event: SessionEvent): void {
@@ -486,10 +485,6 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       eventType === SessionEventType.TERMINATED || SessionEventType.ERROR ? DVL_WARNING_ICON : DVL_VNC_ICON;
 
     void this.webSessionService.updateWebSessionIcon(this.webSessionId, icon);
-  }
-
-  private handleSubscriptionError(error): void {
-    console.error('Error in session event subscription', error);
   }
 
   private handleIronRDPError(error: IronError | string): void {


### PR DESCRIPTION
Update calls to `onSessionEvent` from _@devolutions/iron-remote-desktop_, as the interface changed after RxJS was removed from latter's dependencies.