### PR TITLE
fix(webapp): VNC connect for "None" authentication

### DIFF
--- a/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
+++ b/webapp/src/client/app/modules/web-client/vnc/web-client-vnc.component.ts
@@ -508,7 +508,6 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
   private callConnect(connectionParameters: IronVNCConnectionParameters): void {
     const configBuilder = this.remoteClient
       .configBuilder()
-      .withPassword(connectionParameters.password)
       .withDestination(connectionParameters.host)
       .withProxyAddress(connectionParameters.gatewayAddress)
       .withAuthToken(connectionParameters.token)
@@ -523,6 +522,10 @@ export class WebClientVncComponent extends WebClientBaseComponent implements OnI
 
     if (connectionParameters.username != null) {
       configBuilder.withUsername(connectionParameters.username);
+    }
+
+    if (connectionParameters.password != null) {
+      configBuilder.withPassword(connectionParameters.password);
     }
 
     if (connectionParameters.screenSize != null) {


### PR DESCRIPTION
Fixes this error when trying to connect without a username and a password in VNC session:
<img width="711" height="672" alt="image" src="https://github.com/user-attachments/assets/dfc96a5c-5134-4e29-8c03-a653eac3cabf" />
