### PR TITLE
ci: drop leftover code for Windows containers

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -249,12 +249,9 @@ jobs:
           }
 
           Remove-Item $PSModuleZipFilePath -ErrorAction SilentlyContinue | Out-Null
+          Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -CompressionLevel Optimal
 
           $PSModuleParentPath = Split-Path $DGatewayPSModulePath -Parent
-
-          Push-Location $PSModuleParentPath
-          Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -CompressionLevel Optimal
-          Pop-Location
 
           New-ModulePackage $DGatewayPSModulePath $PSModuleParentPath
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -74,6 +74,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI_RUN: ${{ steps.get-run.outputs.run }}
         run: |
+          Set-PSDebug -Trace 1
+
           $Ref = '${{ inputs.ref }}'
           if (-Not $Ref) {
             $Run = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN | ConvertFrom-Json
@@ -225,6 +227,8 @@ jobs:
         if: matrix.os == 'windows' && matrix.project == 'devolutions-gateway'
         shell: pwsh
         run: |
+          Set-PSDebug -Trace 1
+
           . .\ci\PSModuleHelpers.ps1
           $PSModuleOutputPath = Join-Path ${{ runner.temp }} ${{ matrix.project }} "PowerShell"
           $PSModuleZipFilePath = Get-ChildItem -Path $PSModuleOutputPath "DevolutionsGateway-ps-*.zip" | Select-Object -First 1
@@ -637,6 +641,8 @@ jobs:
         shell: pwsh
         working-directory: jetsocat/nuget
         run: |
+          Set-PSDebug -Trace 1
+
           $Version = '${{ github.event.inputs.jetsocat-nuget-version }}'
           if ([string]::IsNullOrWhitespace($Version)) {
             $Version = Get-Date -Format "yyyy.M.d"
@@ -652,6 +658,8 @@ jobs:
         shell: pwsh
         working-directory: jetsocat/nuget
         run: |
+          Set-PSDebug -Trace 1
+
           Install-Module -Name ZipIt -Force
           & 'nuget' 'pack' 'Devolutions.Jetsocat.nuspec'
           $NugetPackage = (Get-Item ".\*.nupkg" | Select-Object -First 1) | Resolve-Path -Relative

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,8 @@ jobs:
           }
           echo "skip-publishing=$SkipPublishing" >> $Env:GITHUB_OUTPUT
 
-  containers:
-    name: Containers [${{ matrix.os }} ${{ matrix.base-image }}]
+  container:
+    name: Container [${{ matrix.os }} ${{ matrix.base-image }}]
     runs-on: ${{ matrix.runner }}
     environment: publish-prod
     needs: preflight
@@ -111,21 +111,12 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ x86_64 ]
-        os: [ windows, linux ]
-        base-image: [debian-bullseye-slim, windowsservercore-ltsc2022, lts-nanoserver-ltsc2022 ]
+        os: [ linux ]
+        base-image: [ bookworm-slim ]
 
         include:
-          - os: windows
-            runner: windows-2022
           - os: linux
             runner: ubuntu-latest
-        exclude:
-          - os: windows
-            base-image: debian-bullseye-slim
-          - os: linux
-            base-image: windowsservercore-ltsc2022
-          - os: linux
-            base-image: lts-nanoserver-ltsc2022
 
     steps:
       - name: Download artifacts
@@ -151,13 +142,7 @@ jobs:
           Get-ChildItem -Path "$PkgDir"
 
           $SourceFileName = "DevolutionsGateway_$($Env:RUNNER_OS)_${{ needs.preflight.outputs.version }}_${{ matrix.arch }}"
-
-          if ($Env:RUNNER_OS -eq "Windows") {
-            $SourceFileName = "$($SourceFileName).exe"
-            $TargetFileName = "DevolutionsGateway.exe"
-          } else {
-            $TargetFileName = "devolutions-gateway"
-          }
+          $TargetFileName = "devolutions-gateway"
           Write-Host "SourceFileName = $SourceFileName"
           Write-Host "TargetFileName = $TargetFileName"
 
@@ -172,11 +157,6 @@ jobs:
           }
 
           $XmfFileName = "libxmf.so"
-
-          if ($Env:RUNNER_OS -eq "Windows") {
-            $XmfFileName = "xmf.dll"
-          }
-
           $XmfSourcePath = Get-ChildItem -Recurse -Filter $XmfFileName -File -Path native-libs
           $XmfTargetPath = Join-Path $PkgDir $XmfFileName
           Write-Host "XmfSourcePath = $XmfSourcePath"
@@ -201,11 +181,7 @@ jobs:
           Set-PSDebug -Trace 1
 
           $ImageName = "devolutions/devolutions-gateway:${{ needs.preflight.outputs.version }}-${{ matrix.base-image }}"
-          if ("${{ matrix.base-image }}" -Eq "lts-nanoserver-ltsc2022") {
-            docker build --build-arg FROM_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022 -t "$ImageName" .
-          } else {
-            docker build -t "$ImageName" .
-          }
+          docker build -t "$ImageName" .
           echo "image-name=$ImageName" >> $Env:GITHUB_OUTPUT
           Get-ChildItem -Recurse
 
@@ -457,7 +433,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.preflight.outputs.skip-publishing == 'false' || ${{ inputs.dry-run }}
     needs:
-      - containers
+      - container
       - github-release
       - psgallery-release
       - onedrive-gateway
@@ -472,3 +448,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./ci/remove-labels.ps1 -Label 'release-required'
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          Set-PSDebug -Trace 1
+
           $Output = (gh release list --repo $Env:GITHUB_REPOSITORY) | Out-String
           $Releases = ( $Output -split '\r?\n' ).Trim()
           $Versions = ForEach($Release in $Releases) {
@@ -106,6 +108,7 @@ jobs:
     needs: preflight
     if: needs.preflight.outputs.skip-publishing == 'false' || ${{ inputs.dry-run }}
     strategy:
+      fail-fast: false
       matrix:
         arch: [ x86_64 ]
         os: [ windows, linux ]
@@ -134,14 +137,18 @@ jobs:
       ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
         shell: pwsh
-        run: Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+        run: Remove-Item -Path (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
 
       - name: Prepare artifacts
         id: prepare-artifacts
         shell: pwsh
         run: |
+          Set-PSDebug -Trace 1
+
           $PkgDir = Join-Path docker $Env:RUNNER_OS # RUNNER_OS is camelcase
           echo "package-path=$PkgDir" >> $Env:GITHUB_OUTPUT
+          Write-Host "PkgDir = $PkgDir"
+          Get-ChildItem -Path "$PkgDir"
 
           $SourceFileName = "DevolutionsGateway_$($Env:RUNNER_OS)_${{ needs.preflight.outputs.version }}_${{ matrix.arch }}"
 
@@ -151,10 +158,14 @@ jobs:
           } else {
             $TargetFileName = "devolutions-gateway"
           }
+          Write-Host "SourceFileName = $SourceFileName"
+          Write-Host "TargetFileName = $TargetFileName"
 
           $SourcePath = Get-ChildItem -Recurse -Filter $SourceFileName -File -Path devolutions-gateway
           $TargetPath = Join-Path $PkgDir $TargetFileName
-          Copy-Item $SourcePath $TargetPath
+          Write-Host "SourcePath = $SourcePath"
+          Write-Host "TargetPath = $TargetPath"
+          Copy-Item -Path $SourcePath -Destination $TargetPath
 
           if ($Env:RUNNER_OS -eq "Linux") {
             Invoke-Expression "chmod +x $TargetPath"
@@ -168,21 +179,27 @@ jobs:
 
           $XmfSourcePath = Get-ChildItem -Recurse -Filter $XmfFileName -File -Path native-libs
           $XmfTargetPath = Join-Path $PkgDir $XmfFileName
-          Copy-Item $XmfSourcePath $XmfTargetPath
+          Write-Host "XmfSourcePath = $XmfSourcePath"
+          Write-Host "XmfTargetPath = $XmfTargetPath"
+          Copy-Item -Path $XmfSourcePath -Destination $XmfTargetPath
 
           $WebAppArchive = Get-ChildItem -Recurse -Filter "devolutions_gateway_webapp_*.tar.gz" | Select-Object -First 1
           $TargetPath = Join-Path $PkgDir "webapp" "client"
+          Write-Host "WebAppArchive = $WebAppArchive"
+          Write-Host "TargetPath = $TargetPath"
           New-Item -ItemType Directory -Path $TargetPath
           tar -xvzf $WebAppArchive.FullName -C $TargetPath --strip-components=1
 
           $PowerShellArchive = Get-ChildItem -Recurse -Filter "DevolutionsGateway-ps-*.zip" | Select-Object -First 1
-          Expand-Archive $PowerShellArchive -DestinationPath "$PkgDir"
+          Expand-Archive -Path $PowerShellArchive -DestinationPath "$PkgDir"
 
       - name: Build container
         id: build-container
         shell: pwsh
         working-directory: ${{ steps.prepare-artifacts.outputs.package-path }}
         run: |
+          Set-PSDebug -Trace 1
+
           $ImageName = "devolutions/devolutions-gateway:${{ needs.preflight.outputs.version }}-${{ matrix.base-image }}"
           if ("${{ matrix.base-image }}" -Eq "lts-nanoserver-ltsc2022") {
             docker build --build-arg FROM_IMAGE=mcr.microsoft.com/powershell:lts-nanoserver-ltsc2022 -t "$ImageName" .
@@ -196,6 +213,8 @@ jobs:
         shell: pwsh
         working-directory: ${{ steps.prepare-artifacts.outputs.package-path }}
         run: |
+          Set-PSDebug -Trace 1
+
           echo ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }} | docker login -u devolutionsbot --password-stdin
           $DockerPushCmd = 'docker push ${{ steps.build-container.outputs.image-name }}'
           Write-Host $DockerPushCmd
@@ -227,16 +246,18 @@ jobs:
         run: |
           # workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
           # FIXME: I suspect this line is no longer required.
-          Remove-Item (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+          Remove-Item -Path (Join-Path devolutions-gateway PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
 
           # Devolutions Agent on Linux does not have any useful feature yet, so we filter out the Linux artifacts.
-          Remove-Item (Join-Path devolutions-agent linux) -Recurse -ErrorAction Ignore
+          Remove-Item -Path (Join-Path devolutions-agent linux) -Recurse -ErrorAction Ignore
 
       - name: Create GitHub release
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          Set-PSDebug -Trace 1
+
           $Version = "${{ needs.preflight.outputs.version }}"
           $HashPath = 'checksums'
           $Files = Get-ChildItem -Recurse -File -Exclude 'CHANGELOG.md', '*.dll' | % { Get-FileHash -Algorithm SHA256 $_.FullName }
@@ -278,11 +299,13 @@ jobs:
       ## workflow_call: The same artifacts persist across the entire run, so the PowerShell/DevolutionsGateway directory will still exist from the CI workflow
       - name: Manage artifacts
         shell: pwsh
-        run: Remove-Item (Join-Path PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
+        run: Remove-Item -Path (Join-Path PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
 
       - name: Publish PowerShell module
         shell: pwsh
         run: |
+          Set-PSDebug -Trace 1
+
           $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File
           Expand-Archive -Path $Archive -DestinationPath 'PowerShell'
 
@@ -340,6 +363,8 @@ jobs:
         id: prepare
         shell: pwsh
         run: |
+          Set-PSDebug -Trace 1
+
           $destinationFolder = "${{ runner.temp }}/artifacts"
           $version="${{ needs.preflight.outputs.version }}"
           # Note that ".0" is appended here (required by release tooling downstream)
@@ -399,6 +424,8 @@ jobs:
         id: prepare
         shell: pwsh
         run: |
+          Set-PSDebug -Trace 1
+
           $destinationFolder = "${{ runner.temp }}/artifacts"
           $version="${{ needs.preflight.outputs.version }}"
           # Note that ".0" is appended here (required by release tooling downstream)
@@ -445,4 +472,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: ./ci/remove-labels.ps1 -Label 'release-required'
-


### PR DESCRIPTION
We decided to drop Windows container images a while back, but this was not reflected in the workflow.

