### PR TITLE
build(jetsocat,dgw): optimize binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,9 @@ debug = 1
 
 [profile.production]
 inherits = "release"
-lto = true
 strip = "symbols"
+codegen-units = 1
+lto = true
 
 [patch.crates-io]
 tracing-appender = { git = "https://github.com/CBenoit/tracing.git", rev = "42097daf92e683cf18da7639ddccb056721a796c" }


### PR DESCRIPTION
Size was already optimized in the past by enabling lto and stripping the debug symbols. Adding codegen-units = 1 brings the binary size further down.

- Jetsocat baseline: 7.3M
- Jetsocat after: 6.6M

- Devolutions Gateway baseline: 27M
- Devolutions Gateway after: 25M