### PR TITLE
fix(dgw): split TlsVerifyStrict warning for absent and false

### DIFF
--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -72,9 +72,7 @@ impl GatewayService {
         match conf_file.tls_verify_strict {
             None => {
                 warn!("TlsVerifyStrict option is not set, defaulting to false. This may hide latent issues.");
-                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled(
-                    "TlsVerifyStrict option is not set, defaulting to false",
-                ));
+                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled("compat");
             }
             Some(false) => {
                 warn!("TlsVerifyStrict option is explicitly set to false. This may hide latent issues.");

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -69,11 +69,20 @@ impl GatewayService {
             );
         }
 
-        if matches!(conf_file.tls_verify_strict, None | Some(false)) {
-            warn!("TlsVerifyStrict option is absent or set to false. This may hide latent issues.");
-            let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled(
-                "TlsVerifyStrict option is absent or set to false",
-            ));
+        match conf_file.tls_verify_strict {
+            None => {
+                warn!("TlsVerifyStrict option is not set, defaulting to false. This may hide latent issues.");
+                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled(
+                    "TlsVerifyStrict option is not set, defaulting to false",
+                ));
+            }
+            Some(false) => {
+                warn!("TlsVerifyStrict option is explicitly set to false. This may hide latent issues.");
+                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled(
+                    "TlsVerifyStrict option is explicitly set to false",
+                ));
+            }
+            Some(true) => {}
         }
 
         if let Some((cert_subject_name, hostname)) = conf_file

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -72,7 +72,7 @@ impl GatewayService {
         match conf_file.tls_verify_strict {
             None => {
                 warn!("TlsVerifyStrict option is not set, defaulting to false. This may hide latent issues.");
-                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled("compat");
+                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled("compat"));
             }
             Some(false) => {
                 warn!("TlsVerifyStrict option is explicitly set to false. This may hide latent issues.");

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -76,9 +76,7 @@ impl GatewayService {
             }
             Some(false) => {
                 warn!("TlsVerifyStrict option is explicitly set to false. This may hide latent issues.");
-                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled(
-                    "TlsVerifyStrict option is explicitly set to false",
-                ));
+                let _ = SYSTEM_LOGGER.emit(sysevent_codes::tls_verify_strict_disabled("explicit"));
             }
             Some(true) => {}
         }


### PR DESCRIPTION
This splits the warnings for absent and false.