### PR TITLE
fix cleaning up of build artifacts after packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,7 +663,7 @@ jobs:
 
           # cleanup staging directory before uploading artifacts we want to keep
           $StagingPath = '${{ steps.load-variables.outputs.staging-path }}'
-          Get-ChildItem -Path $StagingPath -Exclude "DevolutionsAgent*"
+          Get-ChildItem -Path $StagingPath -Exclude "DevolutionsAgent*" | Remove-Item -Recurse -Force
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I only listed the files to be deleted in the cleanup after the packaging step, but I forgot to actually delete them.