### PR TITLE
ci: fix powershell publishing job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,14 +467,22 @@ jobs:
       - name: Build module
         shell: pwsh
         run: |
-          ./powershell/build.ps1
-          $PSModuleName = "DevolutionsGateway"
           $PSModuleVersion = "${{ needs.preflight.outputs.version }}"
-          $PSModuleOutputPath = Join-Path "powershell" "package" $PSModuleName
+
+          ./powershell/build.ps1
+
+          $PSModuleName = "DevolutionsGateway"
+          $PSModuleParentPath = Join-Path "powershell" "package"
+          Write-Host "PSModuleOutputPath = $PSModuleParentPath"
+
           $PSStagingPath = Join-Path "powershell-staging" "PowerShell"
+          Write-Host "PSStagingPath = $PSStagingPath"
           New-Item -Path $PSStagingPath -ItemType Directory | Out-Null
-          $PSModuleZipFilePath = Join-Path $PSStagingPath "$PSModuleName-ps-$PSModuleVersion.zip"
-          Compress-Archive -Path $PSModuleOutputPath -Destination $PSModuleZipFilePath
+
+          $PSModuleTarFilePath = Join-Path $PSStagingPath "$PSModuleName-ps-$PSModuleVersion.tar"
+          Write-Host "PSModuleTarFilePath = $PSModuleTarFilePath"
+
+          tar -cvf "$PSModuleTarFilePath" -C "$PSModuleParentPath" "$PSModuleName"
 
       - name: Pester tests
         shell: pwsh
@@ -630,14 +638,19 @@ jobs:
           TARGET_OUTPUT_PATH: ${{ steps.load-variables.outputs.target-output-path }}
           DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}
         run: |
+          Set-PSDebug -Trace 1
+
           if ($Env:RUNNER_OS -eq "Windows") {
             $Env:DGATEWAY_PACKAGE = "${{ steps.load-variables.outputs.dgateway-package }}"
             $Env:DGATEWAY_LIB_XMF_PATH = Join-Path "native-libs" "xmf.dll" | Resolve-Path
 
             $PSStagingPath = Join-Path (Get-Location) "powershell-staging"
+            Write-Host "PSStagingPath = $PSStagingPath"
             $PSModuleOutputPath = Join-Path $PSStagingPath "DevolutionsGateway"
-            $PSModuleZipFilePath = Get-ChildItem -Path "$PSStagingPath/PowerShell" "*-ps-*.zip" | Select-Object -First 1
-            Expand-Archive -Path $PSModuleZipFilePath -Destination $PSStagingPath
+            $PSModuleTarFilePath = Get-ChildItem -Path "$PSStagingPath/PowerShell" "*-ps-*.tar" | Select-Object -First 1
+            tar -xvf "$PSModuleTarFilePath" -C "$PSStagingPath"
+            Get-ChildItem -Path "$PSStagingPath" -Recurse
+
             $Env:DGATEWAY_PSMODULE_PATH = $PSModuleOutputPath
           } else {
             $Env:DGATEWAY_LIB_XMF_PATH = Join-Path "native-libs" "libxmf.so" | Resolve-Path

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -231,8 +231,8 @@ jobs:
 
           . .\ci\PSModuleHelpers.ps1
           $PSModuleOutputPath = Join-Path ${{ runner.temp }} ${{ matrix.project }} "PowerShell"
-          $PSModuleZipFilePath = Get-ChildItem -Path $PSModuleOutputPath "DevolutionsGateway-ps-*.zip" | Select-Object -First 1
-          Expand-Archive -Path $PSModuleZipFilePath -Destination $PSModuleOutputPath
+          $PSModuleTarFilePath = Get-ChildItem -Path $PSModuleOutputPath "DevolutionsGateway-ps-*.tar" | Select-Object -First 1
+          tar -xvf "$PSModuleTarFilePath" -C "$PSModuleOutputPath"
           $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
 
           $IncludePattern = @('*.ps1', '*.psd1', '*.psm1', 'DevolutionsGateway.dll')
@@ -248,11 +248,21 @@ jobs:
             AzureSignTool @Params $_.FullName
           }
 
-          Remove-Item $PSModuleZipFilePath -ErrorAction SilentlyContinue | Out-Null
-          Compress-Archive -Path $DGatewayPSModulePath -Destination $PSModuleZipFilePath -CompressionLevel Optimal
+          Remove-Item $PSModuleTarFilePath -ErrorAction SilentlyContinue | Out-Null
 
           $PSModuleParentPath = Split-Path $DGatewayPSModulePath -Parent
 
+          # For some reason, when using Compress-Archive we end up with a corrupted archive once in the release.yml workflow.
+          # Maybe because of the double compression via the upload-artifact action?
+          # With a tarball archive, there is no problem.
+          Write-Host "Recreate archive at $PSModuleTarFilePath"
+          tar -cvf "$PSModuleTarFilePath" -C "$PSModuleParentPath" DevolutionsGateway
+
+          # Verify the archive.
+          Write-Host "Verify archive at $PSModuleTarFilePath"
+          tar -t "$PSModuleTarFilePath"
+
+          Set-PSDebug -Off # Too many traces are logged when running New-ModulePackage.
           New-ModulePackage $DGatewayPSModulePath $PSModuleParentPath
 
       - name: Sign executables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,8 +170,8 @@ jobs:
           New-Item -ItemType Directory -Path $TargetPath
           tar -xvzf $WebAppArchive.FullName -C $TargetPath --strip-components=1
 
-          $PowerShellArchive = Get-ChildItem -Recurse -Filter "DevolutionsGateway-ps-*.zip" | Select-Object -First 1
-          Expand-Archive -Path $PowerShellArchive -DestinationPath "$PkgDir"
+          $PowerShellArchive = Get-ChildItem -Recurse -Filter "DevolutionsGateway-ps-*.tar" | Select-Object -First 1
+          tar -xvf "$PowerShellArchive" -C "$PkgDir"
 
       - name: Build container
         id: build-container
@@ -277,27 +277,32 @@ jobs:
         shell: pwsh
         run: Remove-Item -Path (Join-Path PowerShell DevolutionsGateway) -Recurse -ErrorAction Ignore
 
+      - name: Install PSResourceGet
+        shell: pwsh
+        run: |
+          Install-PSResource Microsoft.PowerShell.PSResourceGet -Scope CurrentUser -TrustRepository
+
       - name: Publish PowerShell module
         shell: pwsh
         run: |
-          Set-PSDebug -Trace 1
+          $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.tar" -File
+          Write-Host "Archive = $Archive"
 
-          $Archive = Get-ChildItem -Recurse -Filter "*-ps-*.zip" -File
-          Expand-Archive -Path $Archive -DestinationPath 'PowerShell'
+          tar -xvf "$Archive" -C './PowerShell'
+          Get-ChildItem -Path "./PowerShell" -Recurse
 
-          $PublishCmd = @('Publish-Module', '-Force', '-Path', (Join-Path PowerShell DevolutionsGateway), '-NugetApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
+          $PublishCmd = @('Publish-PSResource', '-Repository', 'PSGallery', '-Path', (Join-Path PowerShell DevolutionsGateway), '-ApiKey', '${{ secrets.PS_GALLERY_NUGET_API_KEY }}')
 
           $DryRun = [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
           if ($DryRun) {
             $PublishCmd += '-WhatIf'
           }
           $PublishCmd = $PublishCmd -Join ' '
-          Write-Host $PublishCmd
+          Write-Host "PublishCmd = $PublishCmd"
 
           try {
             Invoke-Expression $PublishCmd
-          }
-          catch {
+          } catch {
             if ($_.Exception.Message -ilike "*cannot be published as the current version*is already available in the repository*") {
               echo "::warning::PowerShell module not published; this version is already listed on PSGallery"
             } else {


### PR DESCRIPTION
- Create a tarball archive instead of a zip archive for the PowerShell module.
  -  It’s unclear to me why, but the PowerShell module we sign and re-archive in the package workflow is corrupted when we try to decompress it in the release workflow.
  - This is something I could verify locally using the `7z` command.
- The `Publish-Module` cmdlet was also failing with a cryptic error:

  > Write-Error: Cannot retrieve the dynamic parameters for the cmdlet. Loading repository store failed: Could not find a part of the path '/home/runner/.local/share/PSResourceGet/PSResourceRepository.xml'.

  - I walked around that by switching to the newer `Publish-PSResource` cmdlet, which is a more modern rewrite of `Publish-Module`.