### PR TITLE
fix(ci): include psd1 when zipping the PS module

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -245,9 +245,13 @@ jobs:
           }
 
           Remove-Item $PSModuleZipFilePath -ErrorAction SilentlyContinue | Out-Null
-          Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -CompressionLevel Optimal
 
           $PSModuleParentPath = Split-Path $DGatewayPSModulePath -Parent
+
+          Push-Location $PSModuleParentPath
+          Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -CompressionLevel Optimal
+          Pop-Location
+
           New-ModulePackage $DGatewayPSModulePath $PSModuleParentPath
 
       - name: Sign executables


### PR DESCRIPTION
The "Publish PowerShell module" step of _release.yml_ is failing due to

```
Run $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File
Remove-Item: Cannot find path
'/home/runner/work/devolutions-gateway/devolutions-gateway/PowerShell/Devolution
sGateway/DevolutionsGateway.psd1' because it does not exist.
Error: Process completed with exit code 1.
```

This PR runs `Compress-Archive` from the parent folder. This is an attempt to include the psd1 in the "Sign PowerShell module contents" step.