### PR TITLE
build: add tun2socks to Devolutions Agent package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,22 @@ jobs:
           name: devolutions-pedm-desktop
           path: devolutions-pedm-desktop
 
+      - name: Download tun2socks
+        id: tun2socks
+        shell: pwsh
+        if: matrix.os == 'windows'
+        run: |
+          $Arch = @{'x86_64'='x64';'arm64'='arm64'}['${{ matrix.arch }}']
+          $Destination = Join-Path $PWD "tun2socks"
+          ./ci/download-tun2socks.ps1 -Architecture $Arch -Destination $Destination
+          $Tun2SocksExecutablePath = Join-Path $Destination "tun2socks.exe"
+          $WintunLibraryPath = Join-Path $Destination "wintun.dll"
+          echo "tun2socks-executable-path=$Tun2SocksExecutablePath" >> $Env:GITHUB_OUTPUT
+          echo "wintun-library-path=$WintunLibraryPath" >> $Env:GITHUB_OUTPUT
+          @($Tun2SocksExecutablePath, $WintunLibraryPath) | % {
+            if (-Not (Test-Path $_)) { throw "$_ not found" }
+          }
+
       - name: Setup LLVM
         uses: Devolutions/actions-public/setup-llvm@v1
         if: runner.os == 'Linux'
@@ -835,6 +851,8 @@ jobs:
             $Env:DAGENT_PEDM_SHELL_EXT_DLL = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-dll }}"
             $Env:DAGENT_PEDM_SHELL_EXT_MSIX = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-msix }}"
             $Env:DAGENT_SESSION_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-session-executable }}"
+            $Env:DAGENT_TUN2SOCKS_EXE = "${{ steps.tun2socks.outputs.tun2socks-executable-path }}"
+            $Env:DAGENT_WINTUN_DLL = "${{ steps.tun2socks.outputs.wintun-library-path }}"
           }
 
           if ($Env:RUNNER_OS -eq "Linux") {
@@ -864,6 +882,8 @@ jobs:
             $Env:DAGENT_PEDM_SHELL_EXT_DLL = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-dll }}"
             $Env:DAGENT_PEDM_SHELL_EXT_MSIX = "${{ steps.load-variables.outputs.dagent-pedm-shell-ext-msix }}"
             $Env:DAGENT_SESSION_EXECUTABLE = "${{ steps.load-variables.outputs.dagent-session-executable }}"
+            $Env:DAGENT_TUN2SOCKS_EXE = "${{ steps.tun2socks.outputs.tun2socks-executable-path }}"
+            $Env:DAGENT_WINTUN_DLL = "${{ steps.tun2socks.outputs.wintun-library-path }}"
           }
 
           ./ci/tlk.ps1 package -Product agent -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}

--- a/ci/download-tun2socks.ps1
+++ b/ci/download-tun2socks.ps1
@@ -1,0 +1,34 @@
+#!/bin/env pwsh
+
+param(
+    [Parameter(Mandatory=$true)]
+	[ValidateSet('x64', 'arm64')]
+	[string] $Architecture,
+
+    [string] $Destination = "."
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-Not (Test-Path $Destination)) {
+    New-Item -Path $Destination -ItemType Directory | Out-Null
+}
+
+$WintunVersion = "0.14.1"
+$WintunArch = @{'x64'='amd64';'arm64'='arm64'}[$Architecture]
+$WintunBaseUrl = "https://www.wintun.net/builds"
+$WintunZipFileName = "wintun-$WintunVersion.zip"
+Invoke-WebRequest -Uri "$WintunBaseUrl/$WintunZipFileName" -OutFile $WintunZipFileName -ErrorAction Stop
+Expand-Archive $WintunZipFileName -Destination . -Force
+Remove-Item $WintunZipFileName | Out-Null
+Move-Item "./wintun/bin/$WintunArch/wintun.dll" (Join-Path $Destination "wintun.dll") -Force
+Remove-Item "./wintun" -Recurse | Out-Null
+
+$Tun2SocksVersion = "v2.5.2"
+$Tun2SocksArch = @{'x64'='amd64';'arm64'='arm64'}[$Architecture]
+$Tun2SocksBaseUrl = "https://github.com/xjasonlyu/tun2socks/releases/download/$Tun2SocksVersion"
+$Tun2SocksZipFileName = "tun2socks-windows-$Tun2SocksArch.zip"
+Invoke-WebRequest -Uri "$Tun2SocksBaseUrl/$Tun2SocksZipFileName" -OutFile $Tun2SocksZipFileName -ErrorAction Stop
+Expand-Archive $Tun2SocksZipFileName -Destination . -Force
+Remove-Item $Tun2SocksZipFileName | Out-Null
+Move-Item "tun2socks-windows-$Tun2SocksArch.exe" (Join-Path $Destination "tun2socks.exe") -Force

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -89,6 +89,10 @@ internal class Program
 
     private static string DevolutionsSession => ResolveArtifact("DAGENT_SESSION_EXECUTABLE", "..\\..\\target\\x86_64-pc-windows-msvc\\release\\devolutions-session.exe");
 
+    private static string DevolutionsTun2SocksExe => ResolveArtifact("DAGENT_TUN2SOCKS_EXE", "..\\..\\tun2socks.exe");
+
+    private static string DevolutionsWintunDll => ResolveArtifact("DAGENT_WINTUN_DLL", "..\\..\\wintun.dll");
+
     private static string TargetOutputPath => ResolveDirectory("TARGET_OUTPUT_PATH", "..\\..\\target\\x86_64-pc-windows-msvc\\release\\");
 
     private static Version DevolutionsAgentVersion
@@ -258,9 +262,12 @@ internal class Program
                 Dirs = new[]
                 {
                     new Dir(Features.PEDM_FEATURE, "desktop", new Files(Features.PEDM_FEATURE, $"{DevolutionsDesktopAgentPath}\\*.*")),
-                    new Dir(Features.PEDM_FEATURE, "ShellExt", 
-                        new File(Features.PEDM_FEATURE, DevolutionsPedmShellExtDll), 
-                        new File(Features.PEDM_FEATURE, DevolutionsPedmShellExtMsix))
+                    new Dir(Features.PEDM_FEATURE, "ShellExt",
+                        new File(Features.PEDM_FEATURE, DevolutionsPedmShellExtDll),
+                        new File(Features.PEDM_FEATURE, DevolutionsPedmShellExtMsix)),
+                    new Dir(Features.AGENT_FEATURE, "tun2socks", 
+                        new File(Features.AGENT_FEATURE, DevolutionsTun2SocksExe), 
+                        new File(Features.AGENT_FEATURE, DevolutionsWintunDll))
                 }
             })),
         };


### PR DESCRIPTION
add tun2socks directory with tun2socks.exe, wintun.dll to Devolutions Agent package on Windows. It will make it much easier for us to try using manually since tun2socks doesn't have an installer. I'm not making it optional, I'm just including a copy of it. We'll work later on figuring out a way to call it from Devolutions Agent elevated to start/stop tunnels, similar to Cloudflare WARP.