### PR TITLE
refactor(dgw): use sspi::Username::parse instead of new

### DIFF
--- a/devolutions-gateway/src/rdp_proxy.rs
+++ b/devolutions-gateway/src/rdp_proxy.rs
@@ -432,7 +432,7 @@ where
     {
         let crate::credential::AppCredential::UsernamePassword { username, password } = credentials;
 
-        let username = ironrdp_connector::sspi::Username::new(username, None).context("invalid username")?;
+        let username = ironrdp_connector::sspi::Username::parse(username).context("invalid username")?;
 
         let identity = ironrdp_connector::sspi::AuthIdentity {
             username,


### PR DESCRIPTION
We do not support passing the domain as a separate field (intentionally).