### PR TITLE
feat(installer): rename the session feature and make it available by default

### DIFF
--- a/package/AgentWindowsManaged/DevolutionsAgent.csproj
+++ b/package/AgentWindowsManaged/DevolutionsAgent.csproj
@@ -27,9 +27,9 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="WixSharp" Version="1.25.3" />
-    <PackageReference Include="WixSharp.bin" Version="1.25.3" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
+    <PackageReference Include="WixSharp" Version="1.26.0" />
+    <PackageReference Include="WixSharp.bin" Version="1.26.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Security" />
@@ -39,7 +39,7 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.26100.4948" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Dialogs\VerifyReadyDialog.cs" />

--- a/package/AgentWindowsManaged/Dialogs/FeaturesDialog.cs
+++ b/package/AgentWindowsManaged/Dialogs/FeaturesDialog.cs
@@ -15,7 +15,7 @@ public partial class FeaturesDialog : AgentDialog
 {
     private FeatureItem[] features;
 
-    private ImageList imageList = new ImageList();
+    private readonly ImageList imageList = new ImageList();
 
     public FeaturesDialog()
     {

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -432,6 +432,7 @@ internal class Program
         if (installedVersion is null)
         {
             features.Add(Features.AGENT_UPDATER_FEATURE.Id);
+            features.Add(Features.SESSION_FEATURE.Id);
         }
 
         e.Session["ADDLOCAL"] = features.ToString();

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" Codepage="1252" Language="1033" xmlns="http://schemas.microsoft.com/wix/2006/localization">
         <!-- metadata -->
-                <String Id="FeatureAgentDescription">Install the Devolutions Agent service</String>
+                <String Id="FeatureAgentDescription">Installs the Devolutions Agent service</String>
                 <String Id="FeatureAgentName">Devolutions Agent</String>
-                <String Id="FeatureAgentUpdaterDescription">Enable the Devolutions Gateway updater</String>
+                <String Id="FeatureAgentUpdaterDescription">Enables the Devolutions Gateway updater</String>
                 <String Id="FeatureAgentUpdaterName">Devolutions Gateway Updater</String>
-                <String Id="FeaturePedmDescription">Enable PEDM features and install the shell extension</String>
+                <String Id="FeaturePedmDescription">Enables PEDM features and installs the shell extension</String>
                 <String Id="FeaturePedmName">Devolutions PEDM</String>
-                <String Id="FeatureSessionDescription">Install the Devolutions Session application</String>
-                <String Id="FeatureSessionName">Devolutions Session</String>
+                <String Id="FeatureSessionDescription">Installs the RDP Extension</String>
+                <String Id="FeatureSessionName">RDP Extension</String>
                 <String Id="Language">1033</String>
                 <String Id="ProductDescription">System-wide service for extending Devolutions Gateway functionality.</String>
                 <String Id="VendorFullName">Devolutions Inc.</String>

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="fr-fr" Codepage="1252" Language="1036" xmlns="http://schemas.microsoft.com/wix/2006/localization">
         <!-- metadata -->
+                <String Id="FeatureSessionDescription">Installe l'extension RDP</String>
+                <String Id="FeatureSessionName">Extension RDP</String>
                 <String Id="Language">1036</String>
                 <String Id="ProductDescription">Service à l’échelle du système pour étendre les fonctionnalités de Devolutions Gateway.</String>
                 <String Id="VendorFullName">Devolutions Inc.</String>
@@ -58,12 +60,10 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                 <String Id="WixSchedFirewallExceptionsInstall">Configuration du Pare-feu Windows</String>
                 <String Id="WixSchedFirewallExceptionsUninstall">Configuration du Pare-feu Windows</String>
                     <!-- metadata.- -->
-                <String Id="FeatureAgentDescription">Install the Devolutions Agent service</String>
+                <String Id="FeatureAgentDescription">Installs the Devolutions Agent service</String>
                 <String Id="FeatureAgentName">Devolutions Agent</String>
-                <String Id="FeatureAgentUpdaterDescription">Enable the Devolutions Gateway updater</String>
+                <String Id="FeatureAgentUpdaterDescription">Enables the Devolutions Gateway updater</String>
                 <String Id="FeatureAgentUpdaterName">Devolutions Gateway Updater</String>
-                <String Id="FeaturePedmDescription">Enable PEDM features and install the shell extension</String>
+                <String Id="FeaturePedmDescription">Enables PEDM features and installs the shell extension</String>
                 <String Id="FeaturePedmName">Devolutions PEDM</String>
-                <String Id="FeatureSessionDescription">Install the Devolutions Session application</String>
-                <String Id="FeatureSessionName">Devolutions Session</String>
                     </WixLocalization>

--- a/package/AgentWindowsManaged/Resources/Features.cs
+++ b/package/AgentWindowsManaged/Resources/Features.cs
@@ -10,7 +10,7 @@ namespace DevolutionsAgent.Resources
     {
         internal const string FEATURE_ID_PREFIX = "F.";
 
-        internal static IEnumerable<Feature> ExperimentalFeatures => [ SESSION_FEATURE ];
+        internal static IEnumerable<Feature> ExperimentalFeatures => [ ];
 
         internal static Feature AGENT_UPDATER_FEATURE = new("!(loc.FeatureAgentUpdaterName)", "!(loc.FeatureAgentUpdaterDescription)", true, true)
         {
@@ -29,7 +29,7 @@ namespace DevolutionsAgent.Resources
             Id = $"{FEATURE_ID_PREFIX}Pedm"
         };
 
-        internal static Feature SESSION_FEATURE = new("!(loc.FeatureSessionName)", "!(loc.FeatureSessionDescription)", false)
+        internal static Feature SESSION_FEATURE = new("!(loc.FeatureSessionName)", "!(loc.FeatureSessionDescription)", true)
         {
             Id = $"{FEATURE_ID_PREFIX}Session"
         };

--- a/package/AgentWindowsManaged/Resources/Strings.g.cs
+++ b/package/AgentWindowsManaged/Resources/Strings.g.cs
@@ -29,7 +29,7 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string FeatureAgentName = "FeatureAgentName";		
 		/// <summary>
-		/// Install the Devolutions Agent service
+		/// Installs the Devolutions Agent service
 		/// </summary>
 		public const string FeatureAgentDescription = "FeatureAgentDescription";		
 		/// <summary>
@@ -37,7 +37,7 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string FeatureAgentUpdaterName = "FeatureAgentUpdaterName";		
 		/// <summary>
-		/// Enable the Devolutions Gateway updater
+		/// Enables the Devolutions Gateway updater
 		/// </summary>
 		public const string FeatureAgentUpdaterDescription = "FeatureAgentUpdaterDescription";		
 		/// <summary>
@@ -45,15 +45,15 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string FeaturePedmName = "FeaturePedmName";		
 		/// <summary>
-		/// Enable PEDM features and install the shell extension
+		/// Enables PEDM features and installs the shell extension
 		/// </summary>
 		public const string FeaturePedmDescription = "FeaturePedmDescription";		
 		/// <summary>
-		/// Devolutions Session
+		/// RDP Extension
 		/// </summary>
 		public const string FeatureSessionName = "FeatureSessionName";		
 		/// <summary>
-		/// Install the Devolutions Session application
+		/// Installs the RDP Extension
 		/// </summary>
 		public const string FeatureSessionDescription = "FeatureSessionDescription";		
 		/// <summary>

--- a/package/AgentWindowsManaged/Resources/Strings_en-US.json
+++ b/package/AgentWindowsManaged/Resources/Strings_en-US.json
@@ -24,7 +24,7 @@
         },
         {
           "id": "FeatureAgentDescription",
-          "text": "Install the Devolutions Agent service"
+          "text": "Installs the Devolutions Agent service"
         },
         {
           "id": "FeatureAgentUpdaterName",
@@ -32,7 +32,7 @@
         },
         {
           "id": "FeatureAgentUpdaterDescription",
-          "text": "Enable the Devolutions Gateway updater"
+          "text": "Enables the Devolutions Gateway updater"
         },
         {
           "id": "FeaturePedmName",
@@ -40,15 +40,15 @@
         },
         {
           "id": "FeaturePedmDescription",
-          "text": "Enable PEDM features and install the shell extension"
+          "text": "Enables PEDM features and installs the shell extension"
         },
         {
           "id": "FeatureSessionName",
-          "text": "Devolutions Session"
+          "text": "RDP Extension"
         },
         {
           "id": "FeatureSessionDescription",
-          "text": "Install the Devolutions Session application"
+          "text": "Installs the RDP Extension"
         }
       ],
       "messages": [

--- a/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
@@ -17,6 +17,14 @@
         {
           "id": "ProductDescription",
           "text": "Service à l’échelle du système pour étendre les fonctionnalités de Devolutions Gateway."
+        },
+        {
+          "id": "FeatureSessionName",
+          "text": "Extension RDP"
+        },
+        {
+          "id": "FeatureSessionDescription",
+          "text": "Installe l'extension RDP"
         }
       ],
       "messages": [


### PR DESCRIPTION
Rename the session feature to "RDP Extension" and remove the experimental tag. The feature will be selected by default for new installs.