### PR TITLE
fix(webapp): change toolbar activation height

### DIFF
--- a/webapp/src/client/app/shared/components/session-toolbar/session-toolbar.component.ts
+++ b/webapp/src/client/app/shared/components/session-toolbar/session-toolbar.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, HostListener, Input, Renderer2 } from '@angular/core';
 import { UtilsService } from '@shared/services/utils.service';
+import { WebSession } from "@shared/models/web-session.model";
 
 @Component({
   selector: 'session-toolbar',
@@ -79,9 +80,11 @@ export class SessionToolbarComponent {
       return;
     }
 
-    if (event.clientY === 0) {
+    const TOOLBAR_ACTIVATION_HEIGHT = 10;
+
+    if (event.clientY <= TOOLBAR_ACTIVATION_HEIGHT) {
       this.showToolbarDiv = true;
-    } else if (event.clientY > 44) {
+    } else if (event.clientY > WebSession.TOOLBAR_SIZE) {
       this.showToolbarDiv = false;
     }
   }


### PR DESCRIPTION
When the webapp is in fullscreen mode, the session toolbar doesn't appear when ф user moves the cursor to the top of the screen. It turned out that for some reason, the minimum cursor height is not 0px, but somewhere around 6px. So, I changed the conditions, and now we're checking that the height is less than 10. No,w the session toolbar appears when the user moves the cursor to the top of the screen.