### PR TITLE
refactor(webapp): replace the current clipboard with auto and manual modes

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -18,9 +18,9 @@
         "@angular/platform-browser-dynamic": "18.2.1",
         "@angular/router": "18.2.1",
         "@devolutions/icons": "4.0.8",
-        "@devolutions/iron-remote-desktop": "^0.7.0",
-        "@devolutions/iron-remote-desktop-rdp": "^0.5.0",
-        "@devolutions/iron-remote-desktop-vnc": "^0.4.1",
+        "@devolutions/iron-remote-desktop": "../../ironrdp/web-client/iron-remote-desktop/dist",
+        "@devolutions/iron-remote-desktop-rdp": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
+        "@devolutions/iron-remote-desktop-vnc": "../../ironvnc/web-client/iron-remote-desktop-vnc/dist",
         "@devolutions/terminal-shared": "^1.3.1",
         "@devolutions/web-ssh-gui": "^0.4.0",
         "@devolutions/web-telnet-gui": "^0.3.0",
@@ -30,6 +30,7 @@
         "prismjs": "1.29.0",
         "rxjs": "^7.8.1",
         "tslib": "2.6.1",
+        "ua-parser-js": "^2.0.4",
         "uuid": "^9.0.1",
         "web-animations-js": "2.3.2",
         "zone.js": "0.14.10"
@@ -61,13 +62,18 @@
     },
     "../../ironrdp/web-client/iron-remote-desktop-rdp/dist": {
       "name": "@devolutions/iron-remote-desktop-rdp",
-      "version": "0.2.1",
-      "extraneous": true
+      "version": "0.5.2"
     },
     "../../ironrdp/web-client/iron-remote-desktop/dist": {
       "name": "@devolutions/iron-remote-desktop",
-      "version": "0.5.1",
-      "extraneous": true
+      "version": "0.7.0"
+    },
+    "../../ironvnc/web-client/iron-remote-desktop-vnc/dist": {
+      "name": "@devolutions/iron-remote-desktop-vnc",
+      "version": "0.4.1",
+      "dependencies": {
+        "rxjs": "^6.6.7"
+      }
     },
     "../../ironvnc/web-client/iron-remote-desktop/dist": {
       "extraneous": true
@@ -2917,40 +2923,16 @@
       }
     },
     "node_modules/@devolutions/iron-remote-desktop": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@devolutions/iron-remote-desktop/-/iron-remote-desktop-0.7.0.tgz",
-      "integrity": "sha512-5poFHoDkuyE9592tXfQZisyFm0+1pTBll+MDECmsAGT/OB4r4Si5okDqrx7cJmm+Y4m/OcMYNdSUVbhJZwBclw=="
+      "resolved": "../../ironrdp/web-client/iron-remote-desktop/dist",
+      "link": true
     },
     "node_modules/@devolutions/iron-remote-desktop-rdp": {
-      "version": "0.5.0",
-      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-rdp/-/iron-remote-desktop-rdp-0.5.0.tgz",
-      "integrity": "sha512-9BM2ZUrtqoY2EC0U/wOXmNRqwSkzYciID4cLUII4mZbLgBej3twPy8WKxP4WE1l1rNdm2RNBCGZQ1dr68Z7C9w=="
+      "resolved": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
+      "link": true
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc": {
-      "version": "0.4.1",
-      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-vnc/-/@devolutions/iron-remote-desktop-vnc-0.4.1.tgz",
-      "integrity": "sha512-JRrmRdwxl74gtlpHys//OAUIJ/vJgPlQlBEV8FY2nDZDtUYA+mY3qa0VubI5P0ss8ZxQI1Ez9ghf1GP2oQa+Xg==",
-      "dependencies": {
-        "rxjs": "^6.6.7"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "resolved": "../../ironvnc/web-client/iron-remote-desktop-vnc/dist",
+      "link": true
     },
     "node_modules/@devolutions/terminal-shared": {
       "version": "1.3.1",
@@ -4890,9 +4872,18 @@
       "version": "22.9.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
       "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~6.19.8"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/node-forge": {
@@ -5437,6 +5428,12 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -5867,6 +5864,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6127,6 +6137,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -6611,6 +6633,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6629,6 +6660,26 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.0.3",
@@ -6730,6 +6781,20 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -6776,7 +6841,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -6786,7 +6850,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6912,13 +6975,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -6927,7 +6987,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6937,6 +6996,33 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
       "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.23.0",
@@ -7447,6 +7533,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7528,7 +7630,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7564,22 +7665,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -7663,12 +7782,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7707,11 +7826,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -7719,11 +7838,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -7735,7 +7857,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -8351,6 +8472,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -8842,6 +8983,33 @@
       "dev": true,
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/karma/node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/karma/node_modules/wrap-ansi": {
@@ -9393,6 +9561,15 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -9495,7 +9672,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9504,7 +9680,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9903,6 +10078,26 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
@@ -11403,7 +11598,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/sass": {
       "version": "1.77.6",
@@ -12500,6 +12695,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tree-dump": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
@@ -12588,11 +12789,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ua-parser-js": {
-      "version": "0.7.39",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
-      "integrity": "sha512-IZ6acm6RhQHNibSt7+c09hhvsKy9WUr4DVbeq9U8o71qxyYtJpQeDxQnMrVqnIFMLcQjHO0I9wgfO2vIahht4w==",
-      "dev": true,
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.4.tgz",
+      "integrity": "sha512-XiBOnM/UpUq21ZZ91q2AVDOnGROE6UQd37WrO9WBgw4u2eGvUCNOheMmZ3EfEUj7DLHr8tre+Um/436Of/Vwzg==",
       "funding": [
         {
           "type": "opencollective",
@@ -12607,6 +12827,14 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@types/node-fetch": "^2.6.12",
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "node-fetch": "^2.7.0",
+        "ua-is-frozen": "^0.1.2"
+      },
       "bin": {
         "ua-parser-js": "script/cli.js"
       },
@@ -12617,8 +12845,7 @@
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -13333,6 +13560,12 @@
       "resolved": "https://registry.npmjs.org/web-animations-js/-/web-animations-js-2.3.2.tgz",
       "integrity": "sha512-TOMFWtQdxzjWp8qx4DAraTWTsdhxVSiWa6NkPFSaPtZ1diKUxTn4yTix73A1euG1WbSOMMPcY51cnjTIHrGtDA=="
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack": {
       "version": "5.94.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
@@ -13670,6 +13903,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -31,8 +31,8 @@
     "@angular/router": "18.2.1",
     "@devolutions/icons": "4.0.8",
     "@devolutions/iron-remote-desktop": "../../ironrdp/web-client/iron-remote-desktop/dist",
-    "@devolutions/iron-remote-desktop-rdp": "^0.5.0",
-    "@devolutions/iron-remote-desktop-vnc": "^0.4.1",
+    "@devolutions/iron-remote-desktop-rdp": "../../ironrdp/web-client/iron-remote-desktop-rdp/dist",
+    "@devolutions/iron-remote-desktop-vnc": "../../ironvnc/web-client/iron-remote-desktop-vnc/dist",
     "@devolutions/terminal-shared": "^1.3.1",
     "@devolutions/web-ssh-gui": "^0.4.0",
     "@devolutions/web-telnet-gui": "^0.3.0",
@@ -42,6 +42,7 @@
     "prismjs": "1.29.0",
     "rxjs": "^7.8.1",
     "tslib": "2.6.1",
+    "ua-parser-js": "^2.0.4",
     "uuid": "^9.0.1",
     "web-animations-js": "2.3.2",
     "zone.js": "0.14.10"

--- a/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.html
+++ b/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.html
@@ -12,7 +12,8 @@
     [middleButtons]="middleToolbarButtons"
     [middleToggleButtons]="middleToolbarToggleButtons"
     [rightButtons]="rightToolbarButtons"
-    [sliders]="sliders">
+    [sliders]="sliders"
+    [clipboardActionButtons]="clipboardActionButtons">
   </session-toolbar>
 
   <div class="loading-info-container" *ngIf="loading">

--- a/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts
+++ b/webapp/src/client/app/modules/web-client/ard/web-client-ard.component.ts
@@ -61,6 +61,8 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
   isFullScreenMode = false;
   cursorOverrideActive = false;
 
+  saveRemoteClipboardButtonEnabled = false;
+
   middleToolbarButtons = [
     {
       label: 'Full Screen',
@@ -107,6 +109,37 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
     },
   ];
 
+  clipboardActionButtons: {
+    label: string;
+    tooltip: string;
+    icon: string;
+    action: () => Promise<void>;
+    enabled: () => boolean;
+  }[] = [];
+
+  private setupClipboardHandling(): void {
+    if (this.formData.autoClipboard === true) {
+      return;
+    }
+
+    this.clipboardActionButtons.push(
+      {
+        label: 'Save Clipboard',
+        tooltip: 'Copy received clipboard content to your local clipboard.',
+        icon: 'dvl-icon dvl-icon-save',
+        action: () => this.saveRemoteClipboard(),
+        enabled: () => this.saveRemoteClipboardButtonEnabled,
+      },
+      {
+        label: 'Send Clipboard',
+        tooltip: 'Send your local clipboard content to the remote server.',
+        icon: 'dvl-icon dvl-icon-send',
+        action: () => this.sendClipboard(),
+        enabled: () => true,
+      },
+    );
+  }
+
   protected removeElement = new Subject();
   private remoteClientEventListener: (event: Event) => void;
   private remoteClient: UserInteraction;
@@ -129,6 +162,7 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
 
   ngOnInit(): void {
     this.removeWebClientGuiElement();
+    this.setupClipboardHandling();
   }
 
   ngAfterViewInit(): void {
@@ -162,6 +196,25 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
 
   setKeyboardUnicodeMode(useUnicode: boolean): void {
     this.remoteClient.setKeyboardUnicodeMode(useUnicode);
+  }
+
+  async saveRemoteClipboard(): Promise<void> {
+    const result = await this.remoteClient.saveRemoteClipboardData();
+    // We handle only the successful result. On failure, an error event is raised,
+    // which we handle separately.
+    if (result) {
+      super.webClientSuccess('Clipboard content has been copied to your clipboard!');
+      this.saveRemoteClipboardButtonEnabled = false;
+    }
+  }
+
+  async sendClipboard(): Promise<void> {
+    const result = await this.remoteClient.sendClipboardData();
+    // We handle only the successful result. On failure, an error event is raised,
+    // which we handle separately.
+    if (result) {
+      super.webClientSuccess('Clipboard content has been sent to the remote server!');
+    }
   }
 
   toggleCursorKind(): void {
@@ -268,6 +321,10 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
     const customEvent = event as CustomEvent;
     this.remoteClient = customEvent.detail.irgUserInteraction;
 
+    if (this.formData.autoClipboard !== true) {
+      this.remoteClient.setEnableAutoClipboard(false);
+    }
+
     this.initSessionEventHandler();
     this.startConnectionProcess();
   }
@@ -365,6 +422,9 @@ export class WebClientArdComponent extends WebClientBaseComponent implements OnI
           break;
         case SessionEventType.ERROR:
           this.handleSessionError(event);
+          break;
+        case SessionEventType.CLIPBOARD_REMOTE_UPDATE:
+          this.saveRemoteClipboardButtonEnabled = true;
           break;
       }
     };

--- a/webapp/src/client/app/modules/web-client/form/form-components/ard/ard-form.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-components/ard/ard-form.component.html
@@ -17,7 +17,7 @@
     </div>
 
     <div [hidden]="!showMoreSettings" class="col-12 gateway-form-group">
-  
+
       <div class="col-12 gateway-form-group">
         <web-client-resolution-quality-control [parentForm]="form"
                                                [inputFormData]="inputFormData"></web-client-resolution-quality-control>
@@ -28,6 +28,11 @@
                                              [inputFormData]="inputFormData"></web-client-ard-quality-mode-control>
       </div>
 
-    </div>
-    
+      <div *ngIf="showAutoClipboardCheckbox" class="col-12 gateway-form-group">
+        <web-client-auto-clipboard-control [parentForm]="form"
+                                           [inputFormData]="inputFormData"></web-client-auto-clipboard-control>
+      </div>
+
+  </div>
+
 </div>

--- a/webapp/src/client/app/modules/web-client/form/form-components/ard/ard-form.component.ts
+++ b/webapp/src/client/app/modules/web-client/form/form-components/ard/ard-form.component.ts
@@ -3,6 +3,7 @@ import { FormGroup } from '@angular/forms';
 import { ArdFormDataInput } from '@gateway/shared/interfaces/forms.interfaces';
 
 import { BaseComponent } from '@shared/bases/base.component';
+import { UAParser } from 'ua-parser-js';
 
 @Component({
   selector: 'ard-form',
@@ -14,12 +15,15 @@ export class ArdFormComponent extends BaseComponent implements OnInit {
   @Input() inputFormData: ArdFormDataInput;
 
   showMoreSettings = false;
+  showAutoClipboardCheckbox = false;
 
   constructor() {
     super();
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.showAutoClipboardCheckbox = new UAParser().getEngine().name === 'Blink';
+  }
 
   toggleMoreSettings(event: Event): void {
     event.preventDefault();

--- a/webapp/src/client/app/modules/web-client/form/form-components/rdp/rdp-form.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-components/rdp/rdp-form.component.html
@@ -36,6 +36,11 @@
                                                 [inputFormData]="inputFormData"></web-client-pre-connection-blob-control>
       </div>
 
+    <div *ngIf="showAutoClipboardCheckbox" class="col-12 gateway-form-group">
+      <web-client-auto-clipboard-control [parentForm]="form"
+                                         [inputFormData]="inputFormData"></web-client-auto-clipboard-control>
     </div>
+
+  </div>
 
 </div>

--- a/webapp/src/client/app/modules/web-client/form/form-components/rdp/rdp-form.component.ts
+++ b/webapp/src/client/app/modules/web-client/form/form-components/rdp/rdp-form.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 import { BaseComponent } from '@shared/bases/base.component';
+import { UAParser } from 'ua-parser-js';
 
 @Component({
   selector: 'rdp-form',
@@ -14,12 +15,15 @@ export class RdpFormComponent extends BaseComponent implements OnInit {
 
   showMoreSettingsToggle = false;
   showPasswordToggle = false;
+  showAutoClipboardCheckbox = false;
 
   constructor() {
     super();
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.showAutoClipboardCheckbox = new UAParser().getEngine().name === 'Blink';
+  }
 
   toggleMoreSettings(event: Event): void {
     event.preventDefault();

--- a/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.html
@@ -53,7 +53,12 @@
       <web-client-extended-clipboard-control [parentForm]="form"
                                              [inputFormData]="inputFormData"></web-client-extended-clipboard-control>
     </div>
-    
+
+    <div *ngIf="showAutoClipboardCheckbox" class="col-12 gateway-form-group">
+      <web-client-auto-clipboard-control [parentForm]="form"
+                                         [inputFormData]="inputFormData"></web-client-auto-clipboard-control>
+    </div>
+
   </div>
 
 </div>

--- a/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
+++ b/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
@@ -7,6 +7,7 @@ import { WebFormService } from '@shared/services/web-form.service';
 import { SelectItem } from 'primeng/api';
 import { Observable, of } from 'rxjs';
 import { map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { UAParser } from 'ua-parser-js';
 
 interface FormInputVisibility {
   showUsernameInput?: boolean;
@@ -30,6 +31,7 @@ export class VncFormComponent extends BaseComponent implements OnInit {
   };
 
   showMoreSettings = false;
+  showAutoClipboardCheckbox = false;
 
   constructor(
     private formService: WebFormService,
@@ -88,6 +90,8 @@ export class VncFormComponent extends BaseComponent implements OnInit {
         },
         error: (error) => console.error('Error fetching dropdown options', error),
       });
+
+    this.showAutoClipboardCheckbox = new UAParser().getEngine().name === 'Blink';
   }
 
   private subscribeToAuthModeChanges(): void {

--- a/webapp/src/client/app/modules/web-client/form/form-controls/auto-clipboard-control/auto-clipboard-control.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/auto-clipboard-control/auto-clipboard-control.component.html
@@ -1,0 +1,7 @@
+<div [formGroup]="parentForm">
+  <div class="gateway-form-input">
+      <p-checkbox formControlName="autoClipboard" label="Auto Clipboard Mode"
+                  pTooltip="Enables automatic clipboard syncing with the remote server."
+                  binary="true"></p-checkbox>
+  </div>
+</div>

--- a/webapp/src/client/app/modules/web-client/form/form-controls/auto-clipboard-control/auto-clipboard-control.component.scss
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/auto-clipboard-control/auto-clipboard-control.component.scss
@@ -1,0 +1,22 @@
+@import '../../../../../../../assets/css/style/mixins';
+@import "../../../../../../../assets/css/style/variables";
+@import "../../../../../../../assets/css/theme/theme-mode-variables";
+
+.gateway-form-input {
+  display: flex;
+  align-items: center;
+}
+
+.form-helper-text {
+  line-height: 11px;
+  word-wrap: break-word;
+  color: var(--status-error-text-color);
+  font-size: 11px;
+  font-family: Open Sans;
+  font-weight: 400;
+  padding-left: 0;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 10px;
+  display: inline-flex;
+}

--- a/webapp/src/client/app/modules/web-client/form/form-controls/auto-clipboard-control/auto-clipboard-control.component.ts
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/auto-clipboard-control/auto-clipboard-control.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+import { BaseComponent } from '@shared/bases/base.component';
+import { WebFormService } from '@shared/services/web-form.service';
+
+@Component({
+  selector: 'web-client-auto-clipboard-control',
+  templateUrl: 'auto-clipboard-control.component.html',
+  styleUrls: ['auto-clipboard-control.component.scss'],
+})
+export class AutoClipboardControlComponent extends BaseComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+  @Input() inputFormData;
+
+  constructor(private formService: WebFormService) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.formService.addControlToForm({
+      formGroup: this.parentForm,
+      controlName: 'autoClipboard',
+      inputFormData: this.inputFormData,
+      isRequired: false,
+      defaultValue: true,
+    });
+  }
+}

--- a/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.html
+++ b/webapp/src/client/app/modules/web-client/rdp/web-client-rdp.component.html
@@ -13,7 +13,8 @@
     [middleButtons]="middleToolbarButtons"
     [middleToggleButtons]="middleToolbarToggleButtons"
     [rightButtons]="rightToolbarButtons"
-    [checkboxes]="checkboxes">
+    [checkboxes]="checkboxes"
+    [clipboardActionButtons]="clipboardActionButtons">
   </session-toolbar>
 
   <div class="loading-info-container" *ngIf="loading">

--- a/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.html
+++ b/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.html
@@ -14,7 +14,8 @@
     [middleToggleButtons]="middleToolbarToggleButtons"
     [rightButtons]="rightToolbarButtons"
     [checkboxes]="checkboxes"
-    [sliders]="sliders">
+    [sliders]="sliders"
+    [clipboardActionButtons]="clipboardActionButtons">
   </session-toolbar>
 
   <div class="loading-info-container" *ngIf="loading">

--- a/webapp/src/client/app/modules/web-client/web-client.module.ts
+++ b/webapp/src/client/app/modules/web-client/web-client.module.ts
@@ -27,6 +27,7 @@ import { SharedModule } from '@shared/shared.module';
 import { CheckboxModule } from 'primeng/checkbox';
 import { KeyFilterModule } from 'primeng/keyfilter';
 import { ArdQualityModeControlComponent } from './form/form-controls/ard-quality-mode-control/ard-quality-mode-control.component';
+import { AutoClipboardControlComponent } from './form/form-controls/auto-clipboard-control/auto-clipboard-control.component';
 // TODO: uncomment when adding support for iDRAC and VMWare
 // import { VmIdControlComponent } from './form/form-controls/vm-id-control/vm-id-control.component';
 // import { ForceFirmwareV7ControlComponent } from './form/form-controls/force-firmware-v7-control/force-firmware-v7-control.component';
@@ -84,6 +85,7 @@ const routes: Routes = [
     PreConnectionBlobControlComponent,
     EnabledEncodingsControlComponent,
     EnableCursorControlComponent,
+    AutoClipboardControlComponent,
     // TODO: iDRAC and VMWare support
     // VmIdControlComponent,
     // ForceFirmwareV7ControlComponent,

--- a/webapp/src/client/app/shared/bases/base-web-client.component.ts
+++ b/webapp/src/client/app/shared/bases/base-web-client.component.ts
@@ -39,6 +39,10 @@ export abstract class WebClientBaseComponent extends BaseSessionComponent {
     this.analyticHandle = this.analyticService.sendOpenEvent(this.getProtocol());
   }
 
+  protected webClientSuccess(message: string): void {
+    this.gatewayAlertMessageService.addSuccess(message);
+  }
+
   protected webClientError(errorMessage: string): void {
     this.gatewayAlertMessageService.addError(errorMessage);
     console.error(errorMessage);

--- a/webapp/src/client/app/shared/components/session-toolbar/session-toolbar.component.html
+++ b/webapp/src/client/app/shared/components/session-toolbar/session-toolbar.component.html
@@ -68,6 +68,19 @@
     </ng-container>
   </div>
 
+  <div class="session-toolbar-right-group" *ngIf="clipboardActionButtons.length > 0">
+    <ng-container *ngFor="let button of clipboardActionButtons; let i = index; let last = last">
+      <p-button (click)="button.action()"
+                [label]="button.label"
+                [pTooltip]="button.tooltip"
+                [icon]="button.icon"
+                [disabled]="!button.enabled()"
+                iconPos="left"></p-button>
+
+      <div class="separator" *ngIf="!last"></div>
+    </ng-container>
+  </div>
+
   <div class="session-toolbar-right-group" *ngIf="rightButtons.length > 0">
     <ng-container *ngFor="let button of rightButtons; let i = index; let last = last">
       <p-button (click)="button.action()"

--- a/webapp/src/client/app/shared/components/session-toolbar/session-toolbar.component.ts
+++ b/webapp/src/client/app/shared/components/session-toolbar/session-toolbar.component.ts
@@ -51,6 +51,14 @@ export class SessionToolbarComponent {
     step: number;
   }[] = [];
 
+  @Input() clipboardActionButtons: {
+    label: string;
+    tooltip: string;
+    icon: string;
+    action: () => Promise<void>;
+    enabled: () => boolean;
+  }[] = [];
+
   isFullScreenMode = false;
   showToolbarDiv = true;
   loading = true;

--- a/webapp/src/client/app/shared/enums/session-event-type.enum.ts
+++ b/webapp/src/client/app/shared/enums/session-event-type.enum.ts
@@ -2,6 +2,7 @@ enum SessionEventType {
   STARTED = 0,
   TERMINATED = 1,
   ERROR = 2,
+  CLIPBOARD_REMOTE_UPDATE = 3,
 }
 
 namespace SessionEventType {

--- a/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
+++ b/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
@@ -28,6 +28,7 @@ export interface RdpFormDataInput {
   preConnectionBlob: string;
   protocol: number;
   screenSize: ScreenSize;
+  autoClipboard?: boolean;
   customWidth?: number;
   customHeight?: number;
 }
@@ -44,6 +45,7 @@ export interface VncFormDataInput {
   enabledEncodings: Encoding[];
   wheelSpeedFactor: number;
   screenSize: ScreenSize;
+  autoClipboard?: boolean;
   customWidth?: number;
   customHeight?: number;
 }
@@ -57,6 +59,7 @@ export interface ArdFormDataInput {
   wheelSpeedFactor: number;
   resolutionQuality: ResolutionQuality;
   ardQualityMode: ArdQualityMode;
+  autoClipboard?: boolean;
 }
 
 export interface TelnetFormDataInput {


### PR DESCRIPTION
This PR refactors the clipboard part of the Devolutions Gateway Standalone to follow the new API(see https://github.com/Devolutions/IronRDP/pull/935/) of the _iron-remote-desktop_. The changes:
 * Introduce _autoclipboard_ mode, which the user can enable/disable using the connection form. However, it's available only for browsers based on _Blink_  engine. For others, _autoclipboard_ mode is always false.
 * Add two new buttons to the toolbar that are available when _autoclipboard_ is false: _Save Clipboard_ and _Send Clipboard_.
 * Add notification for manual clipboard actions. For example, when the user clicks the _Save Clipboard_ button, an error or success notification will appear, informing the user about the operation status.
 
Demos:

- Chrome auto clipboard mode

https://github.com/user-attachments/assets/001d150a-982a-430d-84ba-fd29b5ea1258

- Chrome manual clipboard mode

https://github.com/user-attachments/assets/957d9832-80af-4c95-9559-a11ab8eeba12

- Firefox (Safari behaves the same way) clipboard

https://github.com/user-attachments/assets/7842e5ec-c83e-40a6-9d81-2b09f99fa4e8