### PR TITLE
ci(release): fix SBOM job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -527,7 +527,7 @@ jobs:
       - name: Download SBOM artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download ${{ needs.preflight.outputs.run }} -n sbom --repo $Env:GITHUB_REPOSITORY
+        run: gh run download ${{ needs.preflight.outputs.run }} -n sbom --repo $GITHUB_REPOSITORY
 
       - name: Upload SBOM to OneDrive Releases
         uses: ./.github/workflows/onedrive-upload


### PR DESCRIPTION
Unfortunately, this is stuff that does not run unless we cut a release, so it’s hard to get right… but I think now we should be good!