### PR TITLE
fix(agent): configure features correctly during silent install

### DIFF
--- a/package/AgentWindowsManaged/Actions/AgentActions.cs
+++ b/package/AgentWindowsManaged/Actions/AgentActions.cs
@@ -246,6 +246,26 @@ internal static class AgentActions
         Execute = Execute.rollback,
     };
 
+    /// <summary>
+    /// Read the requested feature states into a session property for use by the deferred <see cref="configureFeatures"/> action.
+    /// </summary>
+    /// <remarks>
+    /// <c>session.Features</c> is only accessible from immediate custom actions (DTF restriction).
+    /// This action runs immediately in the execute sequence after <c>InstallInitialize</c>, at which point
+    /// <c>MigrateFeatures</c> has already run and feature <c>RequestState</c> is authoritative for all
+    /// scenarios (fresh install, upgrade, maintenance, silent or interactive).
+    /// </remarks>
+    private static readonly ManagedAction setFeaturesToConfigure = new(
+        new Id($"CA.{nameof(setFeaturesToConfigure)}"),
+        CustomActions.SetFeaturesToConfigure,
+        Return.check,
+        When.After, Step.InstallInitialize,
+        Condition.NOT_BeingRemoved,
+        Sequence.InstallExecuteSequence)
+    {
+        Execute = Execute.immediate,
+    };
+
     private static readonly ElevatedManagedAction configureFeatures = new(
         CustomActions.ConfigureFeatures
     )
@@ -255,7 +275,8 @@ internal static class AgentActions
         Return = Return.check,
         Step = Step.StartServices,
         When = When.Before,
-        Condition = Condition.NOT_BeingRemoved & new Condition("(UILevel >= 3 OR WIXSHARP_MANAGED_UI_HANDLE <> \"\")")
+        Condition = Condition.NOT_BeingRemoved,
+        UsesProperties = UseProperties(new[] { AgentProperties.featuresToConfigure })
     };
 
     private static readonly ElevatedManagedAction registerExplorerCommand = new(
@@ -329,6 +350,7 @@ internal static class AgentActions
         checkNetFxInstalledVersion,
         getInstallDirFromRegistry,
         setArpInstallLocation,
+        setFeaturesToConfigure,
         configureFeatures,
         createProgramDataDirectory,
         setProgramDataDirectoryPermissions,

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -291,13 +291,55 @@ namespace DevolutionsAgent.Actions
         }
 
         [CustomAction]
+        public static ActionResult SetFeaturesToConfigure(Session session)
+        {
+            // session.Features is only accessible from immediate custom actions (DTF restriction).
+            // Encode the requested feature states into a session property so the deferred
+            // ConfigureFeatures action can read them via CustomActionData.
+            (string featureId, string jsonId)[] features =
+            [
+                (Features.SESSION_FEATURE.Id, Features.SESSION_FEATURE.Id.Substring(Features.FEATURE_ID_PREFIX.Length)),
+                (Features.AGENT_UPDATER_FEATURE.Id, Features.AGENT_UPDATER_FEATURE.Id.Substring(Features.FEATURE_ID_PREFIX.Length)),
+                (Features.PEDM_FEATURE.Id, Features.PEDM_FEATURE.Id.Substring(Features.FEATURE_ID_PREFIX.Length)),
+            ];
+
+            List<string> toEnable = [];
+
+            foreach ((string featureId, string jsonId) in features)
+            {
+                if (session.Features[featureId].RequestState == InstallState.Local)
+                {
+                    toEnable.Add(jsonId);
+                }
+            }
+
+            session[AgentProperties.featuresToConfigure.Id] = string.Join(",", toEnable);
+
+            return ActionResult.Success;
+        }
+
+        [CustomAction]
         public static ActionResult ConfigureFeatures(Session session)
         {
-            foreach (Feature feature in (Feature[]) [Features.SESSION_FEATURE, Features.PEDM_FEATURE, Features.AGENT_UPDATER_FEATURE])
+            string featuresToConfigure = session.Property(AgentProperties.featuresToConfigure.Id);
+            HashSet<string> enabledFeatures = new HashSet<string>(
+                featuresToConfigure.Split([','], StringSplitOptions.RemoveEmptyEntries));
+
+            string[] allFeatureJsonIds =
+            [
+                Features.SESSION_FEATURE.Id.Substring(Features.FEATURE_ID_PREFIX.Length),
+                Features.AGENT_UPDATER_FEATURE.Id.Substring(Features.FEATURE_ID_PREFIX.Length),
+                Features.PEDM_FEATURE.Id.Substring(Features.FEATURE_ID_PREFIX.Length),
+            ];
+
+            foreach (string featureJsonId in allFeatureJsonIds)
             {
-                bool enable = session.IsFeatureEnabled(feature.Id);
-                string jsonId = feature.Id.Substring(Features.FEATURE_ID_PREFIX.Length);
-                ToggleAgentFeature(session, jsonId, enable);
+                ActionResult result = ToggleAgentFeature(session, featureJsonId, enabledFeatures.Contains(featureJsonId));
+
+                if (result != ActionResult.Success)
+                {
+                    return result;
+                }
             }
 
             return ActionResult.Success;

--- a/package/AgentWindowsManaged/Properties/AgentProperties.g.cs
+++ b/package/AgentWindowsManaged/Properties/AgentProperties.g.cs
@@ -235,37 +235,65 @@ namespace DevolutionsAgent.Properties
                 string stringValue = this.FnGetPropValue(maintenance.Id);
                 return WixProperties.GetPropertyValue<Boolean>(stringValue);
             }
-            set 
-            { 
+            set
+            {
                 if (this.runtimeSession is not null)
                 {
-                    this.runtimeSession.Set(maintenance, value); 
+                    this.runtimeSession.Set(maintenance, value);
                 }
             }
         }
- 
+
+        internal static readonly WixProperty<String> featuresToConfigure = new()
+        {
+            Id = "P.FeaturesToConfigure",
+            Default = "",
+            Name = "FeaturesToConfigure",
+            Secure = false,
+            Hidden = false,
+            Public = false
+        };
+
+        public String FeaturesToConfigure
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(featuresToConfigure.Id);
+                return WixProperties.GetPropertyValue<String>(stringValue);
+            }
+            set
+            {
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(featuresToConfigure, value);
+                }
+            }
+        }
+
 
         public static IWixProperty[] Properties =
         {
- 
+
             configureAgent,
- 
+
             debugPowerShell,
- 
+
             installId,
- 
+
             netFx45Version,
- 
+
             firstInstall,
- 
+
             upgrading,
- 
+
             removingForUpgrade,
- 
+
             uninstalling,
- 
+
             maintenance,
- 
+
+            featuresToConfigure,
+
         };
     }
 }

--- a/package/AgentWindowsManaged/Properties/AgentProperties.g.tt
+++ b/package/AgentWindowsManaged/Properties/AgentProperties.g.tt
@@ -139,5 +139,6 @@ namespace DevolutionsAgent.Properties
     new PropertyDefinition<bool>("RemovingForUpgrade", false, isPublic: false, secure: false),
     new PropertyDefinition<bool>("Uninstalling", false, isPublic: false, secure: false),
     new PropertyDefinition<bool>("Maintenance", false, isPublic: false, secure: false),
+    new PropertyDefinition<string>("FeaturesToConfigure", "", isPublic: false, secure: false),
   };             
 #>


### PR DESCRIPTION
Features such as Session were not being written to agent.json when installing silently (/qn), leaving the agent misconfigured until an interactive repair or upgrade was run.

The root cause was two-fold: 

(1) a UILevel guard was incorrectly preventing the feature configuration action from running in silent mode 
(2) the deferred custom action could not access feature state directly (DTF restriction). Fixed by introducing an immediate action that reads feature request states and forwards them to the deferred action via CustomActionData.

Issue: DGW-369