### PR TITLE
ci: fix PowerShell .tar validation

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -260,7 +260,12 @@ jobs:
 
           # Verify the archive.
           Write-Host "Verify archive at $PSModuleTarFilePath"
-          tar -t "$PSModuleTarFilePath"
+          # tar -tvf "$PSModuleTarFilePath" | Out-Null
+          & 7z t "$PSModuleTarFilePath"
+
+          if ($LASTEXITCODE -ne 0) { 
+            throw "tar verify failed: $PSModuleTarFilePath is invalid." 
+          }
 
           Set-PSDebug -Off # Too many traces are logged when running New-ModulePackage.
           New-ModulePackage $DGatewayPSModulePath $PSModuleParentPath


### PR DESCRIPTION
We saw that a .tar archive was corrupted with the warning "There are data after the archive [sic]". This seems like something transient, but validation didn't catch it.

`tar -t {path}` will not work as expected (at least on Windows); it's needed to pass `f` to specify the file path. Otherwise tar falls back on `\\.\tape0)`(!).

Regardless, when validating tar does not set a non-zero error code for this kind of issue.

Instead, use `7z -t` which properly sets the error code and allows us to bail out.