### PR TITLE
feat(dgw): implement traffic audit claim/ack HTTP endpoints

### DIFF
--- a/crates/traffic-audit/src/lib.rs
+++ b/crates/traffic-audit/src/lib.rs
@@ -99,14 +99,14 @@ pub trait TrafficAuditRepo: Send + Sync {
     /// * `consumer_id` - Unique identifier for this consumer instance
     /// * `lease_duration_ms` - How long to hold the lease (milliseconds)
     /// * `limit` - Maximum number of events to claim
-    async fn claim(&self, consumer_id: &str, lease_duration_ms: i64, limit: usize)
+    async fn claim(&self, consumer_id: &str, lease_duration_ms: u32, limit: usize)
     -> anyhow::Result<Vec<ClaimedEvent>>;
 
     /// Acknowledges processing completion and removes events from the repository.
     ///
     /// Events are permanently deleted after acknowledgment as we don't retain
-    /// audit data after forwarding. This operation should be idempotent.
-    async fn ack(&self, ids: &[i64]) -> anyhow::Result<()>;
+    /// audit data after forwarding.
+    async fn ack(&self, ids: &[i64]) -> anyhow::Result<u64>;
 
     /// Extends the lease on claimed events to prevent timeout.
     ///

--- a/devolutions-gateway/src/api/mod.rs
+++ b/devolutions-gateway/src/api/mod.rs
@@ -13,6 +13,7 @@ pub mod preflight;
 pub mod rdp;
 pub mod session;
 pub mod sessions;
+pub mod traffic;
 pub mod update;
 pub mod webapp;
 
@@ -32,6 +33,7 @@ pub fn make_router<S>(state: crate::DgwState) -> axum::Router<S> {
         .nest("/jet/fwd", fwd::make_router(state.clone()))
         .nest("/jet/webapp", webapp::make_router(state.clone()))
         .nest("/jet/net", net::make_router(state.clone()))
+        .nest("/jet/traffic", traffic::make_router(state.clone()))
         .route("/jet/update", axum::routing::post(update::trigger_update_check));
 
     if state.conf_handle.get_conf().web_app.enabled {

--- a/devolutions-gateway/src/api/traffic.rs
+++ b/devolutions-gateway/src/api/traffic.rs
@@ -1,0 +1,246 @@
+use axum::extract::{Query, State};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+use traffic_audit::{EventOutcome, TrafficEvent, TransportProtocol};
+use uuid::Uuid;
+
+use crate::extract::{TrafficAckScope, TrafficClaimScope};
+use crate::http::{HttpError, HttpErrorBuilder};
+
+const DEFAULT_CONSUMER: &str = "provisioner";
+
+pub fn make_router<S>(state: crate::DgwState) -> Router<S> {
+    Router::new()
+        .route("/claim", axum::routing::post(post_traffic_claim))
+        .route("/ack", axum::routing::post(post_traffic_ack))
+        .with_state(state)
+}
+
+/// Claim traffic audit events for processing
+#[cfg_attr(feature = "openapi", utoipa::path(
+    post,
+    operation_id = "ClaimTrafficEvents",
+    tag = "Traffic",
+    path = "/jet/traffic/claim",
+    params(ClaimQuery),
+    responses(
+        (status = 200, description = "Successfully claimed traffic events", body = Vec<ClaimedTrafficEvent>),
+        (status = 400, description = "Invalid query parameters"),
+        (status = 401, description = "Invalid or missing authorization token"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 500, description = "Internal server error"),
+    ),
+    security(("scope_token" = ["gateway.traffic.claim"])),
+))]
+pub async fn post_traffic_claim(
+    _scope: TrafficClaimScope,
+    State(state): State<crate::DgwState>,
+    Query(q): Query<ClaimQuery>,
+) -> Result<Json<Vec<ClaimedTrafficEvent>>, HttpError> {
+    if q.max < 1 || q.max > 1000 {
+        return Err(HttpError::bad_request().msg("max must be between 1 and 1000"));
+    }
+
+    if q.lease_ms < 1_000 || q.lease_ms > 3_600_000 {
+        return Err(HttpError::bad_request().msg("lease_ms must be between 1000 and 3600000"));
+    }
+
+    let handle = &state.traffic_audit_handle;
+
+    let items = handle
+        .claim(DEFAULT_CONSUMER, q.lease_ms, q.max)
+        .await
+        .map_err(HttpError::internal().err())?;
+
+    // Convert to response format and ensure ascending id order
+    let mut response_items: Vec<ClaimedTrafficEvent> = items
+        .into_iter()
+        .map(|claimed| ClaimedTrafficEvent {
+            id: claimed.id,
+            event: claimed.event.into(),
+        })
+        .collect();
+
+    // Sort by id to ensure ascending order
+    response_items.sort_by_key(|item| item.id);
+
+    info!(
+        max = q.max,
+        lease_ms = q.lease_ms,
+        claimed = response_items.len(),
+        "traffic claim"
+    );
+
+    Ok(Json(response_items))
+}
+
+/// Acknowledge traffic audit events and remove them from the queue
+#[cfg_attr(feature = "openapi", utoipa::path(
+    post,
+    operation_id = "AckTrafficEvents",
+    tag = "Traffic", 
+    path = "/jet/traffic/ack",
+    request_body(content = AckRequest, description = "Array of event IDs to acknowledge", content_type = "application/json"),
+    responses(
+        (status = 200, description = "Successfully acknowledged events", body = AckResponse),
+        (status = 400, description = "Invalid request body (empty ids array)"),
+        (status = 401, description = "Invalid or missing authorization token"),
+        (status = 403, description = "Insufficient permissions"),
+        (status = 413, description = "Payload too large (more than 10,000 IDs)"),
+        (status = 500, description = "Internal server error"),
+    ),
+    security(("scope_token" = ["gateway.traffic.ack"])),
+))]
+pub async fn post_traffic_ack(
+    _scope: TrafficAckScope,
+    State(state): State<crate::DgwState>,
+    Json(req): Json<AckRequest>,
+) -> Result<Json<AckResponse>, HttpError> {
+    if req.ids.is_empty() {
+        return Err(HttpError::bad_request().msg("ids array cannot be empty"));
+    }
+
+    if req.ids.len() > 10_000 {
+        return Err(
+            HttpErrorBuilder::new(axum::http::StatusCode::PAYLOAD_TOO_LARGE).msg("ids array too large (max 10000)")
+        );
+    }
+
+    let handle = &state.traffic_audit_handle;
+
+    let deleted_count = handle.ack(req.ids.clone()).await.map_err(HttpError::internal().err())?;
+
+    info!(deleted = deleted_count, "traffic ack");
+
+    Ok(Json(AckResponse { deleted_count }))
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Deserialize)]
+pub struct ClaimQuery {
+    /// Lease duration in milliseconds (1000-3600000, default: 300000 = 5 minutes)
+    #[serde(default = "default_lease_ms")]
+    pub lease_ms: u32,
+    /// Maximum number of events to claim (1-1000, default: 100)
+    #[serde(default = "default_max")]
+    pub max: usize,
+}
+
+fn default_lease_ms() -> u32 {
+    1000 * 60 * 5 // 5 minutes
+}
+
+fn default_max() -> usize {
+    100
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Deserialize)]
+pub struct AckRequest {
+    /// Array of event IDs to acknowledge (1-10000 items)
+    pub ids: Vec<i64>,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Serialize)]
+pub struct AckResponse {
+    /// Number of events that were acknowledged and deleted
+    pub deleted_count: u64,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Serialize)]
+pub struct ClaimedTrafficEvent {
+    /// Database ID of the claimed event (used for acknowledgment)
+    pub id: i64,
+    /// Traffic event data
+    #[serde(flatten)]
+    pub event: TrafficEventResponse,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Serialize)]
+pub struct TrafficEventResponse {
+    /// Unique identifier for the session/tunnel this traffic item belongs to
+    pub session_id: Uuid,
+    /// Classification of how the traffic item lifecycle ended
+    pub outcome: EventOutcomeResponse,
+    /// Transport protocol used for the connection attempt
+    pub protocol: TransportProtocolResponse,
+    /// Original target host string before DNS resolution
+    pub target_host: String,
+    /// Concrete target IP address after resolution
+    pub target_ip: IpAddr,
+    /// Target port number for the connection
+    pub target_port: u16,
+    /// Timestamp when the connection attempt began (epoch milliseconds)
+    pub connect_at_ms: i64,
+    /// Timestamp when the traffic item was closed or connection failed (epoch milliseconds)
+    pub disconnect_at_ms: i64,
+    /// Total duration the traffic item was active (milliseconds)
+    pub active_duration_ms: i64,
+    /// Total bytes transmitted to the remote peer
+    pub bytes_tx: u64,
+    /// Total bytes received from the remote peer
+    pub bytes_rx: u64,
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventOutcomeResponse {
+    /// Could not establish a transport to a concrete socket address
+    ConnectFailure,
+    /// Data path was established and the traffic item ended cleanly
+    NormalTermination,
+    /// Data path was established but the traffic item ended with an error
+    AbnormalTermination,
+}
+
+impl From<EventOutcome> for EventOutcomeResponse {
+    fn from(outcome: EventOutcome) -> Self {
+        match outcome {
+            EventOutcome::ConnectFailure => Self::ConnectFailure,
+            EventOutcome::NormalTermination => Self::NormalTermination,
+            EventOutcome::AbnormalTermination => Self::AbnormalTermination,
+        }
+    }
+}
+
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportProtocolResponse {
+    /// Transmission Control Protocol
+    Tcp,
+    /// User Datagram Protocol  
+    Udp,
+}
+
+impl From<TransportProtocol> for TransportProtocolResponse {
+    fn from(protocol: TransportProtocol) -> Self {
+        match protocol {
+            TransportProtocol::Tcp => Self::Tcp,
+            TransportProtocol::Udp => Self::Udp,
+        }
+    }
+}
+
+impl From<TrafficEvent> for TrafficEventResponse {
+    fn from(event: TrafficEvent) -> Self {
+        Self {
+            session_id: event.session_id,
+            outcome: event.outcome.into(),
+            protocol: event.protocol.into(),
+            target_host: event.target_host,
+            target_ip: event.target_ip,
+            target_port: event.target_port,
+            connect_at_ms: event.connect_at_ms,
+            disconnect_at_ms: event.disconnect_at_ms,
+            active_duration_ms: event.active_duration_ms,
+            bytes_tx: event.bytes_tx,
+            bytes_rx: event.bytes_rx,
+        }
+    }
+}

--- a/devolutions-gateway/src/extract.rs
+++ b/devolutions-gateway/src/extract.rs
@@ -316,6 +316,42 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct TrafficClaimScope;
+
+impl<S> FromRequestParts<S> for TrafficClaimScope
+where
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match ScopeToken::from_request_parts(parts, state).await?.0.scope {
+            AccessScope::Wildcard => Ok(Self),
+            AccessScope::TrafficClaim => Ok(Self),
+            _ => Err(HttpError::forbidden().msg("invalid scope for route")),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct TrafficAckScope;
+
+impl<S> FromRequestParts<S> for TrafficAckScope
+where
+    S: Send + Sync,
+{
+    type Rejection = HttpError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match ScopeToken::from_request_parts(parts, state).await?.0.scope {
+            AccessScope::Wildcard => Ok(Self),
+            AccessScope::TrafficAck => Ok(Self),
+            _ => Err(HttpError::forbidden().msg("invalid scope for route")),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct WebAppToken(pub WebAppTokenClaims);
 

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -451,6 +451,10 @@ pub enum AccessScope {
     Update,
     #[serde(rename = "gateway.preflight")]
     Preflight,
+    #[serde(rename = "gateway.traffic.claim")]
+    TrafficClaim,
+    #[serde(rename = "gateway.traffic.ack")]
+    TrafficAck,
 }
 
 #[derive(Clone, Deserialize)]

--- a/devolutions-gateway/src/traffic_audit.rs
+++ b/devolutions-gateway/src/traffic_audit.rs
@@ -24,13 +24,13 @@ pub enum TrafficAuditMessage {
     },
     Claim {
         consumer_id: String,
-        lease_duration_ms: i64,
+        lease_duration_ms: u32,
         max_events: usize,
         channel: oneshot::Sender<anyhow::Result<Vec<ClaimedEvent>>>,
     },
     Ack {
         ids: Vec<i64>,
-        channel: oneshot::Sender<anyhow::Result<()>>,
+        channel: oneshot::Sender<anyhow::Result<u64>>,
     },
 }
 
@@ -87,7 +87,7 @@ impl TrafficAuditHandle {
     pub async fn claim(
         &self,
         consumer_id: impl Into<String>,
-        lease_duration_ms: i64,
+        lease_duration_ms: u32,
         max_events: usize,
     ) -> anyhow::Result<Vec<ClaimedEvent>> {
         let (tx, rx) = oneshot::channel();
@@ -107,7 +107,7 @@ impl TrafficAuditHandle {
     }
 
     /// Acknowledge processing of claimed traffic events
-    pub async fn ack(&self, ids: Vec<i64>) -> anyhow::Result<()> {
+    pub async fn ack(&self, ids: Vec<i64>) -> anyhow::Result<u64> {
         let (tx, rx) = oneshot::channel();
 
         self.0

--- a/devolutions-gateway/tests/traffic.rs
+++ b/devolutions-gateway/tests/traffic.rs
@@ -1,0 +1,552 @@
+#![allow(unused_crate_dependencies)]
+#![allow(clippy::unwrap_used)]
+
+//! Integration tests for the **traffic audit** HTTP endpoints.
+//!
+//! ## Scope
+//!
+//! These tests validate the behavior of:
+//! - `POST /jet/traffic/claim`
+//! - `POST /jet/traffic/ack`
+//!
+//! against the live `TrafficAuditManagerTask` and `TrafficAuditHandle` running
+//! in-process with an in-memory database.
+//!
+//! ## Key properties verified
+//!
+//! - **Shape & Auth:** Endpoints are reachable under `/jet/traffic/*` with the
+//!   standard DGW auth layer (disabled token validation in test config).
+//! - **FIFO & Limits:** Claims are returned in ascending `id` order and respect
+//!   `max`.
+//! - **Leases:** Active leases prevent re-claim; after expiry, events are re-claimable.
+//! - **Ack semantics:** `ack` removes claimed items; subsequent claims return empty.
+//! - **Serialization:** Unicode hostnames and IPv6 addresses round-trip correctly.
+//! - **Concurrency (stress):** Concurrent claimers make forward progress without panics.
+
+use std::net::{IpAddr, SocketAddr};
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::connect_info::MockConnectInfo;
+use axum::http::{self, Request, StatusCode};
+use devolutions_gateway::traffic_audit::TrafficAuditManagerTask;
+use devolutions_gateway::{DgwState, MockHandles};
+use devolutions_gateway_task::{ChildTask, Task};
+use http_body_util::BodyExt as _;
+use serde_json::json;
+use tower::ServiceExt as _;
+use tracing_subscriber::util::SubscriberInitExt;
+use traffic_audit::{EventOutcome, TrafficEvent, TransportProtocol};
+use uuid::Uuid;
+
+/// Test app configuration:
+/// - Two listeners (tcp & http)
+/// - Token validation disabled (so tests can use a static bearer)
+const CONFIG: &str = r#"{
+    "ProvisionerPublicKeyData": {
+        "Value": "mMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4vuqLOkl1pWobt6su1XO9VskgCAwevEGs6kkNjJQBwkGnPKYLmNF1E/af1yCocfVn/OnPf9e4x+lXVyZ6LMDJxFxu+axdgOq3Ld392J1iAEbfvwlyRFnEXFOJNyylqg3bY6LvnWHL/XZczVdMD9xYfq2sO9bg3xjRW4s7r9EEYOFjqVT3VFznH9iWJVtcSEKukmS/3uKoO6lGhacvu0HhjXXdgq0R8zvR4XRJ9Fcnf0f9Ypoc+i6L80NVjrRCeVOH+Ld/2fA9bocpfLarcVqG3RjS+qgOtpyCc0jWVFF4zaGQ7LUDFkEIYILkICeMMn2ll29hmZNzsJzZJ9s6NocgQIDAQAB"
+    },
+    "Listeners": [
+        { "InternalUrl": "tcp://*:8080",  "ExternalUrl": "tcp://*:8080"  },
+        { "InternalUrl": "http://*:7171", "ExternalUrl": "https://*:7171" }
+    ],
+    "__debug__": { "disable_token_validation": true }
+}"#;
+
+/// Bearer token with wildcard scope for testing (validation disabled).
+const BEARER_TOKEN: &str = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImN0eSI6IlNDT1BFIn0.eyJqdGkiOiI5YTdkZWRhOC1jNmM2LTQ1YzAtODZlYi01MGJiMzI4YWFjMjMiLCJleHAiOjAsInNjb3BlIjoiKiJ9.dTazZemDS08Fy13Hx7wxDoOxQ2oNFaaEYMSFDQHCWiUdlYv4NMQh6N_GQok3wdiSJf384fvLKccYe1fipRepLlinUAqcEum68ngvGuUVP78xYb_vC3ZDqFi6nvd1BLp621XgzsCbOyBZHhLXHgzwVNTpnbt9laTTaHh8_rSYLaujBOpidWS6vKIZqOE66beqygSprPt3y0LYFTQWGYq21jJ73uW6htdWrmXbDUUjdvG7ymnKb-7Scs5y03jjSTr4QB1rH_3Z8DsfuuxFCIBd8V2yu192PrWooAdMKboLSjvmdFiD509lljoaNoGLBv9hmmQyiLQr-rsUllXBD6UpTQ";
+
+/// Signals shutdown on drop.
+struct HandlesGuard {
+    handles: MockHandles,
+}
+
+impl Drop for HandlesGuard {
+    fn drop(&mut self) {
+        self.handles.shutdown_handle.signal();
+    }
+}
+
+/// Build a Router with a live TrafficAuditManagerTask and real handle,
+/// similar to tests/preflight.rs harness.
+async fn make_router() -> anyhow::Result<(Router, DgwState, HandlesGuard)> {
+    let (mut state, handles) = DgwState::mock(CONFIG)?;
+
+    // Start the manager with an in-memory DB.
+    let manager = TrafficAuditManagerTask::init(":memory:").await?;
+    state.traffic_audit_handle = manager.handle();
+
+    // Run the task (graceful shutdown ensured via HandlesGuard).
+    ChildTask::spawn({
+        let shutdown_signal = state.shutdown_signal.clone();
+        async move { manager.run(shutdown_signal).await }
+    })
+    .detach();
+
+    let app = devolutions_gateway::make_http_service(state.clone())
+        .layer(MockConnectInfo(SocketAddr::from(([0, 0, 0, 0], 3000))));
+
+    let guard = HandlesGuard { handles };
+
+    Ok((app, state, guard))
+}
+
+/// Initialize test logging to the test output.
+fn init_logger() -> tracing::subscriber::DefaultGuard {
+    tracing_subscriber::fmt()
+        .with_test_writer()
+        .with_max_level(tracing::Level::DEBUG)
+        .set_default()
+}
+
+/// Construct a minimal traffic event for seeding tests.
+fn create_test_traffic_event(n: u32) -> TrafficEvent {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+
+    TrafficEvent {
+        session_id: Uuid::new_v4(),
+        outcome: EventOutcome::NormalTermination,
+        protocol: TransportProtocol::Tcp,
+        target_host: format!("host{n}.example.com"),
+        target_ip: IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 1, (n % 250) as u8)),
+        target_port: 80,
+        connect_at_ms: now_ms - 1000,
+        disconnect_at_ms: now_ms,
+        active_duration_ms: 1000,
+        bytes_tx: 100,
+        bytes_rx: 200,
+    }
+}
+
+/// Build a request to claim events.
+fn claim_request(lease_ms: Option<u32>, max: Option<usize>) -> anyhow::Result<Request<Body>> {
+    let uri = match (lease_ms, max) {
+        (None, None) => "/jet/traffic/claim".to_owned(),
+        (None, Some(max)) => format!("/jet/traffic/claim?max={max}"),
+        (Some(lease_ms), None) => format!("/jet/traffic/claim?lease_ms={lease_ms}"),
+        (Some(lease_ms), Some(max)) => format!("/jet/traffic/claim?lease_ms={lease_ms}&max={max}"),
+    };
+
+    Ok(Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header(http::header::AUTHORIZATION, BEARER_TOKEN)
+        .body(Body::empty())?)
+}
+
+/// Build a request to ack (delete) events by ids.
+fn ack_request(ids: Vec<i64>) -> anyhow::Result<Request<Body>> {
+    let payload = json!({ "ids": ids });
+    Ok(Request::builder()
+        .method("POST")
+        .uri("/jet/traffic/ack")
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(http::header::AUTHORIZATION, BEARER_TOKEN)
+        .body(Body::from(serde_json::to_vec(&payload)?))?)
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   TESTS                                    */
+/* -------------------------------------------------------------------------- */
+
+/// Intent: verify the **shape** of the claim endpoint.
+///
+/// Expectation:
+/// - `POST /jet/traffic/claim` returns `200 OK` and a JSON array.
+/// - With an empty DB, the array is empty.
+///
+/// Success criteria: status is 200; body is `[]`.
+#[tokio::test(flavor = "current_thread")]
+async fn claim_shape_ok() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    let response = app.oneshot(claim_request(Some(1000), Some(10))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await?.to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body)?;
+    assert!(v.is_array());
+    assert!(v.as_array().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// Intent: verify the **shape** of the ack endpoint.
+///
+/// Expectation:
+/// - `POST /jet/traffic/ack` returns `200 OK` and `{ "deleted_count": <u64> }`.
+/// - Acknowledging non-existent ids deletes nothing (count = 0).
+///
+/// Success criteria: status is 200; `deleted_count == 0`.
+#[tokio::test(flavor = "current_thread")]
+async fn ack_shape_ok() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    let response = app.oneshot(ack_request(vec![1, 2, 3])?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await?.to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body)?;
+
+    // The database is empty, and nothing was claimed, so ack should do nothing.
+    assert_eq!(v["deleted_count"], 0);
+
+    Ok(())
+}
+
+/// Intent: verify **FIFO** ordering and the **max** bound on claim.
+///
+/// Expectation:
+/// - After pushing 10 events, claiming with `max=5` returns exactly 5 items.
+/// - Returned `id`s are strictly increasing (ascending).
+///
+/// Success criteria: len == 5; ids[i] < ids[i+1].
+#[tokio::test(flavor = "current_thread")]
+async fn claim_fifo_and_limits() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, state, _handles) = make_router().await?;
+
+    for i in 0..10 {
+        state.traffic_audit_handle.push(create_test_traffic_event(i)).await?;
+    }
+
+    let response = app.oneshot(claim_request(None, Some(5))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await?.to_bytes();
+    let arr: serde_json::Value = serde_json::from_slice(&body)?;
+    let events = arr.as_array().unwrap();
+    assert_eq!(events.len(), 5);
+
+    for i in 1..events.len() {
+        let prev = events[i - 1]["id"].as_i64().unwrap();
+        let curr = events[i]["id"].as_i64().unwrap();
+        assert!(prev < curr, "ids are not strictly increasing: {prev} !< {curr}");
+    }
+
+    Ok(())
+}
+
+/// Intent: verify **lease expiry** allows re-claim of the same items.
+///
+/// Expectation:
+/// - Claim with a short lease yields items.
+/// - After sleeping long enough (lease + buffer), the same items can be claimed again.
+///
+/// Success criteria: both claims return 1 item with the **same** `id`.
+#[tokio::test(flavor = "current_thread")]
+async fn lease_expiry_reclaim() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, state, _handles) = make_router().await?;
+
+    state.traffic_audit_handle.push(create_test_traffic_event(1)).await?;
+
+    let r1 = app.clone().oneshot(claim_request(Some(1_000), None)?).await.unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let b1 = r1.into_body().collect().await?.to_bytes();
+    let v1: serde_json::Value = serde_json::from_slice(&b1)?;
+    let e1 = v1.as_array().unwrap();
+    assert_eq!(e1.len(), 1, "first claim should return one item");
+
+    // Wait for lease to expire (1s + buffer)
+    tokio::time::sleep(tokio::time::Duration::from_millis(1_100)).await;
+
+    let r2 = app.oneshot(claim_request(None, None)?).await.unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    let b2 = r2.into_body().collect().await?.to_bytes();
+    let v2: serde_json::Value = serde_json::from_slice(&b2)?;
+    let e2 = v2.as_array().unwrap();
+    assert_eq!(e2.len(), 1, "second claim should also return one item");
+
+    assert_eq!(e1[0]["id"], e2[0]["id"], "reclaimed id should match");
+
+    Ok(())
+}
+
+/// Intent: verify **active leases prevent** re-claim before expiry.
+///
+/// Expectation:
+/// - After an initial claim with a long lease, a second immediate claim returns no items.
+///
+/// Success criteria: first claim len==1; second claim len==0.
+#[tokio::test(flavor = "current_thread")]
+async fn active_lease_protection() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, state, _handles) = make_router().await?;
+
+    state.traffic_audit_handle.push(create_test_traffic_event(42)).await?;
+
+    let r1 = app.clone().oneshot(claim_request(None, None)?).await.unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let b1 = r1.into_body().collect().await?.to_bytes();
+    let v1: serde_json::Value = serde_json::from_slice(&b1)?;
+    let e1 = v1.as_array().unwrap();
+    assert_eq!(e1.len(), 1, "first claim should return one item");
+
+    let r2 = app.oneshot(claim_request(None, None)?).await.unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    let b2 = r2.into_body().collect().await?.to_bytes();
+    let v2: serde_json::Value = serde_json::from_slice(&b2)?;
+    let e2 = v2.as_array().unwrap();
+    assert_eq!(e2.len(), 0, "second claim should return no items while lease active");
+
+    Ok(())
+}
+
+/// Intent: verify **ack deletes** items so they cannot be claimed again.
+///
+/// Expectation:
+/// - Claim → `ack(ids)` → subsequent claim returns empty.
+/// - `deleted_count` equals the number of acknowledged ids.
+///
+/// Success criteria: `deleted_count == ids.len()` and next claim `len==0`.
+#[tokio::test(flavor = "current_thread")]
+async fn ack_deletes() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, state, _handle) = make_router().await?;
+
+    for i in 0..5 {
+        state.traffic_audit_handle.push(create_test_traffic_event(i)).await?;
+    }
+
+    let claim = app.clone().oneshot(claim_request(None, None)?).await.unwrap();
+    assert_eq!(claim.status(), StatusCode::OK);
+    let cbody = claim.into_body().collect().await?.to_bytes();
+    let carr: serde_json::Value = serde_json::from_slice(&cbody)?;
+    let items = carr.as_array().unwrap();
+    assert_eq!(items.len(), 5);
+
+    let ids: Vec<i64> = items.iter().map(|e| e["id"].as_i64().unwrap()).collect();
+
+    let ack = app.clone().oneshot(ack_request(ids.clone())?).await.unwrap();
+    assert_eq!(ack.status(), StatusCode::OK);
+    let abody = ack.into_body().collect().await?.to_bytes();
+    let ajson: serde_json::Value = serde_json::from_slice(&abody)?;
+    assert_eq!(ajson["deleted_count"].as_u64().unwrap(), ids.len() as u64);
+
+    // Next claim should be empty
+    let again = app.oneshot(claim_request(None, None)?).await.unwrap();
+    assert_eq!(again.status(), StatusCode::OK);
+    let body = again.into_body().collect().await?.to_bytes();
+    let v: serde_json::Value = serde_json::from_slice(&body)?;
+    assert!(v.as_array().unwrap().is_empty());
+
+    Ok(())
+}
+
+/// Intent: verify **serialization** of Unicode hostnames and IPv6 addresses.
+///
+/// Expectation:
+/// - Pushed event with non-ASCII host and IPv6 IP is returned exactly as sent.
+///
+/// Success criteria: `target_host` and `target_ip` match the original values.
+#[tokio::test(flavor = "current_thread")]
+async fn unicode_ipv6_roundtrip() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, state, _handles) = make_router().await?;
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as i64;
+
+    let ev = TrafficEvent {
+        session_id: Uuid::new_v4(),
+        outcome: EventOutcome::NormalTermination,
+        protocol: TransportProtocol::Tcp,
+        target_host: "测试主机.example.com".to_string(),
+        target_ip: IpAddr::V6("2001:db8::1".parse().unwrap()),
+        target_port: 443,
+        connect_at_ms: now_ms - 1000,
+        disconnect_at_ms: now_ms,
+        active_duration_ms: 1000,
+        bytes_tx: 100,
+        bytes_rx: 200,
+    };
+    state.traffic_audit_handle.push(ev).await?;
+
+    let response = app.oneshot(claim_request(None, None)?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response.into_body().collect().await?.to_bytes();
+    let arr: serde_json::Value = serde_json::from_slice(&body)?;
+    let events = arr.as_array().unwrap();
+    assert_eq!(events.len(), 1);
+
+    assert_eq!(events[0]["target_host"], "测试主机.example.com");
+    assert_eq!(events[0]["target_ip"], "2001:db8::1");
+    assert_eq!(events[0]["target_port"], 443);
+
+    Ok(())
+}
+
+/// Intent: coarse **concurrency stress** to ensure no panics and forward progress.
+///
+/// Expectation:
+/// - With 20 events and 10 concurrent claim requests, total claimed = 20.
+/// - Precise distribution is not asserted here; just liveness/safety.
+///
+/// Success criteria: sum(claimed sizes) = 20; all tasks complete without panic.
+#[tokio::test(flavor = "multi_thread")]
+async fn concurrent_stress() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, state, _handles) = make_router().await?;
+
+    for i in 0..20 {
+        state.traffic_audit_handle.push(create_test_traffic_event(i)).await?;
+    }
+
+    let handles: Vec<_> = (0..10)
+        .map(|_| {
+            let app = app.clone();
+            tokio::spawn(async move {
+                let response = app.oneshot(claim_request(None, Some(3)).unwrap()).await.unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                let body = response.into_body().collect().await.unwrap().to_bytes();
+                let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                v.as_array().unwrap().len()
+            })
+        })
+        .collect();
+
+    let mut total = 0;
+    for h in handles {
+        total += h.await?;
+    }
+    assert_eq!(total, 20);
+
+    Ok(())
+}
+
+/// Tests boundary validation for max parameter
+#[tokio::test(flavor = "current_thread")]
+async fn max_validation_boundaries() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    // Test max = 0 (invalid, should be rejected)
+    let response = app.clone().oneshot(claim_request(Some(60000), Some(0))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Test max = 1 (valid, boundary)
+    let response = app.clone().oneshot(claim_request(Some(60000), Some(1))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test max = 1000 (valid, boundary)
+    let response = app
+        .clone()
+        .oneshot(claim_request(Some(60000), Some(1000))?)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test max = 1001 (invalid, should be rejected)
+    let response = app.oneshot(claim_request(Some(60000), Some(1001))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+/// Tests boundary validation for lease_ms parameter
+#[tokio::test(flavor = "current_thread")]
+async fn lease_ms_validation_boundaries() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    // Test lease_ms = 999 (invalid, should be rejected)
+    let response = app.clone().oneshot(claim_request(Some(999), Some(10))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Test lease_ms = 1000 (valid, boundary)
+    let response = app.clone().oneshot(claim_request(Some(1000), Some(10))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test lease_ms = 3600000 (valid, boundary)
+    let response = app
+        .clone()
+        .oneshot(claim_request(Some(3600000), Some(10))?)
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test lease_ms = 3600001 (invalid, should be rejected)
+    let response = app.oneshot(claim_request(Some(3600001), Some(10))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+/// Tests that validation uses OR logic (both conditions must be checked)
+#[tokio::test(flavor = "current_thread")]
+async fn validation_logical_operators() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    // Test invalid max with valid lease_ms - should be rejected (tests || in max validation)
+    let response = app.clone().oneshot(claim_request(Some(60000), Some(0))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Test valid max with invalid lease_ms - should be rejected (tests || in lease_ms validation)
+    let response = app.oneshot(claim_request(Some(999), Some(10))?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    Ok(())
+}
+
+/// Tests boundary validation for ack ids array length
+#[tokio::test(flavor = "current_thread")]
+async fn ack_ids_length_validation() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    // Test empty ids array (invalid, should be rejected)
+    let response = app.clone().oneshot(ack_request(vec![])?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Test single id (valid)
+    let response = app.clone().oneshot(ack_request(vec![1])?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test exactly 10,000 ids (valid, boundary)
+    let ids: Vec<i64> = (1..=10_000).collect();
+    let response = app.clone().oneshot(ack_request(ids)?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Test 10,001 ids (invalid, should be rejected)
+    let ids: Vec<i64> = (1..=10_001).collect();
+    let response = app.oneshot(ack_request(ids)?).await.unwrap();
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+
+    Ok(())
+}
+
+/// Tests that requests without Bearer token are rejected with 401 Unauthorized
+#[tokio::test(flavor = "current_thread")]
+async fn unauthorized_without_token() -> anyhow::Result<()> {
+    let _guard = init_logger();
+    let (app, _state, _handles) = make_router().await?;
+
+    // Test claim request without authorization header
+    let claim_req = Request::builder()
+        .method("POST")
+        .uri("/jet/traffic/claim?lease_ms=60000&max=10")
+        .body(Body::empty())?;
+    let response = app.clone().oneshot(claim_req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    // Test ack request without authorization header
+    let payload = json!({ "ids": [1, 2, 3] });
+    let ack_req = Request::builder()
+        .method("POST")
+        .uri("/jet/traffic/ack")
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_vec(&payload)?))?;
+    let response = app.oneshot(ack_req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    Ok(())
+}


### PR DESCRIPTION
Add two new endpoints for external traffic audit integration:

- `POST /jet/traffic/claim` - Claim events with lease-based locking
- `POST /jet/traffic/ack` - Acknowledge processed events

Issue: DGW-271