### PR TITLE
fix(pedm): add additional context to virtual account code paths

### DIFF
--- a/crates/devolutions-pedm/src/elevator/virtual_account_elevator.rs
+++ b/crates/devolutions-pedm/src/elevator/virtual_account_elevator.rs
@@ -26,7 +26,7 @@ use win_api_wrappers::Error;
 
 use super::Elevator;
 
-use anyhow::Context;
+use anyhow::Context as _;
 
 struct VirtualAccountElevation {
     _base_token: Token,

--- a/crates/devolutions-pedm/src/elevator/virtual_account_elevator.rs
+++ b/crates/devolutions-pedm/src/elevator/virtual_account_elevator.rs
@@ -26,6 +26,8 @@ use win_api_wrappers::Error;
 
 use super::Elevator;
 
+use anyhow::Context;
+
 struct VirtualAccountElevation {
     _base_token: Token,
     elevated_token: Token,
@@ -56,7 +58,7 @@ impl VirtualAccountElevator {
     fn create_token(&self, token: &Token) -> anyhow::Result<()> {
         let domain = U16CString::from_str(&self.domain)?;
 
-        let virtual_account = create_virtual_account(self.rid, &domain, token)?;
+        let virtual_account = create_virtual_account(self.rid, &domain, token).context("create virtual account")?;
 
         let mut groups = TokenGroups::new(
             // Needed for the virtual account to access the user's desktop and window station.
@@ -93,9 +95,12 @@ impl VirtualAccountElevator {
             LOGON32_LOGON_INTERACTIVE,
             LOGON32_PROVIDER_VIRTUAL,
             Some(&groups),
-        )?;
+        )
+        .context("logon virtual account")?;
 
-        let profile = base_token.load_profile(virtual_account.name)?;
+        let profile = base_token
+            .load_profile(virtual_account.name)
+            .context("load virtual account profile")?;
 
         let elevated_token = base_token.linked_token()?;
 
@@ -120,7 +125,7 @@ impl Elevator for VirtualAccountElevator {
         let sid = token.sid_and_attributes()?.sid;
 
         if !self.tokens.read().contains_key(&sid) {
-            self.create_token(token)?;
+            self.create_token(token).context("create virtual account token")?;
         }
 
         self.tokens
@@ -128,9 +133,14 @@ impl Elevator for VirtualAccountElevator {
             .get(&sid)
             .ok_or_else(|| anyhow::anyhow!(Error::from_win32(ERROR_ACCOUNT_EXPIRED)))
             .and_then(|vtoken| {
-                let mut vtoken = vtoken.elevated_token.duplicate_impersonation()?;
+                let mut vtoken = vtoken
+                    .elevated_token
+                    .duplicate_impersonation()
+                    .context("duplicate virtual elevated token")?;
 
-                vtoken.set_session_id(token.session_id()?)?;
+                vtoken
+                    .set_session_id(token.session_id()?)
+                    .context("set virtual token session id")?;
 
                 Ok(vtoken)
             })

--- a/crates/win-api-wrappers/src/identity/account.rs
+++ b/crates/win-api-wrappers/src/identity/account.rs
@@ -242,7 +242,10 @@ pub fn create_profile(account_sid: &Sid, account_name: &U16CStr) -> anyhow::Resu
             account_string_sid.as_u16cstr().as_pcwstr(),
             account_name.as_pcwstr(),
             profile_path.as_mut_slice(),
-        )?
+        )
+        .with_context(|| {
+            format!("CreateProfile failed (account_string_sid: {account_string_sid:?}, account_name: {account_name:?}, profile_path: {profile_path:?}")
+        })?
     };
 
     Ok(U16CString::from_vec_truncate(profile_path))
@@ -269,7 +272,10 @@ impl ProfileInfo {
         profile_info.raw.lpUserName = profile_info.username.as_pwstr();
 
         // SAFETY: Only prerequisite is for `profile_info`'s `dwSize` member to be set correctly, which it is.
-        unsafe { LoadUserProfileW(profile_info.token.handle().raw(), &mut profile_info.raw) }?;
+        unsafe {
+            LoadUserProfileW(profile_info.token.handle().raw(), &mut profile_info.raw)
+                .with_context(|| format!("LoadUserProfileW failed (username: {:?})", profile_info.username))?;
+        };
 
         Ok(profile_info)
     }

--- a/crates/win-api-wrappers/src/token.rs
+++ b/crates/win-api-wrappers/src/token.rs
@@ -350,7 +350,8 @@ impl Token {
                 info_class,
                 value as *const _ as *const _,
                 u32size_of::<T>(),
-            )?;
+            )
+            .context("SetTokenInformation")?;
         }
 
         Ok(())
@@ -441,7 +442,10 @@ impl Token {
                 None,
                 None,
             )
-        }?;
+            .with_context(|| {
+                format!("LogonUserExExW failed (username: {username:?}, domain: {domain:?}, logon_type: {logon_type:?}, logon_provider: {logon_provider:?}, groups: {groups:?})")
+            })?
+        }
 
         // SAFETY: We own the handle.
         let handle = unsafe { Handle::new_owned(raw_token)? };

--- a/crates/win-api-wrappers/src/token_groups.rs
+++ b/crates/win-api-wrappers/src/token_groups.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use std::{fmt, mem};
 
 use windows::Win32::Security;
 
@@ -83,6 +83,12 @@ impl TokenGroups {
                 sid,
                 attributes: raw.Attributes,
             })
+    }
+}
+
+impl fmt::Debug for TokenGroups {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenGroups").field("sids", &self.sids).finish()
     }
 }
 


### PR DESCRIPTION
Some users are experiencing an error with the virtual account elevator that I cannot reproduce, and we do not have the necessary contextual information. This PR adds additional context to the virtual account elevator code paths.