### PR TITLE
feat(dgw,agent): display config file path during initialization

### DIFF
--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -178,7 +178,7 @@ pub fn load_conf_file_or_generate_new() -> anyhow::Result<dto::ConfFile> {
         Some(conf_file) => conf_file,
         None => {
             let defaults = dto::ConfFile::generate_new();
-            println!("Write default configuration to disk…");
+            println!("Write default configuration to {conf_file_path}…");
             save_config(&defaults).context("failed to save configuration")?;
             defaults
         }

--- a/devolutions-gateway/src/config.rs
+++ b/devolutions-gateway/src/config.rs
@@ -562,7 +562,7 @@ pub fn load_conf_file_or_generate_new() -> anyhow::Result<dto::ConfFile> {
         Some(conf_file) => conf_file,
         None => {
             let defaults = dto::ConfFile::generate_new();
-            println!("Write default configuration to disk…");
+            println!("Write default configuration to {conf_file_path}…");
             save_config(&defaults).context("failed to save configuration")?;
             defaults
         }

--- a/devolutions-session/src/config.rs
+++ b/devolutions-session/src/config.rs
@@ -124,7 +124,7 @@ pub(crate) fn load_conf_file_or_generate_new() -> anyhow::Result<dto::ConfFile> 
         Some(conf_file) => conf_file,
         None => {
             let defaults = dto::ConfFile::generate_new();
-            println!("Write default configuration to disk…");
+            println!("Write default configuration to {conf_file_path}…");
             save_config(&defaults).context("failed to save configuration")?;
             defaults
         }


### PR DESCRIPTION
Output the full path to the configuration file when initializing the configuration for both Devolutions Gateway and Devolutions Agent. This simplifies debugging and setup verification.