### PR TITLE
fix(pedm): don't error on profile selection if no assignments

### DIFF
--- a/crates/devolutions-pedm/src/api/policy.rs
+++ b/crates/devolutions-pedm/src/api/policy.rs
@@ -82,13 +82,21 @@ async fn get_me(
     Extension(named_pipe_info): Extension<NamedPipeConnectInfo>,
     NoApi(Db(db)): NoApi<Db>,
 ) -> Result<Json<GetProfilesMeResponse>, Error> {
-    let selected_profile = db.get_user_profile(&named_pipe_info.user).await?;
-    let profiles = db.get_profiles_for_user(&named_pipe_info.user).await?;
+    match db.get_user_id(&named_pipe_info.user).await? {
+        Some(_) => {
+            let selected_profile = db.get_user_profile(&named_pipe_info.user).await?;
+            let profiles = db.get_profiles_for_user(&named_pipe_info.user).await?;
 
-    Ok(Json(GetProfilesMeResponse {
-        active: selected_profile.map_or(0, |p| p.id),
-        available: profiles.into_iter().map(|p| p.id).collect(),
-    }))
+            Ok(Json(GetProfilesMeResponse {
+                active: selected_profile.map_or(0, |p| p.id),
+                available: profiles.into_iter().map(|p| p.id).collect(),
+            }))
+        }
+        None => Ok(Json(GetProfilesMeResponse {
+            active: 0,
+            available: vec![],
+        })),
+    }
 }
 
 /// Returns the list of profile IDs.

--- a/crates/devolutions-pedm/src/db/libsql.rs
+++ b/crates/devolutions-pedm/src/db/libsql.rs
@@ -32,20 +32,6 @@ impl LibsqlConn {
             .ok_or(libsql::Error::QueryReturnedNoRows)
     }
 
-    async fn get_user_id(&self, user: &User) -> Result<Option<i64>, DbError> {
-        let mut rows = self.query(
-            "SELECT id FROM user WHERE account_name = ?1 AND domain_name = ?2 AND account_sid = ?3 AND domain_sid = ?4",
-            params![user.account_name.as_str(), user.domain_name.as_str(), user.account_sid.as_str(), user.domain_sid.as_str()],
-        ).await?;
-
-        if let Some(row) = rows.next().await? {
-            let id: i64 = row.get(0)?;
-            Ok(Some(id))
-        } else {
-            Ok(None)
-        }
-    }
-
     async fn get_or_insert_user(&self, tx: &mut Transaction, user: &User) -> Result<i64, DbError> {
         let mut rows = tx.query(
             "SELECT id FROM user WHERE account_name = ?1 AND domain_name = ?2 AND account_sid = ?3 AND domain_sid = ?4",
@@ -623,6 +609,20 @@ impl Database for LibsqlConn {
         }
 
         Ok(users)
+    }
+
+    async fn get_user_id(&self, user: &User) -> Result<Option<i64>, DbError> {
+        let mut rows = self.query(
+            "SELECT id FROM user WHERE account_name = ?1 AND domain_name = ?2 AND account_sid = ?3 AND domain_sid = ?4",
+            params![user.account_name.as_str(), user.domain_name.as_str(), user.account_sid.as_str(), user.domain_sid.as_str()],
+        ).await?;
+
+        if let Some(row) = rows.next().await? {
+            let id: i64 = row.get(0)?;
+            Ok(Some(id))
+        } else {
+            Ok(None)
+        }
     }
 
     async fn get_jit_elevation_log(&self, id: i64) -> Result<Option<JitElevationLogRow>, DbError> {

--- a/crates/devolutions-pedm/src/db/mod.rs
+++ b/crates/devolutions-pedm/src/db/mod.rs
@@ -221,6 +221,8 @@ pub(crate) trait Database: Send + Sync {
 
     async fn get_user_profile(&self, user: &User) -> Result<Option<Profile>, DbError>;
 
+    async fn get_user_id(&self, user: &User) -> Result<Option<i64>, DbError>;
+
     async fn get_users(&self) -> Result<Vec<User>, DbError>;
 
     async fn get_jit_elevation_log(&self, id: i64) -> Result<Option<JitElevationLogRow>, DbError>;

--- a/crates/devolutions-pedm/src/db/pg.rs
+++ b/crates/devolutions-pedm/src/db/pg.rs
@@ -95,6 +95,10 @@ impl Database for PgPool {
         unimplemented!()
     }
 
+    async fn get_user_id(&self, user: &User) -> Result<Option<i64>, DbError> {
+        unimplemented!()
+    }
+
     async fn insert_jit_elevation_result(&self, result: &ElevationResult) -> Result<(), DbError> {
         unimplemented!()
     }


### PR DESCRIPTION
If a user has never had a profile assigned, there will be no record of them in the `user` table.

However, if they try to select a profile, an error is returned. It's better to catch this scenario upfront and just return an empty profile selection and list.