### PR TITLE
refactpr(web): add JPEG Quality option instead of explicit `TightLow`  and `TightHigh` pseudo-encodings

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -20,7 +20,7 @@
         "@devolutions/icons": "4.0.8",
         "@devolutions/iron-remote-desktop": "0.9.0",
         "@devolutions/iron-remote-desktop-rdp": "^0.6.0",
-        "@devolutions/iron-remote-desktop-vnc": "^0.5.0",
+        "@devolutions/iron-remote-desktop-vnc": "^0.6.0",
         "@devolutions/terminal-shared": "^1.3.1",
         "@devolutions/web-ssh-gui": "^0.4.0",
         "@devolutions/web-telnet-gui": "^0.3.0",
@@ -2928,30 +2928,9 @@
       "integrity": "sha512-o0ZEnBTlRB1uCsiMa27C4fXWILgRsRlQOgyarufhyf3MBobWv9loIjSqp833EI7/Zwo7Kp8cEVpmG3zStoPb+A=="
     },
     "node_modules/@devolutions/iron-remote-desktop-vnc": {
-      "version": "0.5.0",
-      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-vnc/-/@devolutions/iron-remote-desktop-vnc-0.5.0.tgz",
-      "integrity": "sha512-fffCg+k5yUZ4FBb68gSUVoceSRdHEZGn/uQfxH/oUTpj/f2NXmXOSNn4BoieEZilhBr4dkcW+e4tPCGNLq3IzA==",
-      "dependencies": {
-        "rxjs": "^6.6.7"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@devolutions/iron-remote-desktop-vnc/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
+      "version": "0.6.0",
+      "resolved": "https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-vnc/-/@devolutions/iron-remote-desktop-vnc-0.6.0.tgz",
+      "integrity": "sha512-SGsu6P0z4ooVLnRFc6Z+/qogq8xO1FLsG+z6oaSN9TgKrqeRAa6cgVr/nkYIRYLeAFdRzpcsmxCNnMz7Pymb2A=="
     },
     "node_modules/@devolutions/terminal-shared": {
       "version": "1.3.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -32,7 +32,7 @@
     "@devolutions/icons": "4.0.8",
     "@devolutions/iron-remote-desktop": "0.9.0",
     "@devolutions/iron-remote-desktop-rdp": "^0.6.0",
-    "@devolutions/iron-remote-desktop-vnc": "^0.5.0",
+    "@devolutions/iron-remote-desktop-vnc": "^0.6.0",
     "@devolutions/terminal-shared": "^1.3.1",
     "@devolutions/web-ssh-gui": "^0.4.0",
     "@devolutions/web-telnet-gui": "^0.3.0",

--- a/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.html
@@ -45,6 +45,11 @@
     </div>
 
     <div class="col-12 gateway-form-group">
+        <web-client-jpeg-quality-level-control [parentForm]="form"
+                                               [inputFormData]="inputFormData"></web-client-jpeg-quality-level-control>
+    </div>
+
+    <div class="col-12 gateway-form-group">
       <web-client-enable-cursor-control [parentForm]="form"
                                          [inputFormData]="inputFormData"></web-client-enable-cursor-control>
     </div>

--- a/webapp/src/client/app/modules/web-client/form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component.html
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component.html
@@ -1,0 +1,22 @@
+<div [formGroup]="parentForm">
+  <div class="gateway-form-input">
+      <p-checkbox formControlName="jpegEnabled"
+                  label="Use Tight JPEG"
+                  binary="true"
+                  (onChange)="toggleCheckbox()"></p-checkbox>
+  </div>
+
+  @if (jpegEnabled) {
+    <div class="gateway-sub-control">
+      <label for="jpegQualityLevel">JPEG Quality Level</label>
+      <div class="gateway-form-input">
+            <p-inputNumber formControlName="jpegQualityLevel"
+                           id="jpegQualityLevel"
+                           mode="decimal"
+                           [min]="0"
+                           [max]="9"
+                           [showButtons]="true"></p-inputNumber>
+      </div>
+    </div>
+  }
+</div>

--- a/webapp/src/client/app/modules/web-client/form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component.scss
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component.scss
@@ -1,0 +1,40 @@
+@import '../../../../../../../assets/css/style/mixins';
+@import "../../../../../../../assets/css/style/variables";
+@import "../../../../../../../assets/css/theme/theme-mode-variables";
+
+:host ::ng-deep p-inputNumber {
+  width: 50px;
+}
+
+.gateway-sub-control {
+  padding: 18px 0 0 0;
+}
+
+.gateway-form-input {
+  display: flex;
+  align-items: center;
+}
+
+.col-pad-right-lg {
+  padding-right: 15px !important;
+}
+.col-pad-right-md {
+  padding-right: 10px !important;
+}
+.col-pad-right-sm {
+  padding-right: 5px !important;
+}
+
+.form-helper-text {
+  line-height: 11px;
+  word-wrap: break-word;
+  color: var(--status-error-text-color);
+  font-size: 11px;
+  font-family: Open Sans;
+  font-weight: 400;
+  padding-left: 0;
+  justify-content: flex-start;
+  align-items: flex-start;
+  gap: 10px;
+  display: inline-flex;
+}

--- a/webapp/src/client/app/modules/web-client/form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component.ts
+++ b/webapp/src/client/app/modules/web-client/form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+import { BaseComponent } from '@shared/bases/base.component';
+import { WebFormService } from '@shared/services/web-form.service';
+
+@Component({
+  selector: 'web-client-jpeg-quality-level-control',
+  templateUrl: 'jpeg-quality-level-control.component.html',
+  styleUrls: ['jpeg-quality-level-control.component.scss'],
+})
+export class JpegQualityLevelControlComponent extends BaseComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+  @Input() inputFormData;
+
+  jpegEnabled = true;
+
+  constructor(private formService: WebFormService) {
+    super();
+  }
+
+  toggleCheckbox() {
+    this.jpegEnabled = !this.jpegEnabled;
+  }
+
+  ngOnInit(): void {
+    this.formService.addControlToForm({
+      formGroup: this.parentForm,
+      controlName: 'jpegEnabled',
+      inputFormData: this.inputFormData,
+      isRequired: false,
+      defaultValue: true,
+    });
+
+    this.formService.addControlToForm({
+      formGroup: this.parentForm,
+      controlName: 'jpegQualityLevel',
+      inputFormData: this.inputFormData,
+      isRequired: false,
+      defaultValue: 9,
+    });
+  }
+}

--- a/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
+++ b/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
@@ -34,6 +34,7 @@ import {
   enableCursor,
   enabledEncodings,
   enableExtendedClipboard,
+  jpegQualityLevel,
   ultraVirtualDisplay,
   wheelSpeedFactor,
 } from '@devolutions/iron-remote-desktop-vnc';
@@ -451,6 +452,8 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       enableExtendedClipboard,
       enabledEncodings,
       ultraVirtualDisplay,
+      jpegEnabled,
+      jpegQualityLevel,
       wheelSpeedFactor = 1,
     } = formData;
     const extractedData: ExtractedHostnamePort = this.utils.string.extractHostnameAndPort(hostname, DefaultVncPort);
@@ -471,6 +474,7 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       screenSize: desktopScreenSize,
       sessionId,
       enabledEncodings: enabledEncodings.join(','),
+      jpegQualityLevel: jpegEnabled ? jpegQualityLevel : undefined,
       enableCursor,
       enableExtendedClipboard: enableExtendedClipboard ?? false,
       ultraVirtualDisplay,
@@ -518,6 +522,10 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
       configBuilder.withExtension(enabledEncodings(connectionParameters.enabledEncodings));
     } else {
       configBuilder.withExtension(enabledEncodings(Encoding.getAllEncodings().join(',')));
+    }
+
+    if (connectionParameters.jpegQualityLevel != null) {
+      configBuilder.withExtension(jpegQualityLevel(connectionParameters.jpegQualityLevel));
     }
 
     const config = configBuilder.build();

--- a/webapp/src/client/app/modules/web-client/web-client.module.ts
+++ b/webapp/src/client/app/modules/web-client/web-client.module.ts
@@ -37,6 +37,7 @@ import { AutoClipboardControlComponent } from './form/form-controls/auto-clipboa
 import { EnabledEncodingsControlComponent } from './form/form-controls/enabled-encodings-control/enabled-encodings-control.component';
 import { ExtendedClipboardControlComponent } from './form/form-controls/extended-clipboard-control/extended-clipboard-control.component';
 import { FileControlComponent } from './form/form-controls/file-control/file-control.component';
+import { JpegQualityLevelControlComponent } from './form/form-controls/jpeg-quality-level-control/jpeg-quality-level-control.component';
 import { ResolutionQualityControlComponent } from './form/form-controls/resolution-quality-control/resolution-quality-control.component';
 import { UltraVirtualDisplayControlComponent } from './form/form-controls/ultra-virtual-display-control/ultra-virtual-display-control.component';
 import { NetScanComponent } from './net-scan/net-scan.component';
@@ -79,6 +80,7 @@ const routes: Routes = [
     UsernameControlComponent,
     PasswordControlComponent,
     ExtendedClipboardControlComponent,
+    JpegQualityLevelControlComponent,
     ScreenSizeControlComponent,
     EnableDisplayConfigurationControlComponent,
     KdcUrlControlComponent,

--- a/webapp/src/client/app/shared/enums/encoding.enum.ts
+++ b/webapp/src/client/app/shared/enums/encoding.enum.ts
@@ -5,8 +5,6 @@ enum Encoding {
   Zlib = 'zlib',
   Hextile = 'hextile',
   Tight = 'tight',
-  JpegLow = 'jpeg-low',
-  JpegHigh = 'jpeg-high',
   TightPng = 'tight-png',
 }
 

--- a/webapp/src/client/app/shared/interfaces/connection-params.interfaces.ts
+++ b/webapp/src/client/app/shared/interfaces/connection-params.interfaces.ts
@@ -36,6 +36,7 @@ export interface IronVNCConnectionParameters {
   token?: string;
   screenSize?: DesktopSize;
   enabledEncodings?: string;
+  jpegQualityLevel?: number;
   enableCursor: boolean;
   enableExtendedClipboard: boolean;
   ultraVirtualDisplay: boolean;

--- a/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
+++ b/webapp/src/client/app/shared/interfaces/forms.interfaces.ts
@@ -44,6 +44,8 @@ export interface VncFormDataInput {
   enableExtendedClipboard?: boolean;
   ultraVirtualDisplay: boolean;
   enabledEncodings: Encoding[];
+  jpegEnabled: boolean;
+  jpegQualityLevel: number;
   wheelSpeedFactor: number;
   screenSize: ScreenSize;
   autoClipboard?: boolean;


### PR DESCRIPTION
Follow-up https://github.com/Devolutions/IronVNC/pull/956.