### PR TITLE
feat(webapp): implement MVP for self-contained session URLs

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -18,8 +18,8 @@
         "@angular/platform-browser-dynamic": "18.2.1",
         "@angular/router": "18.2.1",
         "@devolutions/icons": "4.0.8",
-        "@devolutions/iron-remote-desktop": "../../ironrdp/web-client/iron-remote-desktop/dist",
-        "@devolutions/iron-remote-desktop-rdp": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
+        "@devolutions/iron-remote-desktop": "^0.7.0",
+        "@devolutions/iron-remote-desktop-rdp": "^0.5.0",
         "@devolutions/iron-remote-desktop-vnc": "^0.4.1",
         "@devolutions/web-ssh-gui": "0.3.1",
         "@devolutions/web-telnet-gui": "0.2.19",
@@ -60,11 +60,13 @@
     },
     "../../ironrdp/web-client/iron-remote-desktop-rdp/dist": {
       "name": "@devolutions/iron-remote-desktop-rdp",
-      "version": "0.4.0"
+      "version": "0.2.1",
+      "extraneous": true
     },
     "../../ironrdp/web-client/iron-remote-desktop/dist": {
       "name": "@devolutions/iron-remote-desktop",
-      "version": "0.7.0"
+      "version": "0.5.1",
+      "extraneous": true
     },
     "../../ironvnc/web-client/iron-remote-desktop/dist": {
       "extraneous": true
@@ -2913,12 +2915,14 @@
       }
     },
     "node_modules/@devolutions/iron-remote-desktop": {
-      "resolved": "../../ironrdp/web-client/iron-remote-desktop/dist",
-      "link": true
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop/-/iron-remote-desktop-0.7.0.tgz",
+      "integrity": "sha512-5poFHoDkuyE9592tXfQZisyFm0+1pTBll+MDECmsAGT/OB4r4Si5okDqrx7cJmm+Y4m/OcMYNdSUVbhJZwBclw=="
     },
     "node_modules/@devolutions/iron-remote-desktop-rdp": {
-      "resolved": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
-      "link": true
+      "version": "0.5.0",
+      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-rdp/-/iron-remote-desktop-rdp-0.5.0.tgz",
+      "integrity": "sha512-9BM2ZUrtqoY2EC0U/wOXmNRqwSkzYciID4cLUII4mZbLgBej3twPy8WKxP4WE1l1rNdm2RNBCGZQ1dr68Z7C9w=="
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc": {
       "version": "0.4.1",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -18,8 +18,8 @@
         "@angular/platform-browser-dynamic": "18.2.1",
         "@angular/router": "18.2.1",
         "@devolutions/icons": "4.0.8",
-        "@devolutions/iron-remote-desktop": "^0.7.0",
-        "@devolutions/iron-remote-desktop-rdp": "^0.4.0",
+        "@devolutions/iron-remote-desktop": "../../ironrdp/web-client/iron-remote-desktop/dist",
+        "@devolutions/iron-remote-desktop-rdp": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
         "@devolutions/iron-remote-desktop-vnc": "^0.4.1",
         "@devolutions/web-ssh-gui": "0.3.1",
         "@devolutions/web-telnet-gui": "0.2.19",
@@ -60,13 +60,11 @@
     },
     "../../ironrdp/web-client/iron-remote-desktop-rdp/dist": {
       "name": "@devolutions/iron-remote-desktop-rdp",
-      "version": "0.2.1",
-      "extraneous": true
+      "version": "0.4.0"
     },
     "../../ironrdp/web-client/iron-remote-desktop/dist": {
       "name": "@devolutions/iron-remote-desktop",
-      "version": "0.5.1",
-      "extraneous": true
+      "version": "0.7.0"
     },
     "../../ironvnc/web-client/iron-remote-desktop/dist": {
       "extraneous": true
@@ -2915,14 +2913,12 @@
       }
     },
     "node_modules/@devolutions/iron-remote-desktop": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop/-/iron-remote-desktop-0.7.0.tgz",
-      "integrity": "sha512-5poFHoDkuyE9592tXfQZisyFm0+1pTBll+MDECmsAGT/OB4r4Si5okDqrx7cJmm+Y4m/OcMYNdSUVbhJZwBclw=="
+      "resolved": "../../ironrdp/web-client/iron-remote-desktop/dist",
+      "link": true
     },
     "node_modules/@devolutions/iron-remote-desktop-rdp": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop-rdp/-/iron-remote-desktop-rdp-0.4.0.tgz",
-      "integrity": "sha512-OHJ9bXxp8W0j3KyuFx/HbKT2t9YjlbyBY9ON6WB/WPdlIohkdbXD9ZYnc6kdAOU6M161WjYzPFyw/iY0ZrsbCw=="
+      "resolved": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
+      "link": true
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc": {
       "version": "0.4.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,7 @@
     "@angular/router": "18.2.1",
     "@devolutions/icons": "4.0.8",
     "@devolutions/iron-remote-desktop": "^0.7.0",
-    "@devolutions/iron-remote-desktop-rdp": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
+    "@devolutions/iron-remote-desktop-rdp": "^0.5.0",
     "@devolutions/iron-remote-desktop-vnc": "^0.4.1",
     "@devolutions/web-ssh-gui": "0.3.1",
     "@devolutions/web-telnet-gui": "0.2.19",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,7 +31,7 @@
     "@angular/router": "18.2.1",
     "@devolutions/icons": "4.0.8",
     "@devolutions/iron-remote-desktop": "^0.7.0",
-    "@devolutions/iron-remote-desktop-rdp": "^0.4.0",
+    "@devolutions/iron-remote-desktop-rdp": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
     "@devolutions/iron-remote-desktop-vnc": "^0.4.1",
     "@devolutions/web-ssh-gui": "0.3.1",
     "@devolutions/web-telnet-gui": "0.2.19",

--- a/webapp/src/client/app/modules/login/login.component.ts
+++ b/webapp/src/client/app/modules/login/login.component.ts
@@ -71,7 +71,7 @@ export class LoginComponent extends BaseComponent implements OnInit {
 
   private handleLoginResult(success: boolean): void {
     if (success) {
-      void this.navigationService.navigateToNewSession();
+      void this.navigationService.navigateToReturnUrl();
     } else {
       this.autoLoginAttempted = true;
     }

--- a/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.ts
+++ b/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.ts
@@ -12,13 +12,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { IronError, SessionEvent, UserInteraction } from '@devolutions/iron-remote-desktop';
-import {
-  Backend,
-  displayControl,
-  kdcProxyUrl,
-  preConnectionBlob,
-  RdpConfigParser,
-} from '@devolutions/iron-remote-desktop-rdp';
+import { Backend, displayControl, kdcProxyUrl, preConnectionBlob, RdpFile } from '@devolutions/iron-remote-desktop-rdp';
 import { WebClientBaseComponent } from '@shared/bases/base-web-client.component';
 import { GatewayAlertMessageService } from '@shared/components/gateway-alert-message/gateway-alert-message.service';
 import { ScreenScale } from '@shared/enums/screen-scale.enum';
@@ -411,13 +405,14 @@ export class WebClientRdpComponent extends WebClientBaseComponent implements OnI
   }
 
   private parseRdpConfig(config: string): Observable<IronRDPConnectionParameters> {
-    const configParser = new RdpConfigParser(atob(config));
+    const rdpFile = new RdpFile();
+    rdpFile.parse(atob(config));
 
-    const host = configParser.getStr('full address');
-    const port = configParser.getInt('server port');
-    const username = configParser.getStr('username');
-    const password = configParser.getStr('ClearTextPassword');
-    const kdcProxyUrl = configParser.getStr('kdcproxyurl');
+    const host = rdpFile.getStr('full address');
+    const port = rdpFile.getInt('server port');
+    const username = rdpFile.getStr('username');
+    const password = rdpFile.getStr('ClearTextPassword');
+    const kdcProxyUrl = rdpFile.getStr('kdcproxyurl');
 
     const extractedUsernameDomain: ExtractedUsernameDomain = this.utils.string.extractDomain(username);
 

--- a/webapp/src/client/app/shared/guards/auth.guard.ts
+++ b/webapp/src/client/app/shared/guards/auth.guard.ts
@@ -3,7 +3,7 @@ import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/ro
 
 import { AuthService } from '@shared/services/auth.service';
 
-export function authGuard(_route: ActivatedRouteSnapshot, _state: RouterStateSnapshot): boolean {
+export function authGuard(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
   const router: Router = inject(Router);
   const authService = inject(AuthService);
 
@@ -11,7 +11,8 @@ export function authGuard(_route: ActivatedRouteSnapshot, _state: RouterStateSna
     return true;
   }
 
-  //TODO Add when standalone has more feature pages: { queryParams: { returnUrl: state.url } }
-  void router.navigate(['login']);
+  void router.navigate(['login'], {
+    queryParams: { returnUrl: state.url },
+  });
   return false;
 }

--- a/webapp/src/client/app/shared/services/navigation.service.ts
+++ b/webapp/src/client/app/shared/services/navigation.service.ts
@@ -32,6 +32,15 @@ export class NavigationService {
     return this.router.navigateByUrl(NavigationService.SESSION_KEY);
   }
 
+  navigateToReturnUrl(): Promise<boolean> {
+    const returnUrl = this.activatedRoute.snapshot.queryParams.returnUrl;
+    if (returnUrl) {
+      return this.router.navigateByUrl(returnUrl);
+    }
+    // Navigate to a new session as a fallback.
+    return this.navigateToNewSession();
+  }
+
   navigateToRDPSession(connectionTypeRoute: WebClientSection, queryParams?: string) {
     const webClientUrl = `session/${connectionTypeRoute}` + (queryParams ?? '');
     return this.router.navigateByUrl(webClientUrl);


### PR DESCRIPTION
This PR adds support for `config`, `autoconnect`, and `protocol` query parameters in the Devolutions Gateway Standalone.
Since it is an MVP, there are many things left to be done (I marked them with TODO). 
Here is a demo:  
https://github.com/user-attachments/assets/249ccde3-1973-424b-bd19-78b9d3a71045

