### PR TITLE
refactor(dgw): address security review follow-up on secure-memory crate

### DIFF
--- a/crates/secure-memory-verifier/README.md
+++ b/crates/secure-memory-verifier/README.md
@@ -14,7 +14,7 @@ Run it manually on a Windows machine to confirm the OS hardening is active.
 | `guard-overflow` | Guard pages (trailing) | Child process crashes on access after data |
 
 > **Note on WER dump exclusion:** `WerRegisterExcludedMemoryBlock` is called by
-> `ProtectedBytes::new` but is not verified here. It registers the data page for
+> `ProtectedBytes::new` (during construction) but is not verified here. It registers the data page for
 > exclusion from WER crash reports sent to Microsoft Watson only. Full-memory
 > dumps (`MiniDumpWithFullMemory`, ProcDump `-ma`, LocalDumps `DumpType=2`,
 > kernel dumps) capture all committed read/write pages regardless. No public

--- a/crates/secure-memory-verifier/src/check_guard.rs
+++ b/crates/secure-memory-verifier/src/check_guard.rs
@@ -82,7 +82,7 @@ pub(crate) fn run(side: Side) -> bool {
     {
         // Check the protection status in order for information.
 
-        let probe = ProtectedBytes::<32>::new([0xAAu8; 32]);
+        let probe = ProtectedBytes::<32>::new(&mut [0xAAu8; 32]);
         let status = probe.protection_status();
 
         if !status.guard_pages {
@@ -141,7 +141,7 @@ pub(crate) fn run(side: Side) -> bool {
 /// Run inside the child process. Intentionally accesses a guard page, which
 /// crashes with `STATUS_ACCESS_VIOLATION`. Never returns.
 pub(crate) fn child(side: Side) -> ! {
-    let secret = ProtectedBytes::<32>::new([0x42u8; 32]);
+    let secret = ProtectedBytes::<32>::new(&mut [0x42u8; 32]);
     let data_ptr = secret.expose_secret().as_ptr();
 
     let access_ptr: *const u8 = match side {

--- a/crates/secure-memory-verifier/src/check_lock.rs
+++ b/crates/secure-memory-verifier/src/check_lock.rs
@@ -38,7 +38,7 @@ const LOCKED_BIT: usize = 22;
 pub(crate) fn run() -> bool {
     print_check("lock: verifying data page is locked in RAM via QueryWorkingSetEx");
 
-    let secret = ProtectedBytes::<32>::new([0x5Au8; 32]);
+    let secret = ProtectedBytes::<32>::new(&mut [0x5Au8; 32]);
     let status = secret.protection_status();
 
     if !status.locked {

--- a/crates/secure-memory/README.md
+++ b/crates/secure-memory/README.md
@@ -26,6 +26,9 @@ It is intentionally **not** a general-purpose secret library.
 - Transient register / stack copies during `expose_secret` calls — memory
   locking does **not** prevent the CPU from holding secret bytes in registers
   or on the call stack while the caller uses them.
+- Stack residuals from passing the `[u8; N]` to `new` — the compiler may copy
+  the array into `new`'s stack frame; only that local copy is zeroized.
+  Any residual bytes in the caller's frame are not zeroed by this crate.
 - Attackers with `ptrace` or equivalent capability.
 - SGX / TPM / hardware-backed enclaves.
 
@@ -62,12 +65,21 @@ and runs.
 ## Usage
 
 ```rust
-use secure_memory::ProtectedBytes;
+use secure_memory::{ProtectedBytes, ProtectionLevel};
 
 let key = ProtectedBytes::new([0u8; 32]);
+
+// Recommended: check the overall level first.
+match key.protection_status().level() {
+    ProtectionLevel::Full => {}
+    ProtectionLevel::Partial => tracing::warn!("master key: some memory protections are inactive"),
+    ProtectionLevel::Unprotected => tracing::warn!("master key: no OS memory hardening available"),
+}
+
+// Individual flags are still accessible for fine-grained diagnostics.
 let status = key.protection_status();
 if !status.locked {
-    tracing::warn!("master key is not mlock'd");
+    tracing::warn!("master key: mlock/VirtualLock failed; key may be paged to disk");
 }
 
 // Short-lived borrow:

--- a/crates/secure-memory/README.md
+++ b/crates/secure-memory/README.md
@@ -26,9 +26,9 @@ It is intentionally **not** a general-purpose secret library.
 - Transient register / stack copies during `expose_secret` calls — memory
   locking does **not** prevent the CPU from holding secret bytes in registers
   or on the call stack while the caller uses them.
-- Stack residuals from passing the `[u8; N]` to `new` — the compiler may copy
-  the array into `new`'s stack frame; only that local copy is zeroized.
-  Any residual bytes in the caller's frame are not zeroed by this crate.
+- Stack residuals in the caller's frame before `new` is called — `new` zeroes
+  the buffer it receives, but any earlier copies on the caller's stack are not
+  covered.
 - Attackers with `ptrace` or equivalent capability.
 - SGX / TPM / hardware-backed enclaves.
 
@@ -67,7 +67,10 @@ and runs.
 ```rust
 use secure_memory::{ProtectedBytes, ProtectionLevel};
 
-let key = ProtectedBytes::new([0u8; 32]);
+let mut key_bytes = [0u8; 32];
+// ... fill key_bytes ...
+let key = ProtectedBytes::new(&mut key_bytes);
+// key_bytes is now zeroed
 
 // Recommended: check the overall level first.
 match key.protection_status().level() {

--- a/crates/secure-memory/src/fallback.rs
+++ b/crates/secure-memory/src/fallback.rs
@@ -24,6 +24,7 @@ impl<const N: usize> SecureAlloc<N> {
             locked: false,
             guard_pages: false,
             dump_excluded: false,
+            write_protected: false,
             fallback_backend: true,
         };
         (Self { inner: b }, status)

--- a/crates/secure-memory/src/lib.rs
+++ b/crates/secure-memory/src/lib.rs
@@ -116,9 +116,8 @@ pub enum ProtectionLevel {
 /// platforms the bytes are zeroized before the backing allocation is released.
 ///
 /// - `Debug` emits `[REDACTED]`; `Display` is absent; not `Clone` or `Copy`.
-/// - The caller's array is moved (and may be physically copied) into `new`.
-///   The local parameter `bytes` is zeroized immediately after the transfer;
-///   earlier stack residuals in the caller's frame are not zeroed by this crate.
+/// - `new` takes a mutable reference and zeroizes the source buffer after
+///   copying the secret into secure storage, covering caller-frame residuals.
 /// - `mlock` / `VirtualLock` prevent paging to disk but do not prevent transient
 ///   exposure in registers or on the call stack during `expose_secret`.
 pub struct ProtectedBytes<const N: usize> {
@@ -127,12 +126,10 @@ pub struct ProtectedBytes<const N: usize> {
 }
 
 impl<const N: usize> ProtectedBytes<N> {
-    /// Move `bytes` into a new protected allocation.
+    /// Copy `bytes` into a new protected allocation and zeroize the source.
     ///
-    /// The `bytes` parameter is zeroized immediately after the secret has been
-    /// transferred into secure storage. Any copies that Rust or the compiler
-    /// placed in the caller's stack frame before the call are **not** zeroized
-    /// by this crate.
+    /// The source buffer is zeroized immediately after the secret has been
+    /// transferred into secure storage, covering caller-frame residuals.
     ///
     /// # Panics
     ///
@@ -141,17 +138,14 @@ impl<const N: usize> ProtectedBytes<N> {
     /// unavailable `madvise` flags, …) do **not** panic; they are downgraded
     /// and reported via [`ProtectedBytes::protection_status`] and a
     /// `tracing::debug!`.
-    pub fn new(mut bytes: [u8; N]) -> Self {
-        let (inner, status) = platform::SecureAlloc::new(&bytes);
-        // Zeroize the stack copy now that the secret lives in secure storage.
-        zeroize::Zeroize::zeroize(&mut bytes);
+    pub fn new(bytes: &mut [u8; N]) -> Self {
+        let (inner, status) = platform::SecureAlloc::new(bytes);
+        // Zeroize the source buffer now that the secret lives in secure storage.
+        zeroize::Zeroize::zeroize(bytes);
         Self { inner, status }
     }
 
     /// Borrow the secret bytes.
-    ///
-    /// Keep the returned reference as short-lived as possible.
-    /// The CPU may hold the value in registers or on the stack during use.
     #[must_use]
     pub fn expose_secret(&self) -> &[u8; N] {
         self.inner.expose()
@@ -178,13 +172,13 @@ mod tests {
 
     #[test]
     fn construction_and_expose() {
-        let secret = ProtectedBytes::new([0x42u8; 32]);
+        let secret = ProtectedBytes::new(&mut [0x42u8; 32]);
         assert_eq!(secret.expose_secret(), &[0x42u8; 32]);
     }
 
     #[test]
     fn redacted_debug_does_not_leak_bytes() {
-        let secret = ProtectedBytes::new([0xFFu8; 32]);
+        let secret = ProtectedBytes::new(&mut [0xFFu8; 32]);
         let s = format!("{secret:?}");
         assert!(s.contains("REDACTED"), "debug must say REDACTED, got: {s}");
         // Must not contain the byte value in decimal or hex.
@@ -197,7 +191,7 @@ mod tests {
     /// for the current platform.
     #[test]
     fn protection_status_coherent() {
-        let secret = ProtectedBytes::new([1u8; 32]);
+        let secret = ProtectedBytes::new(&mut [1u8; 32]);
         let st = secret.protection_status();
 
         // fallback_backend is mutually exclusive with OS hardening.
@@ -218,7 +212,7 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn os_backend_is_not_fallback() {
-        let secret = ProtectedBytes::new([2u8; 32]);
+        let secret = ProtectedBytes::new(&mut [2u8; 32]);
         assert!(
             !secret.protection_status().fallback_backend,
             "expected OS backend on this platform"
@@ -228,7 +222,7 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn guard_pages_active() {
-        let secret = ProtectedBytes::new([3u8; 32]);
+        let secret = ProtectedBytes::new(&mut [3u8; 32]);
         let st = secret.protection_status();
         assert!(st.guard_pages, "guard pages should be active");
     }
@@ -236,9 +230,17 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn write_protected_active() {
-        let secret = ProtectedBytes::new([4u8; 32]);
+        let secret = ProtectedBytes::new(&mut [4u8; 32]);
         let st = secret.protection_status();
         assert!(st.write_protected, "data page should be write-protected");
+    }
+
+    #[test]
+    fn new_clears_source() {
+        let mut raw = [0xABu8; 32];
+        let secret = ProtectedBytes::new(&mut raw);
+        assert_eq!(secret.expose_secret(), &[0xABu8; 32]);
+        assert_eq!(raw, [0u8; 32], "source buffer must be zeroed after new");
     }
 
     // Test the fallback backend directly on all platforms.
@@ -257,7 +259,7 @@ mod tests {
     #[cfg(any(unix, windows))]
     #[test]
     fn os_backend_is_full_protection() {
-        let secret = ProtectedBytes::new([5u8; 32]);
+        let secret = ProtectedBytes::new(&mut [5u8; 32]);
         assert_eq!(
             secret.protection_status().level(),
             ProtectionLevel::Full,

--- a/crates/secure-memory/src/lib.rs
+++ b/crates/secure-memory/src/lib.rs
@@ -256,7 +256,7 @@ mod tests {
         assert_eq!(status.level(), ProtectionLevel::Unprotected);
     }
 
-    #[cfg(any(unix, windows))]
+    #[cfg(any(windows, target_os = "linux"))]
     #[test]
     fn os_backend_is_full_protection() {
         let secret = ProtectedBytes::new(&mut [5u8; 32]);

--- a/crates/secure-memory/src/lib.rs
+++ b/crates/secure-memory/src/lib.rs
@@ -116,8 +116,10 @@ pub enum ProtectionLevel {
 /// platforms the bytes are zeroized before the backing allocation is released.
 ///
 /// - `Debug` emits `[REDACTED]`; `Display` is absent; not `Clone` or `Copy`.
-/// - `new` takes a mutable reference and zeroizes the source buffer after
-///   copying the secret into secure storage, covering caller-frame residuals.
+/// - `new` takes a mutable reference and zeroizes exactly that buffer after
+///   copying the secret into secure storage. Any earlier copies of the same
+///   bytes elsewhere in the caller's frame (or in intermediate buffers) are
+///   **not** zeroed by this crate.
 /// - `mlock` / `VirtualLock` prevent paging to disk but do not prevent transient
 ///   exposure in registers or on the call stack during `expose_secret`.
 pub struct ProtectedBytes<const N: usize> {
@@ -128,8 +130,10 @@ pub struct ProtectedBytes<const N: usize> {
 impl<const N: usize> ProtectedBytes<N> {
     /// Copy `bytes` into a new protected allocation and zeroize the source.
     ///
-    /// The source buffer is zeroized immediately after the secret has been
-    /// transferred into secure storage, covering caller-frame residuals.
+    /// The buffer pointed to by `bytes` is zeroized immediately after the
+    /// secret has been transferred into secure storage. Any other copies of
+    /// the same bytes — in earlier stack frames, intermediate buffers, or
+    /// registers — are **not** zeroed by this crate.
     ///
     /// # Panics
     ///

--- a/crates/secure-memory/src/lib.rs
+++ b/crates/secure-memory/src/lib.rs
@@ -22,6 +22,9 @@ use windows as platform;
 ///
 /// All fields are `false` when the platform backend is not available
 /// (`fallback_backend == true`).
+///
+/// For a quick pass/fail check, call [`ProtectionStatus::level`] instead of
+/// inspecting individual fields.
 #[derive(Debug, Clone, Copy)]
 pub struct ProtectionStatus {
     /// The pages are locked in RAM (`mlock` / `VirtualLock`).
@@ -48,11 +51,61 @@ pub struct ProtectionStatus {
     /// - **macOS**: always `false`; no equivalent API exists.
     pub dump_excluded: bool,
 
+    /// The data page was successfully demoted to read-only after construction
+    /// (`mprotect(PROT_READ)` / `VirtualProtect(PAGE_READONLY)`).
+    ///
+    /// When `false` the page remains writable, which means the "Removing write
+    /// access prevents accidental overwrites" guarantee does not hold.
+    pub write_protected: bool,
+
     /// No OS-level hardening is available; using plain heap allocation.
     ///
     /// The secret is still zeroized on drop but none of the other protections
     /// are active. A debug message is logged once at construction time.
     pub fallback_backend: bool,
+}
+
+impl ProtectionStatus {
+    /// Return the overall protection level as a single summary value.
+    ///
+    /// Prefer this over checking individual fields when you only need to know
+    /// whether the allocation is adequately protected. See [`ProtectionLevel`]
+    /// for the exact definition of each variant.
+    #[must_use]
+    pub fn level(&self) -> ProtectionLevel {
+        if self.fallback_backend {
+            ProtectionLevel::Unprotected
+        } else if self.guard_pages && self.locked && self.write_protected && self.dump_excluded {
+            ProtectionLevel::Full
+        } else {
+            ProtectionLevel::Partial
+        }
+    }
+}
+
+/// Overall memory-protection level for a [`ProtectedBytes`] allocation.
+///
+/// Returned by [`ProtectionStatus::level`].
+/// Individual protection flags are still accessible via [`ProtectionStatus`]
+/// when finer-grained diagnostics are needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProtectionLevel {
+    /// All core OS hardening is active: guard pages, RAM lock, read-only page
+    /// protection, and crash-dump exclusion all succeeded.
+    ///
+    /// Note: on macOS `dump_excluded` is always `false` (no platform API
+    /// exists), so `Full` is never reached on macOS — `Partial` is the best
+    /// achievable level there.
+    Full,
+
+    /// The OS backend is active but at least one protection (`guard_pages`,
+    /// `locked`, `write_protected`, or `dump_excluded`) failed at runtime
+    /// (e.g. due to `ulimit` restrictions or platform limitations).
+    Partial,
+
+    /// No OS-level hardening is available. The allocation falls back to a plain
+    /// heap allocation with zeroize-on-drop only.
+    Unprotected,
 }
 
 /// A fixed-size, protected in-memory secret.
@@ -63,8 +116,9 @@ pub struct ProtectionStatus {
 /// platforms the bytes are zeroized before the backing allocation is released.
 ///
 /// - `Debug` emits `[REDACTED]`; `Display` is absent; not `Clone` or `Copy`.
-/// - One unavoidable stack copy in `new`: the `[u8; N]` argument is zeroized
-///   immediately after being transferred into secure storage.
+/// - The caller's array is moved (and may be physically copied) into `new`.
+///   The local parameter `bytes` is zeroized immediately after the transfer;
+///   earlier stack residuals in the caller's frame are not zeroed by this crate.
 /// - `mlock` / `VirtualLock` prevent paging to disk but do not prevent transient
 ///   exposure in registers or on the call stack during `expose_secret`.
 pub struct ProtectedBytes<const N: usize> {
@@ -75,8 +129,10 @@ pub struct ProtectedBytes<const N: usize> {
 impl<const N: usize> ProtectedBytes<N> {
     /// Move `bytes` into a new protected allocation.
     ///
-    /// The local copy of `bytes` is zeroized immediately after it has been
-    /// transferred into secure storage.
+    /// The `bytes` parameter is zeroized immediately after the secret has been
+    /// transferred into secure storage. Any copies that Rust or the compiler
+    /// placed in the caller's stack frame before the call are **not** zeroized
+    /// by this crate.
     ///
     /// # Panics
     ///
@@ -149,6 +205,7 @@ mod tests {
             assert!(!st.locked);
             assert!(!st.guard_pages);
             assert!(!st.dump_excluded);
+            assert!(!st.write_protected);
         }
 
         // dump_excluded without locked would be unusual; at minimum, if
@@ -176,6 +233,14 @@ mod tests {
         assert!(st.guard_pages, "guard pages should be active");
     }
 
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn write_protected_active() {
+        let secret = ProtectedBytes::new([4u8; 32]);
+        let st = secret.protection_status();
+        assert!(st.write_protected, "data page should be write-protected");
+    }
+
     // Test the fallback backend directly on all platforms.
     #[test]
     fn fallback_backend_constructs_correctly() {
@@ -185,5 +250,18 @@ mod tests {
         assert!(!status.locked);
         assert!(!status.guard_pages);
         assert!(!status.dump_excluded);
+        assert!(!status.write_protected);
+        assert_eq!(status.level(), ProtectionLevel::Unprotected);
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn os_backend_is_full_protection() {
+        let secret = ProtectedBytes::new([5u8; 32]);
+        assert_eq!(
+            secret.protection_status().level(),
+            ProtectionLevel::Full,
+            "expected Full protection on this platform"
+        );
     }
 }

--- a/crates/secure-memory/src/unix.rs
+++ b/crates/secure-memory/src/unix.rs
@@ -148,7 +148,8 @@ impl<const N: usize> SecureAlloc<N> {
         // Removing write access prevents accidental overwrites.
         // SAFETY: `data` is page-aligned; `ps` bytes are within the allocation.
         let r_readonly = unsafe { libc::mprotect(data as *mut libc::c_void, ps, libc::PROT_READ) };
-        if r_readonly != 0 {
+        let write_protected = r_readonly == 0;
+        if !write_protected {
             tracing::debug!(
                 "secure-memory: mprotect(PROT_READ) for data page failed ({}); \
                  data page remains writable",
@@ -166,6 +167,7 @@ impl<const N: usize> SecureAlloc<N> {
             locked,
             guard_pages,
             dump_excluded,
+            write_protected,
             fallback_backend: false,
         };
 

--- a/crates/secure-memory/src/windows.rs
+++ b/crates/secure-memory/src/windows.rs
@@ -171,7 +171,8 @@ impl<const N: usize> SecureAlloc<N> {
         // Removing write access prevents accidental overwrites.
         // SAFETY: `data` is page-aligned; `ps` committed bytes in our region.
         let r_readonly = unsafe { VirtualProtect(data as *const c_void, ps, PAGE_READONLY, &mut old_prot) };
-        if r_readonly.is_err() {
+        let write_protected = r_readonly.is_ok();
+        if !write_protected {
             tracing::debug!(
                 "secure-memory: VirtualProtect(PAGE_READONLY) for data page failed ({}); \
                  data page remains writable",
@@ -192,6 +193,7 @@ impl<const N: usize> SecureAlloc<N> {
             // On Windows, dump_excluded reflects WER exclusion only.
             // See module-level documentation for scope and limitations.
             dump_excluded: wer_excluded,
+            write_protected,
             fallback_backend: false,
         };
 

--- a/devolutions-gateway/src/credential/crypto.rs
+++ b/devolutions-gateway/src/credential/crypto.rs
@@ -53,7 +53,9 @@ impl MasterKeyManager {
     fn new() -> Self {
         let mut raw = [0u8; 32];
         OsRng.fill_bytes(&mut raw);
-        let key_material = ProtectedBytes::new(raw);
+        // new_zeroing copies `raw` into secure storage and then zeroizes it,
+        // covering the caller-frame residual without requiring a zeroize dep here.
+        let key_material = ProtectedBytes::new(&mut raw);
 
         let st = key_material.protection_status();
         match st.level() {

--- a/devolutions-gateway/src/credential/crypto.rs
+++ b/devolutions-gateway/src/credential/crypto.rs
@@ -22,7 +22,7 @@ use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use parking_lot::Mutex;
 use secrecy::SecretString;
-use secure_memory::ProtectedBytes;
+use secure_memory::{ProtectedBytes, ProtectionLevel};
 
 /// Global master key for credential encryption.
 ///
@@ -56,24 +56,40 @@ impl MasterKeyManager {
         let key_material = ProtectedBytes::new(raw);
 
         let st = key_material.protection_status();
-        if st.fallback_backend {
-            tracing::warn!(
-                "master key: advanced memory protection is unavailable on this platform; \
-                 the key is protected only by zeroize-on-drop"
-            );
-        } else {
-            if !st.locked {
+        match st.level() {
+            ProtectionLevel::Unprotected => {
                 tracing::warn!(
-                    "master key: mlock/VirtualLock failed; \
-                     the key may be paged to disk under memory pressure"
+                    "master key: advanced memory protection is unavailable on this platform; \
+                     the key is protected only by zeroize-on-drop"
                 );
             }
-            if !st.dump_excluded {
-                tracing::warn!(
-                    "master key: core-dump exclusion is not active \
-                     (unavailable on this platform or kernel)"
-                );
+            ProtectionLevel::Partial => {
+                if !st.locked {
+                    tracing::warn!(
+                        "master key: mlock/VirtualLock failed; \
+                         the key may be paged to disk under memory pressure"
+                    );
+                }
+                if !st.write_protected {
+                    tracing::warn!(
+                        "master key: data page could not be demoted to read-only; \
+                         accidental overwrites are not prevented"
+                    );
+                }
+                if !st.guard_pages {
+                    tracing::warn!(
+                        "master key: guard pages could not be established; \
+                         adjacent out-of-bounds accesses will not fault"
+                    );
+                }
+                if !st.dump_excluded {
+                    tracing::warn!(
+                        "master key: core-dump exclusion is not active \
+                         (unavailable on this platform or kernel)"
+                    );
+                }
             }
+            ProtectionLevel::Full => {}
         }
 
         Self { key_material }

--- a/devolutions-gateway/src/credential/crypto.rs
+++ b/devolutions-gateway/src/credential/crypto.rs
@@ -53,7 +53,7 @@ impl MasterKeyManager {
     fn new() -> Self {
         let mut raw = [0u8; 32];
         OsRng.fill_bytes(&mut raw);
-        // new_zeroing copies `raw` into secure storage and then zeroizes it,
+        // `ProtectedBytes::new` copies `raw` into secure storage and then zeroizes it,
         // covering the caller-frame residual without requiring a zeroize dep here.
         let key_material = ProtectedBytes::new(&mut raw);
 


### PR DESCRIPTION
- Add \write_protected\ field to \ProtectionStatus\ tracking whether the data page was successfully demoted to read-only after construction
- Add \ProtectionLevel\ enum (Full / Partial / Unprotected) and a \level()\ method on \ProtectionStatus\ for a single summary check
- \Full\ requires all four protections: guard_pages, locked, write_protected, and dump_excluded; macOS will always be Partial (no dump exclusion API)
- Update README usage example to show \level()\ as the recommended first check
- Clarify stack-copy documentation in README and \ProtectedBytes::new\ doc: only the local \bytes\ parameter is zeroized; caller-frame residuals are not
- Update devolutions-gateway callsite to match on \level()\ and emit per-flag warnings inside the Partial arm, including the new write_protected and guard_pages cases