### PR TITLE
test(dgw): verify service is not auto-started after install

### DIFF
--- a/.github/scripts/smoke-test-deb.sh
+++ b/.github/scripts/smoke-test-deb.sh
@@ -167,6 +167,9 @@ check_single_execstart
 # The gateway requires a provisioner public key to start.
 # Generate a key pair and place the public key where gateway.json points.
 
+info "Checking service did not start automatically…"
+check_service_not_auto_started
+
 info "Generating provisioner key…"
 check_provisioner_key
 

--- a/.github/scripts/smoke-test-lib.sh
+++ b/.github/scripts/smoke-test-lib.sh
@@ -182,6 +182,28 @@ check_config_file_permissions() {
     fi
 }
 
+check_service_not_auto_started() {
+    if ! systemd_and_unit_available; then
+        info "systemd not available — skipping auto-start check"
+        return
+    fi
+    # The service requires a provisioner key to start. Since the key is not
+    # present immediately after install, auto-starting the service would cause
+    # it to fail immediately. The postinst is therefore expected to only enable
+    # the service, not start it. A status of "active" or "failed" both indicate
+    # the postinst incorrectly attempted to start the service.
+    local status
+    status=$(systemctl is-active devolutions-gateway 2>/dev/null || true)
+    case "$status" in
+        inactive)
+            pass "Service is inactive after install (not auto-started)" ;;
+        active|failed|activating)
+            fail "Service was auto-started after install ($status) — postinst should only enable, not start" ;;
+        *)
+            warn "Unexpected service state after install: $status" ;;
+    esac
+}
+
 check_provisioner_key() {
     info "Generating RSA-2048 provisioner key pair with openssl…"
     KEY_LOG=$(mktemp)

--- a/.github/scripts/smoke-test-rpm.sh
+++ b/.github/scripts/smoke-test-rpm.sh
@@ -204,6 +204,9 @@ fi
 # The gateway requires a provisioner public key to start.
 # Generate a key pair and place the public key where gateway.json points.
 
+info "Checking service did not start automatically…"
+check_service_not_auto_started
+
 info "Generating provisioner key…"
 check_provisioner_key
 


### PR DESCRIPTION
The gateway requires a provisioner key before it can start. If the postinst auto-starts the service on fresh install, it fails immediately. Add a smoke test check that asserts the service is inactive after package installation (skipped when systemd is unavailable).