### PR TITLE
fix(dgw): set default value of TlsVerifyStrict to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Stable options are:
     additional measures like securing access to the files or using the system certificate store (see
     **TlsCertificateSource** option).
 
-- **TlsVerifyStrict** (_Boolean_): Enables strict TLS certificate verification (default is `true`).
+- **TlsVerifyStrict** (_Boolean_): Enables strict TLS certificate verification (default is `false`).
 
     When enabled (`true`), the client performs additional checks on the server certificate,
     including:

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -59,8 +59,7 @@ impl fmt::Debug for Tls {
 
 impl Tls {
     fn init(cert_source: crate::tls::CertificateSource, strict_checks: bool) -> anyhow::Result<Self> {
-        let tls_server_config =
-            crate::tls::build_server_config(cert_source, strict_checks).context("failed to build TLS config")?;
+        let tls_server_config = crate::tls::build_server_config(cert_source, strict_checks)?;
 
         let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(tls_server_config));
 
@@ -152,7 +151,7 @@ impl Conf {
             .iter()
             .any(|l| matches!(l.internal_url.scheme(), "https" | "wss"));
 
-        let strict_checks = conf_file.tls_verify_strict.unwrap_or(true);
+        let strict_checks = conf_file.tls_verify_strict.unwrap_or(false);
 
         let tls = match conf_file.tls_certificate_source.unwrap_or_default() {
             dto::CertSource::External => match conf_file.tls_certificate_file.as_ref() {
@@ -185,7 +184,7 @@ impl Conf {
                     };
 
                     Tls::init(cert_source, strict_checks)
-                        .context("failed to init TLS config")?
+                        .context("failed to initialize TLS configuration")?
                         .pipe(Some)
                 }
             },
@@ -208,7 +207,7 @@ impl Conf {
                     };
 
                     Tls::init(cert_source, strict_checks)
-                        .context("failed to init TLS config")?
+                        .context("failed to initialize TLS configuration")?
                         .pipe(Some)
                 }
             },

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -68,6 +68,10 @@ impl GatewayService {
             );
         }
 
+        if matches!(conf_file.tls_verify_strict, None | Some(false)) {
+            warn!("TlsVerifyStrict option is absent or set to false. This may hide latent issues.");
+        }
+
         if let Some((cert_subject_name, hostname)) = conf_file
             .tls_certificate_subject_name
             .as_deref()

--- a/devolutions-gateway/src/tls.rs
+++ b/devolutions-gateway/src/tls.rs
@@ -93,7 +93,7 @@ pub fn build_server_config(
                 let issues = report.issues;
 
                 anyhow::bail!(
-                    "found significant issues with the certificate: serial_number = {serial_number}, subject = {subject}, issuer = {issuer}, not_before = {not_before}, not_after = {not_after}, issues = {issues}"
+                    "found significant issues with the certificate: serial_number = {serial_number}, subject = {subject}, issuer = {issuer}, not_before = {not_before}, not_after = {not_after}, issues = {issues} (you can set `TlsVerifyStrict` to `false` in the gateway.json configuration file if that's intended)"
                 );
             }
 
@@ -121,7 +121,7 @@ pub fn build_server_config(
         }
         #[cfg(not(windows))]
         CertificateSource::SystemStore { .. } => {
-            anyhow::bail!("System Certificate Store not supported for this platform")
+            anyhow::bail!("system certificate store not supported for this platform")
         }
     }
 }


### PR DESCRIPTION
Previously, strict TLS verification was performed even when the TlsVerifyStrict key was absent from the configuration file.

From now on, if this key is missing, it will default to "TlsVerifyStrict": false.

This change ensures that existing users who are currently using improper certificates will not be affected. At the same time, newly generated configuration files will continue to include "TlsVerifyStrict": true by default, encouraging using proper certificates from the start.

New users can still opt out of strict verification by explicitly setting the value to false or removing the key entirely if they are willing to accept potential compatibility issues with some clients, such as Chrome or macOS.

A warning will be logged if the option is disabled as it may hide latent issues.
Hopefully, this lead the user to enable the option, and fix the underlying certificate issue if necessary.