### PR TITLE
ci(dependabot): group IronVNC bumps with IronRDP

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,9 @@ updates:
       - "CBenoit"
     open-pull-requests-limit: 3
     groups:
-      ironrdp:
+      iron:
         patterns:
           - "ironrdp*"
-      ironvnc:
-        patterns:
           - "ironvnc*"
       serde:
         patterns:


### PR DESCRIPTION
IronVNC also depends on a few IronRDP crates, so we may as well group them together.

cc @MathieuMorrissette 