### PR TITLE
fix(dgw): report disk space when recording dir does not exist yet

### DIFF
--- a/devolutions-gateway/src/api/heartbeat.rs
+++ b/devolutions-gateway/src/api/heartbeat.rs
@@ -176,18 +176,18 @@ pub(crate) fn recording_storage_health(recording_path: &std::path::Path) -> Reco
 
 /// Queries total and available disk space for the given path.
 ///
-/// On Windows, calls `GetDiskFreeSpaceExW` directly against the configured recording path.
-/// This supports UNC paths (`\\server\share\...`) and mapped drive letters without needing
-/// to enumerate mount points or canonicalize the path.
+/// On Windows, calls `GetDiskFreeSpaceExW` against an existing path on the same volume as the
+/// configured recording path.  This supports UNC paths (`\\server\share\...`) and mapped drive
+/// letters without needing to enumerate mount points or canonicalize the path.
 ///
-/// On Unix, calls `statvfs(2)` directly against the configured recording path.
-/// This supports network filesystems (NFS, CIFS/Samba) and any mount point without needing
-/// to enumerate mount points.
+/// On Unix, calls `statvfs(2)` against an existing path on the same volume as the configured
+/// recording path.  This supports network filesystems (NFS, CIFS/Samba) and any mount point
+/// without needing to enumerate mount points.
 ///
 /// On other platforms, space values are not available and `(None, None)` is returned.
 ///
 /// If `recording_path` does not exist yet (e.g. the recordings folder was never created),
-/// the nearest existing ancestor is used instead. Disk space is a volume property, so any
+/// the nearest existing ancestor is used instead.  Disk space is a volume property, so any
 /// path on the same volume yields the correct result.
 fn query_storage_space(recording_path: &std::path::Path) -> (Option<u64>, Option<u64>) {
     static NO_DISK_STATE: NoDiskState = NoDiskState::new();

--- a/devolutions-gateway/src/api/heartbeat.rs
+++ b/devolutions-gateway/src/api/heartbeat.rs
@@ -185,10 +185,20 @@ pub(crate) fn recording_storage_health(recording_path: &std::path::Path) -> Reco
 /// to enumerate mount points.
 ///
 /// On other platforms, space values are not available and `(None, None)` is returned.
+///
+/// If `recording_path` does not exist yet (e.g. the recordings folder was never created),
+/// the nearest existing ancestor is used instead. Disk space is a volume property, so any
+/// path on the same volume yields the correct result.
 fn query_storage_space(recording_path: &std::path::Path) -> (Option<u64>, Option<u64>) {
     static NO_DISK_STATE: NoDiskState = NoDiskState::new();
 
-    return query_storage_space_impl(recording_path);
+    // Walk up to the first existing ancestor so that a missing recordings directory does not
+    // prevent us from reporting disk space (disk space is a volume property, not a directory one).
+    let effective_path = std::iter::successors(Some(recording_path), |p| p.parent())
+        .find(|p| p.exists())
+        .unwrap_or(recording_path);
+
+    return query_storage_space_impl(effective_path);
 
     #[cfg(windows)]
     fn query_storage_space_impl(recording_path: &std::path::Path) -> (Option<u64>, Option<u64>) {

--- a/testsuite/src/dgw_config.rs
+++ b/testsuite/src/dgw_config.rs
@@ -149,7 +149,7 @@ impl DgwConfigHandle {
             let path_str = path.to_string_lossy().replace('\\', "/");
             format!(
                 r#",
-    "recording_path": "{path_str}""#
+    "RecordingPath": "{path_str}""#
             )
         } else {
             String::new()

--- a/testsuite/src/dgw_config.rs
+++ b/testsuite/src/dgw_config.rs
@@ -147,8 +147,10 @@ impl DgwConfigHandle {
         let recording_path_json = if let Some(path) = recording_path {
             // Use forward slashes so the JSON value is valid on all platforms.
             let path_str = path.to_string_lossy().replace('\\', "/");
-            format!(r#",
-    "recording_path": "{path_str}""#)
+            format!(
+                r#",
+    "recording_path": "{path_str}""#
+            )
         } else {
             String::new()
         };

--- a/testsuite/src/dgw_config.rs
+++ b/testsuite/src/dgw_config.rs
@@ -54,6 +54,12 @@ pub struct DgwConfig {
     /// Enable unstable features (required for AI gateway).
     #[builder(default = false)]
     enable_unstable: bool,
+    /// Override the recording path in the gateway config.
+    ///
+    /// When `None`, the gateway uses its default (`<data_dir>/recordings`).
+    /// Pass a path that does not yet exist to test behaviour before the folder is created.
+    #[builder(default, setter(into))]
+    recording_path: Option<std::path::PathBuf>,
 }
 
 fn find_unused_port() -> u16 {
@@ -85,6 +91,7 @@ impl DgwConfigHandle {
             verbosity_profile,
             ai_gateway,
             enable_unstable,
+            recording_path,
         } = config;
 
         let tempdir = tempfile::tempdir().context("create tempdir")?;
@@ -137,6 +144,15 @@ impl DgwConfigHandle {
             String::new()
         };
 
+        let recording_path_json = if let Some(path) = recording_path {
+            // Use forward slashes so the JSON value is valid on all platforms.
+            let path_str = path.to_string_lossy().replace('\\', "/");
+            format!(r#",
+    "recording_path": "{path_str}""#)
+        } else {
+            String::new()
+        };
+
         let config = format!(
             r#"{{
     "ProvisionerPublicKeyData": {{
@@ -156,7 +172,7 @@ impl DgwConfigHandle {
     "__debug__": {{
         "disable_token_validation": {disable_token_validation},
         "enable_unstable": {enable_unstable}
-    }}{ai_gateway_json}
+    }}{ai_gateway_json}{recording_path_json}
 }}"#
         );
 

--- a/testsuite/tests/cli/dgw/heartbeat.rs
+++ b/testsuite/tests/cli/dgw/heartbeat.rs
@@ -1,0 +1,123 @@
+//! Heartbeat API regression tests.
+//!
+//! These tests verify the `/jet/heartbeat` endpoint behaviour under various
+//! recording-path configurations.
+
+use anyhow::Context as _;
+use testsuite::cli::{dgw_tokio_cmd, wait_for_tcp_port};
+use testsuite::dgw_config::{DgwConfig, DgwConfigHandle};
+
+/// Scope token with `gateway.heartbeat.read` scope.
+///
+/// Token validation is disabled in tests, so the signature is fake.
+/// - Header: `{"typ":"JWT","alg":"RS256"}`
+/// - Payload: `{"type":"scope","jti":"...","scope":"gateway.heartbeat.read",...}`
+const HEARTBEAT_SCOPE_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJ0eXBlIjoic2NvcGUiLCJqdGkiOiIwMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDMiLCJpYXQiOjE3MzM2Njk5OTksImV4cCI6MzMzMTU1MzU5OSwibmJmIjoxNzMzNjY5OTk5LCJzY29wZSI6ImdhdGV3YXkuaGVhcnRiZWF0LnJlYWQifQ.aW52YWxpZC1zaWduYXR1cmUtYnV0LXZhbGlkYXRpb24tZGlzYWJsZWQ";
+
+/// Starts a gateway instance and waits until its HTTP port is ready.
+async fn start_gateway(config_handle: &DgwConfigHandle) -> anyhow::Result<tokio::process::Child> {
+    let process = dgw_tokio_cmd()
+        .env("DGATEWAY_CONFIG_PATH", config_handle.config_dir())
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .context("failed to start Devolutions Gateway")?;
+
+    wait_for_tcp_port(config_handle.http_port()).await?;
+
+    Ok(process)
+}
+
+/// Calls `GET /jet/heartbeat` and returns the parsed JSON body.
+async fn get_heartbeat(http_port: u16) -> anyhow::Result<serde_json::Value> {
+    use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _, BufReader};
+
+    let request = format!(
+        "GET /jet/heartbeat HTTP/1.1\r\n\
+         Host: 127.0.0.1:{http_port}\r\n\
+         Authorization: Bearer {HEARTBEAT_SCOPE_TOKEN}\r\n\
+         Connection: close\r\n\
+         \r\n"
+    );
+
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", http_port))
+        .await
+        .context("connect to gateway")?;
+
+    stream.write_all(request.as_bytes()).await.context("send request")?;
+    stream.flush().await.context("flush")?;
+
+    // Read headers until the blank line, then read the body.
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        reader.read_line(&mut line).await.context("read header line")?;
+        if line == "\r\n" || line.is_empty() {
+            break;
+        }
+    }
+
+    let mut body = String::new();
+    tokio::io::AsyncReadExt::read_to_string(&mut reader, &mut body)
+        .await
+        .context("read body")?;
+
+    serde_json::from_str(&body).with_context(|| format!("parse heartbeat JSON: {body:?}"))
+}
+
+/// Regression test: when the configured recording folder does not exist yet (as is the case
+/// immediately after upgrading before the gateway has had a chance to create it), the heartbeat
+/// endpoint must still report disk space information.
+///
+/// Prior to the fix this regressed in 2026.1.1: `GetDiskFreeSpaceExW` / `statvfs` were called
+/// directly on the non-existent path and failed with OS error 3 (path not found), causing
+/// `recording_storage_total_space` and `recording_storage_available_space` to be absent from
+/// the response.
+#[tokio::test]
+async fn heartbeat_reports_disk_space_when_recording_dir_not_yet_created() -> anyhow::Result<()> {
+    // Configure a recording path that does not exist yet.
+    let base = tempfile::tempdir().context("create tempdir for recording path")?;
+    let nonexistent_recordings = base.path().join("recordings_not_created_yet");
+    assert!(
+        !nonexistent_recordings.exists(),
+        "pre-condition: recording dir must not exist before the test"
+    );
+
+    let config_handle = DgwConfig::builder()
+        .disable_token_validation(true)
+        .recording_path(nonexistent_recordings.clone())
+        .build()
+        .init()
+        .context("init config")?;
+
+    let mut process = start_gateway(&config_handle).await?;
+
+    let heartbeat = get_heartbeat(config_handle.http_port())
+        .await
+        .context("get heartbeat")?;
+
+    let _ = process.start_kill();
+    let _ = process.wait().await;
+
+    // The recording folder still must not have been created by the gateway startup.
+    assert!(
+        !nonexistent_recordings.exists(),
+        "recording dir should still not exist after gateway startup"
+    );
+
+    // Disk space must be reported even though the folder doesn't exist.
+    assert!(
+        !heartbeat["recording_storage_total_space"].is_null(),
+        "recording_storage_total_space must be present when recording dir does not exist yet; \
+         got heartbeat: {heartbeat}"
+    );
+    assert!(
+        !heartbeat["recording_storage_available_space"].is_null(),
+        "recording_storage_available_space must be present when recording dir does not exist yet; \
+         got heartbeat: {heartbeat}"
+    );
+
+    Ok(())
+}

--- a/testsuite/tests/cli/dgw/heartbeat.rs
+++ b/testsuite/tests/cli/dgw/heartbeat.rs
@@ -1,7 +1,4 @@
-//! Heartbeat API regression tests.
-//!
-//! These tests verify the `/jet/heartbeat` endpoint behaviour under various
-//! recording-path configurations.
+//! Heartbeat API tests.
 
 use anyhow::Context as _;
 use testsuite::cli::{dgw_tokio_cmd, wait_for_tcp_port};
@@ -67,8 +64,7 @@ async fn get_heartbeat(http_port: u16) -> anyhow::Result<serde_json::Value> {
     serde_json::from_str(&body).with_context(|| format!("parse heartbeat JSON: {body:?}"))
 }
 
-/// Regression test: when the configured recording folder does not exist yet (as is the case
-/// immediately after upgrading before the gateway has had a chance to create it), the heartbeat
+/// Regression test: when the configured recording folder does not exist yet, the heartbeat
 /// endpoint must still report disk space information.
 ///
 /// Prior to the fix this regressed in 2026.1.1: `GetDiskFreeSpaceExW` / `statvfs` were called

--- a/testsuite/tests/cli/dgw/mod.rs
+++ b/testsuite/tests/cli/dgw/mod.rs
@@ -1,6 +1,7 @@
 mod ai_gateway;
 mod benign_disconnect;
 mod cli_args;
+mod heartbeat;
 mod preflight;
 mod tls_anchoring;
 mod traffic_audit;


### PR DESCRIPTION
When the recording folder has not been created yet, GetDiskFreeSpaceExW / statvfs failed with OS error 3 because the path did not exist, causing recording_storage_total_space and recording_storage_available_space to be absent from the heartbeat response.

Fix by walking up to the nearest existing ancestor before querying disk space. Disk space is a volume property, so any path on the same volume yields the correct result.