### PR TITLE
feat(webapp): add color format selector for VNC session

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,7 +20,7 @@
         "@devolutions/icons": "4.0.8",
         "@devolutions/iron-remote-desktop": "0.9.0",
         "@devolutions/iron-remote-desktop-rdp": "^0.6.0",
-        "@devolutions/iron-remote-desktop-vnc": "^0.5.0",
+        "@devolutions/iron-remote-desktop-vnc": "../../ironvnc/web-client/iron-remote-desktop-vnc/dist",
         "@devolutions/terminal-shared": "^1.3.1",
         "@devolutions/web-ssh-gui": "^0.4.0",
         "@devolutions/web-telnet-gui": "^0.3.0",
@@ -69,6 +69,13 @@
       "name": "@devolutions/iron-remote-desktop",
       "version": "0.7.0",
       "extraneous": true
+    },
+    "../../ironvnc/web-client/iron-remote-desktop-vnc/dist": {
+      "name": "@devolutions/iron-remote-desktop-vnc",
+      "version": "0.4.1",
+      "dependencies": {
+        "rxjs": "^6.6.7"
+      }
     },
     "../../ironvnc/web-client/iron-remote-desktop/dist": {
       "extraneous": true
@@ -2928,30 +2935,8 @@
       "integrity": "sha512-o0ZEnBTlRB1uCsiMa27C4fXWILgRsRlQOgyarufhyf3MBobWv9loIjSqp833EI7/Zwo7Kp8cEVpmG3zStoPb+A=="
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc": {
-      "version": "0.5.0",
-      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-vnc/-/@devolutions/iron-remote-desktop-vnc-0.5.0.tgz",
-      "integrity": "sha512-fffCg+k5yUZ4FBb68gSUVoceSRdHEZGn/uQfxH/oUTpj/f2NXmXOSNn4BoieEZilhBr4dkcW+e4tPCGNLq3IzA==",
-      "dependencies": {
-        "rxjs": "^6.6.7"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "resolved": "../../ironvnc/web-client/iron-remote-desktop-vnc/dist",
+      "link": true
     },
     "node_modules/@devolutions/terminal-shared": {
       "version": "1.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,7 +32,7 @@
     "@devolutions/icons": "4.0.8",
     "@devolutions/iron-remote-desktop": "0.9.0",
     "@devolutions/iron-remote-desktop-rdp": "^0.6.0",
-    "@devolutions/iron-remote-desktop-vnc": "^0.5.0",
+    "@devolutions/iron-remote-desktop-vnc": "../../ironvnc/web-client/iron-remote-desktop-vnc/dist",
     "@devolutions/terminal-shared": "^1.3.1",
     "@devolutions/web-ssh-gui": "^0.4.0",
     "@devolutions/web-telnet-gui": "^0.3.0",

--- a/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.html
@@ -45,6 +45,11 @@
     </div>
 
     <div class="col-12 gateway-form-group">
+      <web-client-color-format-control [parentForm]="form"
+        [inputFormData]="inputFormData"></web-client-color-format-control>
+    </div>
+
+    <div class="col-12 gateway-form-group">
       <web-client-enable-cursor-control [parentForm]="form"
                                          [inputFormData]="inputFormData"></web-client-enable-cursor-control>
     </div>

--- a/webapp/src/client/app/modules/web-client/form/form-controls/color-format-control/color-format-control.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/color-format-control/color-format-control.component.html
@@ -1,0 +1,17 @@
+<div [formGroup]="parentForm">
+  <label for="colorFormat">Color Format</label>
+  <div class="gateway-form-input">
+    <p-dropdown id="colorFormat"
+                class="full-width-dropdown"
+                appendTo="body"
+                formControlName="colorFormat"
+                [options]="colorFormatOptions"
+                pTooltip="{{ getSelectedTooltip() }}">
+        <ng-template let-item pTemplate="item">
+            <div pTooltip="{{ item.tooltipText }}" tooltipPosition="right">
+                {{ item.label }}
+            </div>
+        </ng-template>
+    </p-dropdown>
+  </div>
+</div>

--- a/webapp/src/client/app/modules/web-client/form/form-controls/color-format-control/color-format-control.component.scss
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/color-format-control/color-format-control.component.scss
@@ -1,0 +1,41 @@
+@import '../../../../../../../assets/css/style/mixins';
+@import "../../../../../../../assets/css/style/variables";
+@import "../../../../../../../assets/css/theme/theme-mode-variables";
+
+:host ::ng-deep .p-dropdown {
+  width: 100%;
+  min-width: 100% !important;
+}
+
+.gateway-form-group {
+  padding: 0 0 18px 0;
+}
+
+.gateway-form-input {
+  display: flex;
+  align-items: center;
+}
+
+.col-pad-right-lg {
+  padding-right: 15px !important;
+}
+.col-pad-right-md {
+  padding-right: 10px !important;
+}
+.col-pad-right-sm {
+  padding-right: 5px !important;
+}
+
+.form-helper-text {
+  line-height: 11px;
+  word-wrap: break-word;
+  color: var(--status-error-text-color);
+  font-size: 11px;
+  font-family: Open Sans;
+  font-weight: 400;
+  padding-left: 0;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 10px;
+  display: inline-flex;
+}

--- a/webapp/src/client/app/modules/web-client/form/form-controls/color-format-control/color-format-control.component.ts
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/color-format-control/color-format-control.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { BaseComponent } from '@shared/bases/base.component';
+import { ColorFormat } from '@shared/enums/color-format.enum';
+import { SelectItemWithTooltip } from '@shared/interfaces/select-item-tooltip.interface';
+import { WebFormService } from '@shared/services/web-form.service';
+
+@Component({
+  selector: 'web-client-color-format-control',
+  templateUrl: 'color-format-control.component.html',
+  styleUrls: ['color-format-control.component.scss'],
+})
+export class ColorFormatControlComponent extends BaseComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+  @Input() inputFormData;
+
+  colorFormatOptions: SelectItemWithTooltip[];
+
+  constructor(private formService: WebFormService) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.colorFormatOptions = this.formService.getColorFormatOptions();
+    this.formService.addControlToForm({
+      formGroup: this.parentForm,
+      controlName: 'colorFormat',
+      inputFormData: this.inputFormData,
+      isRequired: false,
+      defaultValue: ColorFormat.Default,
+    });
+  }
+
+  getSelectedTooltip(): string {
+    const selectedOptionValue = this.parentForm.get('colorFormat')?.value;
+    return this.colorFormatOptions.find((item) => item.value === selectedOptionValue)?.tooltipText || '';
+  }
+}

--- a/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
+++ b/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
@@ -34,6 +34,7 @@ import {
   enableCursor,
   enabledEncodings,
   enableExtendedClipboard,
+  pixelFormat,
   ultraVirtualDisplay,
   wheelSpeedFactor,
 } from '@devolutions/iron-remote-desktop-vnc';
@@ -450,6 +451,7 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       enableCursor,
       enableExtendedClipboard,
       enabledEncodings,
+      colorFormat,
       ultraVirtualDisplay,
       wheelSpeedFactor = 1,
     } = formData;
@@ -471,6 +473,7 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       screenSize: desktopScreenSize,
       sessionId,
       enabledEncodings: enabledEncodings.join(','),
+      colorFormat,
       enableCursor,
       enableExtendedClipboard: enableExtendedClipboard ?? false,
       ultraVirtualDisplay,
@@ -518,6 +521,10 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       configBuilder.withExtension(enabledEncodings(connectionParameters.enabledEncodings));
     } else {
       configBuilder.withExtension(enabledEncodings(Encoding.getAllEncodings().join(',')));
+    }
+
+    if (connectionParameters.colorFormat) {
+      configBuilder.withExtension(pixelFormat(connectionParameters.colorFormat));
     }
 
     const config = configBuilder.build();

--- a/webapp/src/client/app/modules/web-client/web-client.module.ts
+++ b/webapp/src/client/app/modules/web-client/web-client.module.ts
@@ -28,6 +28,7 @@ import { CheckboxModule } from 'primeng/checkbox';
 import { KeyFilterModule } from 'primeng/keyfilter';
 import { ArdQualityModeControlComponent } from './form/form-controls/ard-quality-mode-control/ard-quality-mode-control.component';
 import { AutoClipboardControlComponent } from './form/form-controls/auto-clipboard-control/auto-clipboard-control.component';
+import { ColorFormatControlComponent } from './form/form-controls/color-format-control/color-format-control.component';
 // TODO: uncomment when adding support for iDRAC and VMWare
 // import { VmIdControlComponent } from './form/form-controls/vm-id-control/vm-id-control.component';
 // import { ForceFirmwareV7ControlComponent } from './form/form-controls/force-firmware-v7-control/force-firmware-v7-control.component';
@@ -84,6 +85,7 @@ const routes: Routes = [
     KdcUrlControlComponent,
     PreConnectionBlobControlComponent,
     EnabledEncodingsControlComponent,
+    ColorFormatControlComponent,
     EnableCursorControlComponent,
     AutoClipboardControlComponent,
     // TODO: iDRAC and VMWare support

--- a/webapp/src/client/app/shared/enums/color-format.enum.ts
+++ b/webapp/src/client/app/shared/enums/color-format.enum.ts
@@ -1,0 +1,36 @@
+import { SelectItemWithTooltip } from '@shared/interfaces/select-item-tooltip.interface';
+
+enum ColorFormat {
+  Default = '',
+  Full = 'rgb888le',
+  High = 'rgb655le',
+  Medium = 'rgb332le',
+  Low = 'rgb222le',
+  'Very Low' = 'rgb111le',
+}
+
+enum Tooltips {
+  Default = 'Color format advertised by a server',
+  Full = 'True 24-bit color',
+  High = 'High 16-bit color',
+  Medium = '256 colors',
+  Low = '64 colors',
+  'Very Low' = '8 colors',
+}
+
+namespace ColorFormat {
+  export function getSelectItems(): SelectItemWithTooltip[] {
+    return (
+      Object.entries(ColorFormat)
+        // Filter out properties that are not from enum values (like function `getSelectItems`).
+        .filter(([_, value]) => typeof value === 'string')
+        .map(([key, value]) => ({
+          label: key,
+          value,
+          tooltipText: Tooltips[key],
+        }))
+    );
+  }
+}
+
+export { ColorFormat };

--- a/webapp/src/client/app/shared/interfaces/connection-params.interfaces.ts
+++ b/webapp/src/client/app/shared/interfaces/connection-params.interfaces.ts
@@ -36,6 +36,7 @@ export interface IronVNCConnectionParameters {
   token?: string;
   screenSize?: DesktopSize;
   enabledEncodings?: string;
+  colorFormat: string;
   enableCursor: boolean;
   enableExtendedClipboard: boolean;
   ultraVirtualDisplay: boolean;

--- a/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
+++ b/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
@@ -1,3 +1,4 @@
+import { ColorFormat } from '@shared/enums/color-format.enum';
 import { ScreenSize } from '@shared/enums/screen-size.enum';
 import { ArdQualityMode } from '../enums/ard-quality-mode.enum';
 import { Encoding } from '../enums/encoding.enum';
@@ -44,6 +45,7 @@ export interface VncFormDataInput {
   enableExtendedClipboard?: boolean;
   ultraVirtualDisplay: boolean;
   enabledEncodings: Encoding[];
+  colorFormat: ColorFormat;
   wheelSpeedFactor: number;
   screenSize: ScreenSize;
   autoClipboard?: boolean;

--- a/webapp/src/client/app/shared/services/web-form.service.ts
+++ b/webapp/src/client/app/shared/services/web-form.service.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectorRef, Injectable } from '@angular/core';
 import { FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { BaseComponent } from '@shared/bases/base.component';
+import { ColorFormat } from '@shared/enums/color-format.enum';
 import { ScreenSize } from '@shared/enums/screen-size.enum';
 import { WebClientAuthMode } from '@shared/enums/web-client-auth-mode.enum';
 import { WebClientProtocol } from '@shared/enums/web-client-protocol.enum';
+import { SelectItemWithTooltip } from '@shared/interfaces/select-item-tooltip.interface';
 import { SelectItem } from 'primeng/api';
 import { Observable, of } from 'rxjs';
 import { ArdQualityMode } from '../enums/ard-quality-mode.enum';
@@ -44,6 +46,10 @@ export class WebFormService extends BaseComponent {
 
   getArdQualityModeOptions(): SelectItem[] {
     return ArdQualityMode.getSelectItems();
+  }
+
+  getColorFormatOptions(): SelectItemWithTooltip[] {
+    return ColorFormat.getSelectItems();
   }
 
   getSupportedEncodings(): SelectItem[] {


### PR DESCRIPTION
This way, a user can tune the session for their environment (e.g, lower image quality if the network is slow).

Closes https://github.com/Devolutions/IronVNC/issues/908.