### PR TITLE
fix(player): add autoplay attribute to WebM video player

### DIFF
--- a/webapp/player-project/src/players/webm.ts
+++ b/webapp/player-project/src/players/webm.ts
@@ -12,6 +12,7 @@ export async function handleWebm(gatewayApi: GatewayAccessApi) {
   videoPlayer.setAttribute('height', '100%');
   videoPlayer.setAttribute('controls', '');
   videoPlayer.setAttribute('muted', '');
+  videoPlayer.setAttribute('autoplay', '');
   document.body.appendChild(videoPlayer);
 
   videoPlayer.play(


### PR DESCRIPTION
## Summary
- Adds missing `autoplay` attribute to the WebM video player component
- Fixes issue where recordings were not auto-starting when embedded in iframes

## Test plan
- [x] Verify that WebM recordings auto-start when loaded in iframe
- [x] Test that existing controls (play/pause, muted) still work correctly
- [x] Build passes successfully

DGW-296