### PR TITLE
build(dgw,agent): improve systemd integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "ceviche"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c08bc4ee8dce2878185fe1e6dc9b550a36ac3b4fa8c8e8546c4d8792d0176d"
+checksum = "df5dea6d0064e3517b6f7ccf7d46713d9221547c74451d529f009b09cd2f9247"
 dependencies = [
  "cfg-if",
  "chrono",

--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 anyhow = "1"
 async-trait = "0.1"
 camino = { version = "1.1", features = ["serde1"] }
-ceviche = "0.6"
+ceviche = "0.7"
 ctrlc = "3.4"
 devolutions-agent-shared = { path = "../crates/devolutions-agent-shared" }
 devolutions-gateway-task = { path = "../crates/devolutions-gateway-task" }

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -40,7 +40,7 @@ ironrdp-rdcleanpath = "0.1"
 ironrdp-tokio = "0.5"
 ironrdp-connector = { version = "0.5" }
 ironrdp-acceptor = { version = "0.5" }
-ceviche = "0.6.1"
+ceviche = "0.7"
 picky-krb = "0.11"
 
 # Serialization

--- a/package/Linux/gateway/debian/postinst
+++ b/package/Linux/gateway/debian/postinst
@@ -6,7 +6,7 @@ if [ ! -d /etc/devolutions-gateway ]; then
 fi
 
 if [ -d /run/systemd/system ]; then
-    # Generate /etc/devolutions-gateway/gateway.json
+	# Generate /etc/devolutions-gateway/gateway.json
 	/usr/bin/devolutions-gateway --config-init-only >/dev/null
 fi
 

--- a/package/Linux/gateway/rpm/postinst
+++ b/package/Linux/gateway/rpm/postinst
@@ -10,5 +10,5 @@ if [ -d /run/systemd/system ]; then
 	systemctl daemon-reload
 	/usr/bin/devolutions-gateway --config-init-only >/dev/null
 	systemctl enable --now devolutions-gateway >/dev/null 2>&1
-   systemctl restart devolutions-gateway >/dev/null 2>&1
+	systemctl restart devolutions-gateway >/dev/null 2>&1
 fi


### PR DESCRIPTION
Update ceviche to 0.7.0 which improves systemd integration.

Here is the new strategy:

- **pkg-config detection**: We query `pkg-config --variable=systemdsystemunitdir systemd` to get the distribution's preferred location. This works on most modern systems that have systemd development packages installed.

- **Fallback probing**: If pkg-config is unavailable or doesn't return a result, we probe common directories in order:
  - `/usr/lib/systemd/system`
  - `/lib/systemd/system`

This fixes installation issues on RHEL-based distributions where systemd units are located in /usr/lib/systemd/system instead of /lib/systemd/ system.

Issue: DGW-317