### PR TITLE
fix(gateway): add warn logs to shadow recording error paths

### DIFF
--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -538,18 +538,22 @@ async fn shadow_recording(
     };
 
     if !xmf::is_init() {
+        warn!(%id, "Shadow recording rejected: XMF native library is not loaded");
         return close_with_error(ws, StreamerCloseCode::InternalError);
     }
 
     let Ok(notify) = recordings.subscribe_to_recording_finish(id).await else {
+        warn!(%id, "Shadow recording rejected: failed to subscribe to recording finish");
         return close_with_error(ws, StreamerCloseCode::InternalError);
     };
 
     let Ok(recording_files) = recordings.list_files(id).await else {
+        warn!(%id, "Shadow recording rejected: failed to list recording files");
         return close_with_error(ws, StreamerCloseCode::InternalError);
     };
 
     let Some(recording_path) = recording_files.last() else {
+        warn!(%id, "Shadow recording rejected: no recording files found");
         return close_with_error(ws, StreamerCloseCode::InternalError);
     };
 


### PR DESCRIPTION
## Summary
- Added `warn!` logs to all 4 `InternalError` (close code 4002) branches in `shadow_recording` handler
- Previously, these error paths silently closed the WebSocket with no diagnostic output, making production debugging nearly impossible (e.g. XMF library not loaded)

## Test plan
- [ ] Verify `cargo check -p devolutions-gateway` passes
- [ ] Confirm warn logs appear when shadow recording fails due to missing XMF library

🤖 Generated with [Claude Code](https://claude.com/claude-code)