### PR TITLE
fix(jetsocat): improve optional flag handling and error reporting

### DIFF
--- a/jetsocat/src/main.rs
+++ b/jetsocat/src/main.rs
@@ -31,10 +31,11 @@ use jetsocat::pipe::PipeMode;
 use jetsocat::proxy::{ProxyConfig, ProxyType, detect_proxy};
 use jmux_proxy::JmuxConfig;
 use seahorse::{App, Command, Context, Flag, FlagType};
+use std::env;
+use std::error::Error;
 use std::future::Future;
 use std::path::PathBuf;
 use std::time::Duration;
-use std::{env, error::Error};
 use tokio::runtime;
 
 fn main() {


### PR DESCRIPTION
Improves the handling of optional command-line flags in jetsocat by replacing direct flag access with proper error handling: missing optional flags are handled gracefully while invalid flag values still produce clear error messages.