### PR TITLE
style(web): add a comment explaining why `enableExtendedClipboard` field can be uninitialized

### DIFF
--- a/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
+++ b/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
@@ -40,6 +40,7 @@ export interface VncFormDataInput {
   password: string;
   protocol: number;
   enableCursor: boolean;
+  // The extended clipboard control may not be initialized if the browser does not support the clipboard API.
   enableExtendedClipboard?: boolean;
   ultraVirtualDisplay: boolean;
   enabledEncodings: Encoding[];


### PR DESCRIPTION
Follow up to https://github.com/Devolutions/devolutions-gateway/pull/1464.