### PR TITLE
ci: overhaul artifact naming and release pipeline

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,13 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pwsh .claude/skills/prepare-release/scripts/resolve-version.ps1 -Arg \"\")",
+      "Bash(pwsh .claude/skills/prepare-release/scripts/resolve-version.ps1 -Arg \"hotfix\")",
+      "Bash(pwsh ./tools/bump-version.ps1 -NewVersion 2026.1.2 2>&1)",
+      "Bash(git cliff:*)",
+      "mcp__claude_ai_Atlassian__transitionJiraIssue",
+      "mcp__claude_ai_Atlassian__getTransitionsForJiraIssue",
+      "mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql"
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         id: setup-matrix
         run: |
           $Jobs = @()
-          $Archs = @( 'x86_64', 'arm64' )
+          $Archs = @( 'x64', 'arm64' )
           $Platforms = @( 'linux', 'windows' )
 
           $Platforms | ForEach-Object {
@@ -203,7 +203,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        arch: [x86_64]
+        arch: [x64]
         os: [windows, linux]
         include:
           - os: windows
@@ -325,7 +325,7 @@ jobs:
         shell: pwsh
 
       - name: Configure macOS (intel) runner
-        if: ${{ matrix.os == 'macos' && matrix.arch == 'x86_64' }}
+        if: ${{ matrix.os == 'macos' && matrix.arch == 'x64' }}
         run: |
           sudo rm -rf /Library/Developer/CommandLineTools
           rustup target add x86_64-apple-darwin
@@ -335,7 +335,7 @@ jobs:
         run: |
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = 'jetsocat_${{ runner.os }}_${{ needs.preflight.outputs.version }}_${{ matrix.arch }}'
+          $ExecutableFileName = 'jetsocat'
 
           if ($Env:RUNNER_OS -eq "Windows") {
             $ExecutableFileName = "$($ExecutableFileName).exe"
@@ -344,8 +344,8 @@ jobs:
           }
 
           if ($Env:RUNNER_OS -eq "Linux") {
-            $LinuxArch = @{'x86_64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
-            $RustArch = @{'x86_64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
+            $LinuxArch = @{'x64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
+            $RustArch = @{'x64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
             $RustTarget = "$RustArch-unknown-linux-gnu"
             $Env:SYSROOT_NAME = "ubuntu-18.04-$LinuxArch"
             . "$HOME/.cargo/cbake/${RustTarget}-enter.ps1"
@@ -402,8 +402,8 @@ jobs:
         run: |
           $OutputPath = Join-Path "macos" "universal"
           New-Item -ItemType Directory -Path $OutputPath | Out-Null
-          $Binaries = Get-ChildItem -Recurse -Path "macos" -Filter "jetsocat_*" | Foreach-Object { $_.FullName } | Select -Unique
-          $LipoCmd = $(@('lipo', '-create', '-output', (Join-Path -Path $OutputPath -ChildPath "jetsocat_macOS_${{ needs.preflight.outputs.version }}_universal")) + $Binaries) -Join ' '
+          $Binaries = Get-ChildItem -Recurse -Path "macos" -Filter "jetsocat" -File | Foreach-Object { $_.FullName } | Select -Unique
+          $LipoCmd = $(@('lipo', '-create', '-output', (Join-Path -Path $OutputPath -ChildPath "jetsocat")) + $Binaries) -Join ' '
           Write-Host $LipoCmd
           Invoke-Expression $LipoCmd
         shell: pwsh
@@ -576,7 +576,7 @@ jobs:
       - name: Download Cadeau
         run: |
           $Platform = @{'windows'='win'; 'linux'='linux'}['${{ matrix.os }}']
-          $Arch = @{'x86_64'='x64';'arm64'='arm64'}['${{ matrix.arch }}']
+          $Arch = '${{ matrix.arch }}'
           ./ci/download-cadeau.ps1 -Platform $Platform -Architecture $Arch
         shell: pwsh
 
@@ -586,11 +586,10 @@ jobs:
           $PackageVersion = "${{ needs.preflight.outputs.version }}"
           $StagingPath = Join-Path $Env:RUNNER_TEMP "staging"
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "DevolutionsGateway_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
+          $ExecutableFileName = if ($Env:RUNNER_OS -eq "Windows") { "DevolutionsGateway.exe" } else { "devolutions-gateway" }
 
           if ($Env:RUNNER_OS -eq "Windows") {
-            $ExecutableFileName = "$($ExecutableFileName).exe"
-            $PackageFileName = "DevolutionsGateway-${{ matrix.arch }}-${PackageVersion}.msi"
+            $PackageFileName = "DevolutionsGateway.msi"
             $DGatewayPackage = Join-Path $TargetOutputPath $PackageFileName
             echo "dgateway-package=$DGatewayPackage" >> $Env:GITHUB_OUTPUT
           }
@@ -657,8 +656,8 @@ jobs:
       - name: Build
         run: |
           if ($Env:RUNNER_OS -eq "Linux") {
-            $LinuxArch = @{'x86_64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
-            $RustArch = @{'x86_64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
+            $LinuxArch = @{'x64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
+            $RustArch = @{'x64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
             $RustTarget = "$RustArch-unknown-linux-gnu"
             $Env:SYSROOT_NAME = "ubuntu-18.04-$LinuxArch"
             . "$HOME/.cargo/cbake/${RustTarget}-enter.ps1"
@@ -703,6 +702,14 @@ jobs:
           $Env:DGATEWAY_WEBPLAYER_PATH = Join-Path "webapp" "dist" "recording-player" | Resolve-Path
 
           ./ci/tlk.ps1 package -Product gateway -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+
+          # Rename versioned fpm output to simple basenames for consistent folder-based addressing.
+          if ($Env:RUNNER_OS -eq "Linux") {
+            $OutputPath = "${{ steps.load-variables.outputs.target-output-path }}"
+            Get-ChildItem "$OutputPath/*.deb"     | Rename-Item -NewName "devolutions-gateway.deb"
+            Get-ChildItem "$OutputPath/*.changes" | Rename-Item -NewName "devolutions-gateway.changes"
+            Get-ChildItem "$OutputPath/*.rpm"     | Rename-Item -NewName "devolutions-gateway.rpm"
+          }
         shell: pwsh
         env:
           DGATEWAY_EXECUTABLE: ${{ steps.load-variables.outputs.dgateway-executable }}
@@ -787,11 +794,10 @@ jobs:
           New-Item -ItemType Directory $SymbolsPath
 
           $TargetOutputPath = Join-Path $StagingPath ${{ matrix.os }} ${{ matrix.arch }}
-          $ExecutableFileName = "DevolutionsAgent_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}"
+          $ExecutableFileName = if ($Env:RUNNER_OS -eq "Windows") { "DevolutionsAgent.exe" } else { "devolutions-agent" }
 
           if ($Env:RUNNER_OS -eq "Windows") {
-            $ExecutableFileName = "$($ExecutableFileName).exe"
-            $PackageFileName = "DevolutionsAgent-${{ matrix.arch }}-${PackageVersion}.msi"
+            $PackageFileName = "DevolutionsAgent.msi"
             $DAgentPackage = Join-Path $TargetOutputPath $PackageFileName
 
             echo "dagent-package=$DAgentPackage" >> $Env:GITHUB_OUTPUT
@@ -805,7 +811,7 @@ jobs:
             $DAgentSessionExecutable = Join-Path $TargetOutputPath "DevolutionsSession.exe"
             echo "dagent-session-executable=$DAgentSessionExecutable" >> $Env:GITHUB_OUTPUT
 
-            $DAgentUpdaterExecutable = Join-Path $TargetOutputPath "DevolutionsAgentUpdater_${{ runner.os }}_${PackageVersion}_${{ matrix.arch }}.exe"
+            $DAgentUpdaterExecutable = Join-Path $TargetOutputPath "DevolutionsAgentUpdater.exe"
             echo "dagent-updater-executable=$DAgentUpdaterExecutable" >> $Env:GITHUB_OUTPUT
           }
 
@@ -827,8 +833,8 @@ jobs:
         id: tun2socks
         if: ${{ matrix.os == 'windows' }}
         run: |
-          $Arch = @{'x86_64'='x64';'arm64'='arm64'}['${{ matrix.arch }}']
-          $Destination = Join-Path $PWD "tun2socks"
+          $Arch = '${{ matrix.arch }}'
+          $Destination = Join-Path $PWD "tun2socks" $Arch
           ./ci/download-tun2socks.ps1 -Architecture $Arch -Destination $Destination
           $Tun2SocksExecutablePath = Join-Path $Destination "tun2socks.exe"
           $WintunLibraryPath = Join-Path $Destination "wintun.dll"
@@ -843,7 +849,7 @@ jobs:
         if: ${{ matrix.os == 'windows' }}
         uses: actions/upload-artifact@v7
         with:
-          name: tun2socks-${{ matrix.os }}-${{ matrix.arch }}
+          name: tun2socks-windows-${{ matrix.arch }}
           path: tun2socks/
 
       - name: Setup LLVM
@@ -911,8 +917,8 @@ jobs:
           }
 
           if ($Env:RUNNER_OS -eq "Linux") {
-            $LinuxArch = @{'x86_64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
-            $RustArch = @{'x86_64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
+            $LinuxArch = @{'x64'='amd64';'arm64'='arm64'}['${{ matrix.arch }}']
+            $RustArch = @{'x64'='x86_64';'arm64'='aarch64'}['${{ matrix.arch }}']
             $RustTarget = "$RustArch-unknown-linux-gnu"
             $Env:SYSROOT_NAME = "ubuntu-18.04-$LinuxArch"
             . "$HOME/.cargo/cbake/${RustTarget}-enter.ps1"
@@ -944,6 +950,14 @@ jobs:
           }
 
           ./ci/tlk.ps1 package -Product agent -Platform ${{ matrix.os }} -Architecture ${{ matrix.arch }} -CargoProfile ${{ needs.preflight.outputs.rust-profile }}
+
+          # Rename versioned fpm output to simple basenames for consistent folder-based addressing.
+          if ($Env:RUNNER_OS -eq "Linux") {
+            $OutputPath = "${{ steps.load-variables.outputs.target-output-path }}"
+            Get-ChildItem "$OutputPath/*.deb"     | Rename-Item -NewName "devolutions-agent.deb"
+            Get-ChildItem "$OutputPath/*.changes" | Rename-Item -NewName "devolutions-agent.changes"
+            Get-ChildItem "$OutputPath/*.rpm"     | Rename-Item -NewName "devolutions-agent.rpm"
+          }
         shell: pwsh
         env:
           DAGENT_EXECUTABLE: ${{ steps.load-variables.outputs.dagent-executable }}
@@ -987,6 +1001,19 @@ jobs:
           pattern: devolutions-agent-*
           delete-merged: true
 
+  tun2socks-windows-merge:
+    name: tun2socks windows merge artifacts
+    runs-on: ubuntu-latest
+    needs: [preflight, devolutions-agent]
+
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v7
+        with:
+          name: tun2socks-windows
+          pattern: tun2socks-windows-*
+          delete-merged: true
+
   devolutions-pedm-client:
     name: devolutions-pedm-client
     runs-on: ubuntu-latest
@@ -1020,9 +1047,7 @@ jobs:
           ref: ${{ needs.preflight.outputs.ref }}
 
       - name: Tests
-        run: |
-          Set-PSDebug -Trace 1
-          dotnet test utils/dotnet/GatewayUtils.sln
+        run: dotnet test utils/dotnet/GatewayUtils.sln
         shell: pwsh
 
 
@@ -1290,39 +1315,98 @@ jobs:
 
           New-Item -Path "$destinationFolder" -ItemType "directory"
 
-          $allFiles = Get-ChildItem -Path "$sourceFolder" -Exclude PowerShell | Get-ChildItem -Recurse | Where { -Not $_.Mode.StartsWith('d') }
+          function MoveArtifact([string]$RelSource, [string]$DestName) {
+            $src = Join-Path $sourceFolder $RelSource
+            $dst = Join-Path $destinationFolder $DestName
+            Write-Host "$src --> $dst"
+            Move-Item -Path $src -Destination $dst
+          }
 
-          # Exclude some files that are already bundled in installers
-          $excludeFiles = @(
-            'DevolutionsPedmShellExt.dll',
-            'DevolutionsPedmShellExt.msix',
-            'DevolutionsSession.exe',
-            # NOTE: We may want to include that in the future, but needs to be renamed per platform.
-            # TODO(@awakecoding): We could create a zip with the same name as
-            # the package except ".symbols" at the end, so we'd end up with arch-specific zips
-            # containing the debug symbols. I've done this for MsRdpEx.
-            'DevolutionsPedmShellExt.pdb',
-            'DevolutionsSession.pdb'
+          # Create symbols ZIPs from individual PDBs (package.yml signing hasn't run yet).
+          $SymbolProducts = @(
+            @{ Dir = 'devolutions-gateway'; Name = 'DevolutionsGateway'; Arches = @('x64') },
+            @{ Dir = 'devolutions-agent';   Name = 'DevolutionsAgent';   Arches = @('x64', 'arm64') },
+            @{ Dir = 'jetsocat';            Name = 'jetsocat';           Arches = @('x64', 'arm64') }
+          )
+          foreach ($P in $SymbolProducts) {
+            foreach ($Arch in $P.Arches) {
+              $ArchDir = Join-Path $sourceFolder $P.Dir windows $Arch
+              $Pdbs = Get-ChildItem -Path $ArchDir -Filter '*.pdb' -File -ErrorAction SilentlyContinue
+              if ($Pdbs) {
+                $Pdbs | Compress-Archive -DestinationPath (Join-Path $ArchDir "$($P.Name).symbols.zip") -CompressionLevel Optimal
+              }
+            }
+          }
+
+          # Gateway Windows MSI + symbols
+          MoveArtifact "devolutions-gateway/windows/x64/DevolutionsGateway.msi" "DevolutionsGateway-${version}-x64.msi"
+          MoveArtifact "devolutions-gateway/windows/x64/DevolutionsGateway.symbols.zip" "DevolutionsGateway-${version}-x64.symbols.zip"
+
+          # Gateway Linux DEB/RPM/changes
+          foreach ($Arch in @('x64', 'arm64')) {
+            MoveArtifact "devolutions-gateway/linux/${Arch}/devolutions-gateway.deb" "devolutions-gateway_${version}_${Arch}.deb"
+            MoveArtifact "devolutions-gateway/linux/${Arch}/devolutions-gateway.rpm" "devolutions-gateway_${version}_${Arch}.rpm"
+            MoveArtifact "devolutions-gateway/linux/${Arch}/devolutions-gateway.changes" "devolutions-gateway_${version}_${Arch}.changes"
+          }
+
+          # Agent Windows MSI + symbols.zip
+          foreach ($Arch in @('x64', 'arm64')) {
+            MoveArtifact "devolutions-agent/windows/${Arch}/DevolutionsAgent.msi" "DevolutionsAgent-${version}-${Arch}.msi"
+            MoveArtifact "devolutions-agent/windows/${Arch}/DevolutionsAgent.symbols.zip" "DevolutionsAgent-${version}-${Arch}.symbols.zip"
+          }
+
+          # Agent Linux DEB/RPM/changes
+          foreach ($Arch in @('x64', 'arm64')) {
+            MoveArtifact "devolutions-agent/linux/${Arch}/devolutions-agent.deb" "devolutions-agent_${version}_${Arch}.deb"
+            MoveArtifact "devolutions-agent/linux/${Arch}/devolutions-agent.rpm" "devolutions-agent_${version}_${Arch}.rpm"
+            MoveArtifact "devolutions-agent/linux/${Arch}/devolutions-agent.changes" "devolutions-agent_${version}_${Arch}.changes"
+          }
+
+          # Jetsocat archives: .tar.xz for Linux, .zip for Windows and macOS
+          $Platforms = @(
+            @{ OS = "windows"; Arch = "x64";       Ext = ".exe"; Archive = "zip" },
+            @{ OS = "windows"; Arch = "arm64";     Ext = ".exe"; Archive = "zip" },
+            @{ OS = "linux";   Arch = "x64";       Ext = "";     Archive = "tar.xz" },
+            @{ OS = "linux";   Arch = "arm64";     Ext = "";     Archive = "tar.xz" },
+            @{ OS = "macos";   Arch = "x64";       Ext = "";     Archive = "tar.xz" },
+            @{ OS = "macos";   Arch = "arm64";     Ext = "";     Archive = "tar.xz" },
+            @{ OS = "macos";   Arch = "universal"; Ext = "";     Archive = "tar.xz" }
           )
 
-          Write-Host
-
-          foreach ($file in $allFiles) {
-            $dir = $file.Directory
-            $name = $file.Name
-            $source = "$dir/$name"
-            $destination = "$destinationFolder/$name"
-
-            # Skip architecture-specific files that are part of installers
-            if ($name -in $excludeFiles) {
-              Write-Host "Skipping $source"
-              continue
+          foreach ($P in $Platforms) {
+            $BinaryPath = Join-Path $sourceFolder jetsocat $P.OS $P.Arch "jetsocat$($P.Ext)"
+            if (Test-Path $BinaryPath) {
+              $ArchiveDst = Join-Path $destinationFolder "jetsocat-${version}-$($P.OS)-$($P.Arch).$($P.Archive)"
+              $BinaryName = Split-Path $BinaryPath -Leaf
+              $StageDir = Join-Path $Env:RUNNER_TEMP "jetsocat-stage-$($P.OS)-$($P.Arch)"
+              New-Item -ItemType Directory -Path $StageDir -Force | Out-Null
+              Copy-Item -Path $BinaryPath -Destination (Join-Path $StageDir $BinaryName) -Force
+              if ($P.Archive -eq 'tar.xz') {
+                tar -cJf $ArchiveDst -C $StageDir .
+              } else {
+                # Compress-Archive preserves the source path structure inside the ZIP.
+                # Staging to a flat temp dir ensures the binary lands at the ZIP root.
+                Compress-Archive -Path (Join-Path $StageDir '*') -DestinationPath $ArchiveDst -Force
+              }
+              Remove-Item -Path $StageDir -Recurse -Force
+              Write-Host "$BinaryPath --> $ArchiveDst"
+            } else {
+              throw "Jetsocat binary not found: $BinaryPath"
             }
-
-            Write-Host "$source --> $destination"
-
-            Move-Item -Path "$source" -Destination "$destination"
           }
+
+          # Jetsocat Windows symbols
+          foreach ($Arch in @('x64', 'arm64')) {
+            $SymPath = Join-Path $sourceFolder jetsocat windows $Arch jetsocat.symbols.zip
+            if (Test-Path $SymPath) {
+              MoveArtifact "jetsocat/windows/${Arch}/jetsocat.symbols.zip" "jetsocat-${version}-windows-${Arch}.symbols.zip"
+            } else {
+              throw "Jetsocat Windows symbols not found: $SymPath"
+            }
+          }
+
+          # git-log
+          MoveArtifact "git-log/git-log.txt" "git-log.txt"
         shell: pwsh
 
       - name: Upload to OneDrive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,7 +834,7 @@ jobs:
         if: ${{ matrix.os == 'windows' }}
         run: |
           $Arch = '${{ matrix.arch }}'
-          $Destination = Join-Path $PWD "tun2socks" $Arch
+          $Destination = Join-Path $PWD "tun2socks" windows $Arch
           ./ci/download-tun2socks.ps1 -Architecture $Arch -Destination $Destination
           $Tun2SocksExecutablePath = Join-Path $Destination "tun2socks.exe"
           $WintunLibraryPath = Join-Path $Destination "wintun.dll"
@@ -1001,8 +1001,8 @@ jobs:
           pattern: devolutions-agent-*
           delete-merged: true
 
-  tun2socks-windows-merge:
-    name: tun2socks windows merge artifacts
+  tun2socks-merge:
+    name: tun2socks merge artifacts
     runs-on: ubuntu-latest
     needs: [preflight, devolutions-agent]
 
@@ -1010,8 +1010,8 @@ jobs:
       - name: Merge Artifacts
         uses: actions/upload-artifact/merge@v7
         with:
-          name: tun2socks-windows
-          pattern: tun2socks-windows-*
+          name: tun2socks
+          pattern: tun2socks-*
           delete-merged: true
 
   devolutions-pedm-client:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -70,8 +70,6 @@ jobs:
       - name: Get commit
         id: get-commit
         run: |
-          Set-PSDebug -Trace 1
-
           $Ref = '${{ inputs.ref }}'
           if (-Not $Ref) {
             $Run = gh api /repos/$Env:GITHUB_REPOSITORY/actions/runs/$Env:CI_RUN | ConvertFrom-Json
@@ -273,10 +271,9 @@ jobs:
       - name: Sign PowerShell module contents
         if: ${{ matrix.os == 'windows' && matrix.project == 'devolutions-gateway' }}
         run: |
-          Set-PSDebug -Trace 1
-
           . .\ci\PSModuleHelpers.ps1
           $PSModuleOutputPath = Join-Path ${{ runner.temp }} ${{ matrix.project }} "PowerShell"
+          Write-Host "Signing PowerShell module in $PSModuleOutputPath"
           $PSModuleTarFilePath = Get-ChildItem -Path $PSModuleOutputPath "DevolutionsGateway-ps-*.tar" | Select-Object -First 1
           tar -xvf "$PSModuleTarFilePath" -C "$PSModuleOutputPath"
           $DGatewayPSModulePath = Join-Path $PSModuleOutputPath DevolutionsGateway
@@ -323,9 +320,9 @@ jobs:
         if: ${{ matrix.os == 'windows' || matrix.os == 'macos' }}
         run: |
           $IncludePattern = @(switch ('${{ matrix.project }}') {
-            'devolutions-gateway' { @('DevolutionsGateway_*.exe') }
-            'devolutions-agent' { @('DevolutionsAgent_*.exe', 'DevolutionsAgentUpdater_*.exe', 'DevolutionsPedmShellExt.dll', 'DevolutionsPedmShellExt.msix', 'DevolutionsDesktopAgent.exe') }
-            'jetsocat' { @('jetsocat_*') }
+            'devolutions-gateway' { @('DevolutionsGateway.exe') }
+            'devolutions-agent' { @('DevolutionsAgent.exe', 'DevolutionsAgentUpdater.exe', 'DevolutionsPedmShellExt.dll', 'DevolutionsPedmShellExt.msix', 'DevolutionsDesktopAgent.exe') }
+            'jetsocat' { @('jetsocat.exe', 'jetsocat') }
           })
           $ExcludePattern = "*.pdb"
           Get-ChildItem -Path ${{ runner.temp }} -Recurse -Include $IncludePattern -Exclude $ExcludePattern | % {
@@ -407,12 +404,22 @@ jobs:
           path: native-libs
 
       - name: Zip debug symbol files
-        if: ${{ matrix.project == 'devolutions-agent' && matrix.os == 'windows' }}
+        if: ${{ matrix.os == 'windows' }}
         run: |
-          $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project}}
+          $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project }}
+          $ProductName = switch ('${{ matrix.project }}') {
+            'devolutions-gateway' { 'DevolutionsGateway' }
+            'devolutions-agent'   { 'DevolutionsAgent' }
+            'jetsocat'            { 'jetsocat' }
+          }
 
-          Get-ChildItem "$PackageRoot\windows\x86_64\*.pdb" -Recurse | Compress-Archive -DestinationPath "$PackageRoot\windows\x86_64\DevolutionsAgent-x86_64-${{ needs.preflight.outputs.version }}.symbols.zip" -CompressionLevel Optimal
-          Get-ChildItem "$PackageRoot\windows\x86_64\*.pdb" -Recurse | Remove-Item | Out-Null
+          Get-ChildItem (Join-Path $PackageRoot windows) -Directory | ForEach-Object {
+            $Pdbs = Get-ChildItem -Path $_.FullName -Filter '*.pdb' -File -Recurse
+            if ($Pdbs) {
+              $Pdbs | Compress-Archive -DestinationPath "$($_.FullName)\${ProductName}.symbols.zip" -CompressionLevel Optimal
+              $Pdbs | Remove-Item | Out-Null
+            }
+          }
         shell: pwsh
 
       - name: Regenerate Gateway MSI
@@ -420,7 +427,7 @@ jobs:
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project}}
 
-          $Env:DGATEWAY_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.exe' | Select -First 1
+          $Env:DGATEWAY_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Filter 'DevolutionsGateway.exe' -File | Select -First 1
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           $Env:DGATEWAY_WEBCLIENT_PATH = Join-Path "webapp" "client" | Resolve-Path
           $Env:DGATEWAY_WEBPLAYER_PATH = Join-Path "webapp" "player" | Resolve-Path
@@ -468,36 +475,64 @@ jobs:
         if: ${{ matrix.os == 'windows' && matrix.project == 'devolutions-agent' }}
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project}}
-          gh run download ${{ needs.preflight.outputs.run }} -n tun2socks-windows-x86_64 -D "$PackageRoot\tun2socks"
+          gh run download ${{ needs.preflight.outputs.run }} -n tun2socks-windows -D (Join-Path $PackageRoot windows)
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Regenerate Agent MSI
+      - name: Regenerate and Repackage Agent MSI
         if: ${{ matrix.project == 'devolutions-agent' && matrix.os == 'windows' }}
         run: |
-          $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project}}
-          $x64Root = Join-Path $PackageRoot windows x86_64
+          $PackageRoot = Join-Path ${{ runner.temp }} devolutions-agent
 
-          $Env:DAGENT_EXECUTABLE = Get-ChildItem -Path $x64Root -Filter '*DevolutionsAgent_*.exe' -File | Select -First 1
-          $Env:DAGENT_UPDATER_EXECUTABLE = Get-ChildItem -Path $x64Root -Filter 'DevolutionsAgentUpdater_*.exe' -File | Select -First 1
-          $Env:DAGENT_DESKTOP_AGENT_PATH = Resolve-Path -Path "devolutions-pedm-desktop"
-          $Env:DAGENT_PEDM_SHELL_EXT_DLL = Get-ChildItem -Path $x64Root -Filter 'DevolutionsPedmShellExt.dll' -File | Select -First 1
-          $Env:DAGENT_PEDM_SHELL_EXT_MSIX = Get-ChildItem -Path $x64Root -Filter 'DevolutionsPedmShellExt.msix' -File | Select -First 1
-          $Env:DAGENT_SESSION_EXECUTABLE = Get-ChildItem -Path $x64Root -Filter 'DevolutionsSession.exe' -File | Select -First 1
-          $Env:DAGENT_TUN2SOCKS_EXE = Get-ChildItem -Path $PackageRoot -Recurse -Filter 'tun2socks.exe' -File | Select -First 1
-          $Env:DAGENT_WINTUN_DLL = Get-ChildItem -Path $PackageRoot -Recurse -Filter 'wintun.dll' -File | Select -First 1
+          foreach ($Arch in @('x64', 'arm64')) {
+            $ArchRoot = Join-Path $PackageRoot windows $Arch
 
-          Write-Host "DAGENT_EXECUTABLE = ${Env:DAGENT_EXECUTABLE}"
-          Write-Host "DAGENT_UPDATER_EXECUTABLE = ${Env:DAGENT_UPDATER_EXECUTABLE}"
-          Write-Host "DAGENT_DESKTOP_AGENT_PATH = ${Env:DAGENT_DESKTOP_AGENT_PATH}"
-          Write-Host "DAGENT_PEDM_SHELL_EXT_DLL = ${Env:DAGENT_PEDM_SHELL_EXT_DLL}"
-          Write-Host "DAGENT_PEDM_SHELL_EXT_MSIX = ${Env:DAGENT_PEDM_SHELL_EXT_MSIX}"
-          Write-Host "DAGENT_SESSION_EXECUTABLE = ${Env:DAGENT_SESSION_EXECUTABLE}"
-          Write-Host "DAGENT_TUN2SOCKS_EXE = ${Env:DAGENT_TUN2SOCKS_EXE}"
-          Write-Host "DAGENT_WINTUN_DLL = ${Env:DAGENT_WINTUN_DLL}"
+            $Env:DAGENT_EXECUTABLE          = Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsAgent.exe'         -File | Select-Object -First 1
+            $Env:DAGENT_UPDATER_EXECUTABLE  = Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsAgentUpdater.exe'  -File | Select-Object -First 1
+            $Env:DAGENT_DESKTOP_AGENT_PATH  = Resolve-Path -Path "devolutions-pedm-desktop"
+            $Env:DAGENT_PEDM_SHELL_EXT_DLL  = Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsPedmShellExt.dll'  -File | Select-Object -First 1
+            $Env:DAGENT_PEDM_SHELL_EXT_MSIX = Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsPedmShellExt.msix' -File | Select-Object -First 1
+            $Env:DAGENT_SESSION_EXECUTABLE  = Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsSession.exe'       -File | Select-Object -First 1
+            $Env:DAGENT_TUN2SOCKS_EXE       = Join-Path $ArchRoot 'tun2socks.exe'
+            $Env:DAGENT_WINTUN_DLL          = Join-Path $ArchRoot 'wintun.dll'
 
-          ./ci/tlk.ps1 package -Product agent -PackageOption generate
+            Write-Host "=== Regenerate Agent MSI ($Arch) ==="
+            Write-Host "DAGENT_EXECUTABLE          = ${Env:DAGENT_EXECUTABLE}"
+            Write-Host "DAGENT_UPDATER_EXECUTABLE  = ${Env:DAGENT_UPDATER_EXECUTABLE}"
+            Write-Host "DAGENT_DESKTOP_AGENT_PATH  = ${Env:DAGENT_DESKTOP_AGENT_PATH}"
+            Write-Host "DAGENT_PEDM_SHELL_EXT_DLL  = ${Env:DAGENT_PEDM_SHELL_EXT_DLL}"
+            Write-Host "DAGENT_PEDM_SHELL_EXT_MSIX = ${Env:DAGENT_PEDM_SHELL_EXT_MSIX}"
+            Write-Host "DAGENT_SESSION_EXECUTABLE  = ${Env:DAGENT_SESSION_EXECUTABLE}"
+            Write-Host "DAGENT_TUN2SOCKS_EXE       = ${Env:DAGENT_TUN2SOCKS_EXE}"
+            Write-Host "DAGENT_WINTUN_DLL          = ${Env:DAGENT_WINTUN_DLL}"
+
+            ./ci/tlk.ps1 package -Product agent -PackageOption generate -Architecture $Arch
+
+            # Sign the generated runtime EXEs before assembling the MSI
+            Get-ChildItem -Path "package/AgentWindowsManaged/Release" -Filter "*.exe" | ForEach-Object {
+              $Params = @('sign',
+                '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
+                '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
+                '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
+                '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
+                '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
+                '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
+                '-v')
+              AzureSignTool @Params $_.FullName
+            }
+
+            $Env:DAGENT_PACKAGE = Join-Path $ArchRoot 'DevolutionsAgent.msi'
+            ./ci/tlk.ps1 package -Product agent -PackageOption assemble
+
+            # Remove arch-specific files that should not appear in the signed artifact
+            @((Join-Path $ArchRoot DesktopAgent),
+              (Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsPedmShellExt.dll'  | Select-Object -First 1),
+              (Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsPedmShellExt.msix' | Select-Object -First 1),
+              (Get-ChildItem -Path $ArchRoot -Filter 'DevolutionsSession.exe'       | Select-Object -First 1)) | ForEach-Object {
+              Remove-Item $_ -Recurse -ErrorAction SilentlyContinue | Out-Null
+            }
+          }
         shell: pwsh
 
       - name: Sign Gateway MSI runtime
@@ -517,53 +552,16 @@ jobs:
         shell: pwsh
         working-directory: package/WindowsManaged/Release
 
-      - name: Sign Agent MSI runtime
-        if: ${{ matrix.project == 'devolutions-agent' && matrix.os == 'windows' }}
-        run: |
-          Get-ChildItem -Path .\* -Include "*.exe" | % {
-            $Params = @('sign',
-              '-kvt', '${{ secrets.AZURE_TENANT_ID }}',
-              '-kvu', '${{ secrets.CODE_SIGNING_KEYVAULT_URL }}',
-              '-kvi', '${{ secrets.CODE_SIGNING_CLIENT_ID }}',
-              '-kvs', '${{ secrets.CODE_SIGNING_CLIENT_SECRET }}',
-              '-kvc', '${{ secrets.CODE_SIGNING_CERTIFICATE_NAME }}',
-              '-tr', '${{ vars.CODE_SIGNING_TIMESTAMP_SERVER }}',
-              '-v')
-            AzureSignTool @Params $_.FullName
-          }
-        shell: pwsh
-        working-directory: package/AgentWindowsManaged/Release
-
       - name: Repackage Gateway
         if: ${{ matrix.project == 'devolutions-gateway' && matrix.os == 'windows' }}
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} devolutions-gateway
-          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsGateway*.msi' | Select -First 1
+          $Env:DGATEWAY_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Filter 'DevolutionsGateway.msi' -File | Select -First 1
 
           ./ci/tlk.ps1 package -Product gateway -PackageOption assemble
 
           $Env:DGATEWAY_PSMODULE_PATH = Join-Path $PackageRoot PowerShell DevolutionsGateway
           Remove-Item $Env:DGATEWAY_PSMODULE_PATH -Recurse -ErrorAction SilentlyContinue | Out-Null
-        shell: pwsh
-
-      - name: Repackage Agent
-        if: ${{ matrix.project == 'devolutions-agent' && matrix.os == 'windows' }}
-        run: |
-          $PackageRoot = Join-Path ${{ runner.temp }} devolutions-agent
-          $Env:DAGENT_PACKAGE = Get-ChildItem -Path $PackageRoot -Recurse -Include '*DevolutionsAgent*.msi' | Select -First 1
-
-          ./ci/tlk.ps1 package -Product agent -PackageOption assemble
-
-          $Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH = Join-Path $PackageRoot ${{ matrix.os }} x86_64 DesktopAgent
-          $Env:DAGENT_PEDM_SHELL_EXT_DLL = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.dll' | Select -First 1
-          $Env:DAGENT_PEDM_SHELL_EXT_MSIX = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsPedmShellExt.msix' | Select -First 1
-          $Env:DAGENT_SESSION_EXECUTABLE = Get-ChildItem -Path $PackageRoot -Recurse -Include 'DevolutionsSession.exe' | Select -First 1
-
-          @($Env:DAGENT_DESKTOP_AGENT_OUTPUT_PATH,
-            $Env:DAGENT_PEDM_SHELL_EXT_DLL, $Env:DAGENT_PEDM_SHELL_EXT_MSIX,
-            $Env:DAGENT_SESSION_EXECUTABLE) | ForEach-Object {
-            Remove-Item $_ -Recurse -ErrorAction SilentlyContinue | Out-Null
-          }
         shell: pwsh
 
       - name: Sign packages
@@ -601,7 +599,7 @@ jobs:
               }
             }
           } elseif ('${{ matrix.os }}' -Eq 'macos') {
-            Get-ChildItem -Path $RootPath -Recurse -Include 'jetsocat_*' | % {
+            Get-ChildItem -Path $RootPath -Recurse -Include 'jetsocat' | % {
               codesign -dvvv "$($_.FullName)"
               if ($LastExitCode -Ne 0) {
                 echo "::error::failed to verify the signature of $($_.FullName)"
@@ -658,26 +656,33 @@ jobs:
           pattern: jetsocat-*-signed
           delete-merged: false
 
-  web-app:
+  webapp:
     name: Web App
     needs: [preflight, codesign]
     runs-on: ubuntu-latest
 
     steps:
       - name: Download artifacts
-        run: gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -R $Env:GITHUB_REPOSITORY -D webapp-client
+        run: |
+          gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -R $Env:GITHUB_REPOSITORY -D webapp-client
+          gh run download ${{ needs.preflight.outputs.run }} -n webapp-player -R $Env:GITHUB_REPOSITORY -D webapp-player
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create tarball
-        run: tar -czvf devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz webapp-client
-
-      - name: Upload artifacts
+      - name: Upload webapp-client artifact
         uses: actions/upload-artifact@v7
         with:
           name: webapp-client
-          path: devolutions_gateway_webapp_${{ needs.preflight.outputs.version }}.tar.gz
+          path: webapp-client
+          if-no-files-found: error
+          overwrite: true
+
+      - name: Upload webapp-player artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: webapp-player
+          path: webapp-player
           if-no-files-found: error
           overwrite: true
 
@@ -698,26 +703,20 @@ jobs:
           name: jetsocat-signed
           path: jetsocat/nuget/bin
 
-      - name: Rename artifacts
+      - name: Prepare artifacts
         run: |
-          # Backward compatibility with prior nuspec versions
-          Get-ChildItem -Directory -Recurse "x86_64" | Rename-Item -NewName "x64"
-
-          # Remove version number and architecture from binary name
-          Get-ChildItem -File -Recurse -Exclude "*.pdb" | Rename-Item -NewName "jetsocat"
-          cd windows
-          Get-ChildItem -File -Recurse -Exclude "*.pdb" | Rename-Item -NewName "jetsocat.exe"
+          # Remove symbols archives; only the binaries belong in the NuGet package.
+          Get-ChildItem -File -Recurse -Filter "*.symbols.zip" | Remove-Item -Force
         shell: pwsh
         working-directory: jetsocat/nuget/bin
 
       - name: Set package metadata
         run: |
-          Set-PSDebug -Trace 1
-
           $Version = '${{ github.event.inputs.jetsocat-nuget-version }}'
           if ([string]::IsNullOrWhitespace($Version)) {
             $Version = Get-Date -Format "yyyy.M.d"
           }
+          Write-Host "NuGet version: $Version"
 
           $Nuspec = (Resolve-Path "Devolutions.Jetsocat.nuspec")
           $Xml = [xml] (Get-Content $Nuspec)
@@ -729,8 +728,6 @@ jobs:
 
       - name: Build package
         run: |
-          Set-PSDebug -Trace 1
-
           Install-Module -Name ZipIt -Force
           & 'nuget' 'pack' 'Devolutions.Jetsocat.nuspec'
           $NugetPackage = (Get-Item ".\*.nupkg" | Select-Object -First 1) | Resolve-Path -Relative

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -475,7 +475,7 @@ jobs:
         if: ${{ matrix.os == 'windows' && matrix.project == 'devolutions-agent' }}
         run: |
           $PackageRoot = Join-Path ${{ runner.temp }} ${{ matrix.project}}
-          gh run download ${{ needs.preflight.outputs.run }} -n tun2socks-windows -D (Join-Path $PackageRoot windows)
+          gh run download ${{ needs.preflight.outputs.run }} -n tun2socks -D $PackageRoot
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,6 @@ jobs:
       - name: Check GitHub releases
         id: check-release
         run: |
-          Set-PSDebug -Trace 1
-
           $Output = (gh release list --repo $Env:GITHUB_REPOSITORY) | Out-String
           $Releases = ( $Output -split '\r?\n' ).Trim()
           $Versions = ForEach($Release in $Releases) {
@@ -122,7 +120,7 @@ jobs:
     steps:
       - name: Download artifacts
         run: |
-          gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -n docker -n devolutions-gateway-signed -n native-libs --repo $Env:GITHUB_REPOSITORY
+          gh run download ${{ needs.preflight.outputs.run }} -n webapp-client -n webapp-player -n docker -n devolutions-gateway-signed -n native-libs --repo $Env:GITHUB_REPOSITORY
           Move-Item -Path devolutions-gateway-signed -Destination devolutions-gateway
         shell: pwsh
         env:
@@ -133,96 +131,34 @@ jobs:
       # needs its own pre-compiled binary and architecture-specific native libraries (libxmf.so).
       # This approach is more reliable than trying to use COPY --platform in the Dockerfile,
       # which would require the binaries to be organized in a specific directory structure.
-      - name: Prepare artifacts (amd64)
-        id: prepare-artifacts-amd64
+      - name: Prepare artifacts
+        id: prepare-artifacts
         run: |
-          Set-PSDebug -Trace 1
+          $PowerShellArchive = Get-ChildItem -Recurse -Filter 'DevolutionsGateway-ps-*.tar' | Select-Object -First 1
 
-          $PkgDir = Join-Path docker $Env:RUNNER_OS "amd64"
-          echo "package-path-amd64=$PkgDir" >> $Env:GITHUB_OUTPUT
-          Write-Host "PkgDir = $PkgDir"
-          New-Item -ItemType Directory -Path $PkgDir -Force
+          foreach ($Arch in @(@{Ci='x64'; Docker='amd64'}, @{Ci='arm64'; Docker='arm64'})) {
+            $PkgDir = Join-Path docker $Env:RUNNER_OS $Arch.Docker
+            New-Item -ItemType Directory -Path $PkgDir -Force | Out-Null
+            echo "package-path-$($Arch.Docker)=$PkgDir" >> $Env:GITHUB_OUTPUT
 
-          $SourceFileName = "DevolutionsGateway_$($Env:RUNNER_OS)_${{ needs.preflight.outputs.version }}_x86_64"
-          $TargetFileName = "devolutions-gateway"
-          Write-Host "SourceFileName = $SourceFileName"
-          Write-Host "TargetFileName = $TargetFileName"
+            Copy-Item -Path (Join-Path devolutions-gateway linux $Arch.Ci devolutions-gateway) -Destination $PkgDir
+            chmod +x (Join-Path $PkgDir devolutions-gateway)
 
-          $SourcePath = Get-ChildItem -Recurse -Filter $SourceFileName -File -Path devolutions-gateway
-          $TargetPath = Join-Path $PkgDir $TargetFileName
-          Write-Host "SourcePath = $SourcePath"
-          Write-Host "TargetPath = $TargetPath"
-          Copy-Item -Path $SourcePath -Destination $TargetPath
-          chmod +x $TargetPath
+            Copy-Item -Path (Join-Path native-libs linux $Arch.Ci libxmf.so) -Destination $PkgDir
 
-          $XmfFileName = "libxmf.so"
-          $XmfSourcePath = Join-Path "native-libs" "linux" "x64" $XmfFileName | Resolve-Path
-          $XmfTargetPath = Join-Path $PkgDir $XmfFileName
-          Write-Host "XmfSourcePath = $XmfSourcePath"
-          Write-Host "XmfTargetPath = $XmfTargetPath"
-          Copy-Item -Path $XmfSourcePath -Destination $XmfTargetPath
+            $ClientTarget = Join-Path $PkgDir webapp client
+            New-Item -ItemType Directory -Path $ClientTarget -Force | Out-Null
+            Copy-Item -Path webapp-client/* -Destination $ClientTarget -Recurse
 
-          $WebAppArchive = Get-ChildItem -Recurse -Filter "devolutions_gateway_webapp_*.tar.gz" | Select-Object -First 1
-          $TargetPath = Join-Path $PkgDir "webapp" "client"
-          Write-Host "WebAppArchive = $WebAppArchive"
-          Write-Host "TargetPath = $TargetPath"
-          New-Item -ItemType Directory -Path $TargetPath
-          tar -xvzf $WebAppArchive.FullName -C $TargetPath --strip-components=1
+            $PlayerTarget = Join-Path $PkgDir webapp player
+            New-Item -ItemType Directory -Path $PlayerTarget -Force | Out-Null
+            Copy-Item -Path webapp-player/* -Destination $PlayerTarget -Recurse
 
-          $PowerShellArchive = Get-ChildItem -Recurse -Filter "DevolutionsGateway-ps-*.tar" | Select-Object -First 1
-          $psModuleArchiveHash = (Get-FileHash -Path "$PowerShellArchive").Hash
-          Write-Host "PS module archive hash: $psModuleArchiveHash"
-          tar -xvf "$PowerShellArchive" -C "$PkgDir"
+            tar -xf $PowerShellArchive.FullName -C $PkgDir
 
-          # Copy Dockerfile and entrypoint
-          Copy-Item -Path "docker/Linux/Dockerfile" -Destination $PkgDir
-          Copy-Item -Path "docker/Linux/entrypoint.ps1" -Destination $PkgDir
-        shell: pwsh
-
-      - name: Prepare artifacts (arm64)
-        id: prepare-artifacts-arm64
-        run: |
-          Set-PSDebug -Trace 1
-
-          $PkgDir = Join-Path docker $Env:RUNNER_OS "arm64"
-          echo "package-path-arm64=$PkgDir" >> $Env:GITHUB_OUTPUT
-          Write-Host "PkgDir = $PkgDir"
-          New-Item -ItemType Directory -Path $PkgDir -Force
-
-          $SourceFileName = "DevolutionsGateway_$($Env:RUNNER_OS)_${{ needs.preflight.outputs.version }}_arm64"
-          $TargetFileName = "devolutions-gateway"
-          Write-Host "SourceFileName = $SourceFileName"
-          Write-Host "TargetFileName = $TargetFileName"
-
-          $SourcePath = Get-ChildItem -Recurse -Filter $SourceFileName -File -Path devolutions-gateway
-          $TargetPath = Join-Path $PkgDir $TargetFileName
-          Write-Host "SourcePath = $SourcePath"
-          Write-Host "TargetPath = $TargetPath"
-          Copy-Item -Path $SourcePath -Destination $TargetPath
-          chmod +x $TargetPath
-
-          $XmfFileName = "libxmf.so"
-          $XmfSourcePath = Join-Path "native-libs" "linux" "arm64" $XmfFileName | Resolve-Path
-          $XmfTargetPath = Join-Path $PkgDir $XmfFileName
-          Write-Host "XmfSourcePath = $XmfSourcePath"
-          Write-Host "XmfTargetPath = $XmfTargetPath"
-          Copy-Item -Path $XmfSourcePath -Destination $XmfTargetPath
-
-          $WebAppArchive = Get-ChildItem -Recurse -Filter "devolutions_gateway_webapp_*.tar.gz" | Select-Object -First 1
-          $TargetPath = Join-Path $PkgDir "webapp" "client"
-          Write-Host "WebAppArchive = $WebAppArchive"
-          Write-Host "TargetPath = $TargetPath"
-          New-Item -ItemType Directory -Path $TargetPath
-          tar -xvzf $WebAppArchive.FullName -C $TargetPath --strip-components=1
-
-          $PowerShellArchive = Get-ChildItem -Recurse -Filter "DevolutionsGateway-ps-*.tar" | Select-Object -First 1
-          $psModuleArchiveHash = (Get-FileHash -Path "$PowerShellArchive").Hash
-          Write-Host "PS module archive hash: $psModuleArchiveHash"
-          tar -xvf "$PowerShellArchive" -C "$PkgDir"
-
-          # Copy Dockerfile and entrypoint
-          Copy-Item -Path "docker/Linux/Dockerfile" -Destination $PkgDir
-          Copy-Item -Path "docker/Linux/entrypoint.ps1" -Destination $PkgDir
+            Copy-Item -Path docker/Linux/Dockerfile     -Destination $PkgDir
+            Copy-Item -Path docker/Linux/entrypoint.ps1 -Destination $PkgDir
+          }
         shell: pwsh
 
       # QEMU is required for cross-platform Docker builds on x86_64 runners.
@@ -264,56 +200,26 @@ jobs:
       - name: Build and push multi-arch container
         id: build-container
         run: |
-          Set-PSDebug -Trace 1
-
           $Version = "${{ needs.preflight.outputs.version }}"
           $ImageName = "devolutions/devolutions-gateway"
-
-          $Amd64Context = "${{ steps.prepare-artifacts-amd64.outputs.package-path-amd64 }}"
-          $Arm64Context = "${{ steps.prepare-artifacts-arm64.outputs.package-path-arm64 }}"
-
           $DryRun = [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
 
-          # Build and push amd64 image
-          Write-Host "Building amd64 image..."
-          if (-Not $DryRun) {
-            docker buildx build --platform linux/amd64 `
-              --tag "${ImageName}:${Version}-amd64" `
-              --push `
-              $Amd64Context
-          } else {
-            docker buildx build --platform linux/amd64 `
-              --tag "${ImageName}:${Version}-amd64" `
-              $Amd64Context
-          }
+          $Amd64Context = "${{ steps.prepare-artifacts.outputs.package-path-amd64 }}"
+          $Arm64Context = "${{ steps.prepare-artifacts.outputs.package-path-arm64 }}"
 
-          # Build and push arm64 image (cross-compiled on x86_64 runner using QEMU)
-          Write-Host "Building arm64 image..."
-          if (-Not $DryRun) {
-            docker buildx build --platform linux/arm64 `
-              --tag "${ImageName}:${Version}-arm64" `
-              --push `
-              $Arm64Context
-          } else {
-            docker buildx build --platform linux/arm64 `
-              --tag "${ImageName}:${Version}-arm64" `
-              $Arm64Context
+          foreach ($P in @(@{Platform='linux/amd64'; Tag='amd64'; Context=$Amd64Context}, @{Platform='linux/arm64'; Tag='arm64'; Context=$Arm64Context})) {
+            $Args = @('buildx', 'build', "--platform=$($P.Platform)", "--tag=${ImageName}:${Version}-$($P.Tag)", $P.Context)
+            if (-Not $DryRun) { $Args += '--push' }
+            docker @Args
           }
 
           if (-Not $DryRun) {
-            # Create multi-arch manifests that reference both architecture-specific images.
-            # This enables Docker to automatically select the correct image based on the user's platform.
-            Write-Host "Creating multi-arch manifest for version ${Version}..."
-            docker buildx imagetools create `
-              --tag "${ImageName}:${Version}" `
-              "${ImageName}:${Version}-amd64" `
-              "${ImageName}:${Version}-arm64"
-
-            Write-Host "Creating multi-arch manifest for latest..."
-            docker buildx imagetools create `
-              --tag "${ImageName}:latest" `
-              "${ImageName}:${Version}-amd64" `
-              "${ImageName}:${Version}-arm64"
+            foreach ($Tag in @($Version, 'latest')) {
+              docker buildx imagetools create `
+                --tag "${ImageName}:${Tag}" `
+                "${ImageName}:${Version}-amd64" `
+                "${ImageName}:${Version}-arm64"
+            }
           } else {
             Write-Host "Dry run: skipping manifest creation and push"
           }
@@ -345,109 +251,123 @@ jobs:
 
       - name: Download artifacts
         run: |
-          gh run download ${{ needs.preflight.outputs.run }} -n jetsocat-signed -n devolutions-gateway-signed -n devolutions-agent-signed -n webapp-client -n changelog --repo $Env:GITHUB_REPOSITORY
-          Move-Item -Path jetsocat-signed -Destination jetsocat
-          Move-Item -Path devolutions-gateway-signed -Destination devolutions-gateway
-          Move-Item -Path devolutions-agent-signed -Destination devolutions-agent
+          gh run download ${{ needs.preflight.outputs.run }} -n jetsocat-signed -n devolutions-gateway-signed -n devolutions-agent-signed -n webapp-client -n webapp-player -n native-libs -n changelog -D downloads --repo $Env:GITHUB_REPOSITORY
+          Move-Item downloads/jetsocat-signed          downloads/jetsocat
+          Move-Item downloads/devolutions-gateway-signed downloads/devolutions-gateway
+          Move-Item downloads/devolutions-agent-signed   downloads/devolutions-agent
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Manage artifacts
-        run: |
-          # Devolutions Agent on Linux does not have any useful feature yet, so we filter out the Linux artifacts.
-          Remove-Item -Path (Join-Path devolutions-agent linux) -Recurse
-
-          # Do not upload tun2socks.exe by itself.
-          Remove-Item -Path (Join-Path devolutions-agent tun2socks) -Recurse
-
-          # DevolutionsAgentUpdater is an internal MSI update helper, not a standalone download.
-          Get-ChildItem -Path devolutions-agent -Recurse -Filter 'DevolutionsAgentUpdater_*' -File | Remove-Item
-
-          # For the PowerShell module, only upload the nupkg.
-          Remove-Item -Path (Join-Path devolutions-gateway PowerShell DevolutionsGateway-ps-*.tar)
-        shell: pwsh
-
-      - name: Create jetsocat ZIP files for winget
+      - name: Prepare release assets
         run: |
           $Version = "${{ needs.preflight.outputs.version }}"
-          $ZipFolder = "jetsocat-zips"
-          New-Item -ItemType Directory -Path $ZipFolder -Force
+          $Dl = "downloads"
+          $Release = New-Item -Path "release" -ItemType Directory
 
-          # Define the platforms and architectures.
-          $Platforms = @(
-            @{ OS = "windows"; Arch = "x86_64"; Extension = ".exe" },
-            @{ OS = "windows"; Arch = "arm64"; Extension = ".exe" },
-            @{ OS = "linux"; Arch = "x86_64"; Extension = "" },
-            @{ OS = "linux"; Arch = "arm64"; Extension = "" },
-            @{ OS = "macos"; Arch = "x86_64"; Extension = "" },
-            @{ OS = "macos"; Arch = "arm64"; Extension = "" }
-          )
+          # Gateway Windows MSI + symbols + self-contained ZIP (binary + xmf.dll + webapp)
+          Move-Item "$Dl/devolutions-gateway/windows/x64/DevolutionsGateway.msi" "$Release/DevolutionsGateway-${Version}-x64.msi"
+          Move-Item "$Dl/devolutions-gateway/windows/x64/DevolutionsGateway.symbols.zip" "$Release/DevolutionsGateway-${Version}-x64.symbols.zip"
 
-          foreach ($Platform in $Platforms) {
-            $OS = $Platform.OS
-            $Arch = $Platform.Arch
-            $Ext = $Platform.Extension
+          $StageDir = Join-Path $Env:RUNNER_TEMP "dgw-windows-x64"
+          New-Item -Path $StageDir -ItemType Directory -Force | Out-Null
+          Copy-Item "$Dl/devolutions-gateway/windows/x64/DevolutionsGateway.exe" (Join-Path $StageDir 'DevolutionsGateway.exe')
+          Copy-Item "$Dl/native-libs/windows/x64/xmf.dll" (Join-Path $StageDir 'xmf.dll')
+          $ClientTarget = Join-Path $StageDir "webapp" "client"
+          New-Item -Path $ClientTarget -ItemType Directory -Force | Out-Null
+          Copy-Item -Path "$Dl/webapp-client/*" -Destination $ClientTarget -Recurse
+          $PlayerTarget = Join-Path $StageDir "webapp" "player"
+          New-Item -Path $PlayerTarget -ItemType Directory -Force | Out-Null
+          Copy-Item -Path "$Dl/webapp-player/*" -Destination $PlayerTarget -Recurse
+          Compress-Archive -Path (Join-Path $StageDir '*') -DestinationPath "$Release/DevolutionsGateway-${Version}-windows-x64.zip" -Force
+          Write-Host "Created DevolutionsGateway-${Version}-windows-x64.zip"
+          Remove-Item -Path $StageDir -Recurse -Force
 
-            # Find the original binary.
-            $BinaryPattern = "jetsocat_*_${Version}_${Arch}${Ext}"
-            $OriginalBinary = Get-ChildItem -Recurse -Filter $BinaryPattern -File | Select-Object -First 1
+          # Gateway PowerShell nupkg
+          Get-ChildItem "$Dl/devolutions-gateway/PowerShell" -Filter "*.nupkg" | Move-Item -Destination $Release
 
-            if ($OriginalBinary) {
-              # Create temporary folder for this zip.
-              $TempFolder = Join-Path $ZipFolder "temp-$OS-$Arch"
-              New-Item -ItemType Directory -Path $TempFolder -Force
+          # Gateway Linux DEB/RPM/changes + self-contained tar.xz (binary + libxmf.so + webapp)
+          foreach ($Arch in @('x64', 'arm64')) {
+            Move-Item "$Dl/devolutions-gateway/linux/${Arch}/devolutions-gateway.deb"     "$Release/devolutions-gateway-${Version}-${Arch}.deb"
+            Move-Item "$Dl/devolutions-gateway/linux/${Arch}/devolutions-gateway.rpm"     "$Release/devolutions-gateway-${Version}-${Arch}.rpm"
+            Move-Item "$Dl/devolutions-gateway/linux/${Arch}/devolutions-gateway.changes" "$Release/devolutions-gateway-${Version}-${Arch}.changes"
 
-              # Copy binary with standard name.
-              $TargetName = "jetsocat${Ext}"
-              $TargetPath = Join-Path $TempFolder $TargetName
-              Copy-Item -Path $OriginalBinary.FullName -Destination $TargetPath
+            # Stage into a temp dir so the tar.xz root contains the files directly,
+            # not embedded under the download path.
+            $StageDir = Join-Path $Env:RUNNER_TEMP "dgw-linux-$Arch"
+            New-Item -Path $StageDir -ItemType Directory -Force | Out-Null
+            Copy-Item "$Dl/devolutions-gateway/linux/${Arch}/devolutions-gateway" (Join-Path $StageDir 'devolutions-gateway')
+            chmod +x (Join-Path $StageDir 'devolutions-gateway')
+            Copy-Item "$Dl/native-libs/linux/${Arch}/libxmf.so" (Join-Path $StageDir 'libxmf.so')
+            $ClientTarget = Join-Path $StageDir "webapp" "client"
+            New-Item -Path $ClientTarget -ItemType Directory -Force | Out-Null
+            Copy-Item -Path "$Dl/webapp-client/*" -Destination $ClientTarget -Recurse
+            $PlayerTarget = Join-Path $StageDir "webapp" "player"
+            New-Item -Path $PlayerTarget -ItemType Directory -Force | Out-Null
+            Copy-Item -Path "$Dl/webapp-player/*" -Destination $PlayerTarget -Recurse
+            tar -cJf "$Release/devolutions-gateway-${Version}-linux-${Arch}.tar.xz" -C $StageDir .
+            Write-Host "Created devolutions-gateway-${Version}-linux-${Arch}.tar.xz"
+            Remove-Item -Path $StageDir -Recurse -Force
+          }
 
-              # Create ZIP file.
-              $ZipName = "jetsocat-$OS-$Arch.zip"
-              $ZipPath = Join-Path $ZipFolder $ZipName
-              Compress-Archive -Path $TargetPath -DestinationPath $ZipPath -Force
+          # Agent Windows MSI + symbols; Linux Agent artifacts are not yet published.
+          foreach ($Arch in @('x64', 'arm64')) {
+            Move-Item "$Dl/devolutions-agent/windows/${Arch}/DevolutionsAgent.msi"         "$Release/DevolutionsAgent-${Version}-${Arch}.msi"
+            Move-Item "$Dl/devolutions-agent/windows/${Arch}/DevolutionsAgent.symbols.zip" "$Release/DevolutionsAgent-${Version}-${Arch}.symbols.zip"
+          }
 
-              Write-Host "Created $ZipName"
-
-              # Clean up temp folder.
-              Remove-Item -Path $TempFolder -Recurse -Force
-
-              # Remove the original binary to avoid uploading it.
-              Remove-Item -Path $OriginalBinary.FullName
+          # Jetsocat archives: .tar.xz for Linux, .zip for Windows and macOS
+          foreach ($P in @(
+            @{ OS = "windows"; Arch = "x64";       Ext = ".exe"; Archive = "zip" },
+            @{ OS = "windows"; Arch = "arm64";     Ext = ".exe"; Archive = "zip" },
+            @{ OS = "linux";   Arch = "x64";       Ext = "";     Archive = "tar.xz" },
+            @{ OS = "linux";   Arch = "arm64";     Ext = "";     Archive = "tar.xz" },
+            @{ OS = "macos";   Arch = "x64";       Ext = "";     Archive = "tar.xz" },
+            @{ OS = "macos";   Arch = "arm64";     Ext = "";     Archive = "tar.xz" },
+            @{ OS = "macos";   Arch = "universal"; Ext = "";     Archive = "tar.xz" }
+          )) {
+            $BinaryPath = Join-Path $Dl jetsocat $P.OS $P.Arch "jetsocat$($P.Ext)"
+            if (Test-Path $BinaryPath) {
+              $ArchivePath = "$Release/jetsocat-${Version}-$($P.OS)-$($P.Arch).$($P.Archive)"
+              $StageDir = Join-Path $Env:RUNNER_TEMP "jetsocat-$($P.OS)-$($P.Arch)"
+              New-Item -ItemType Directory -Path $StageDir -Force | Out-Null
+              Copy-Item $BinaryPath (Join-Path $StageDir (Split-Path $BinaryPath -Leaf)) -Force
+              if ($P.Archive -eq 'tar.xz') {
+                tar -cJf $ArchivePath -C $StageDir .
+              } else {
+                # Compress-Archive preserves the source path structure inside the ZIP.
+                # Staging to a flat temp dir ensures the binary lands at the ZIP root.
+                Compress-Archive -Path (Join-Path $StageDir '*') -DestinationPath $ArchivePath -Force
+              }
+              Remove-Item -Path $StageDir -Recurse -Force
+              Write-Host "Created jetsocat-${Version}-$($P.OS)-$($P.Arch).$($P.Archive)"
             } else {
-              Write-Warning "Could not find binary for $OS $Arch"
+              throw "Jetsocat binary not found: $BinaryPath"
             }
           }
-
-          # Rename macOS universal binary to follow the naming convention (without version).
-          Get-ChildItem -Recurse -Filter "jetsocat_*_${Version}_universal" -File | ForEach-Object {
-            Rename-Item -Path $_.FullName -NewName "jetsocat-macos-universal"
-          }
-
-          # Rename Windows PDB files to follow the naming convention (without version).
-          Get-ChildItem -Recurse -Filter "jetsocat_Windows_${Version}_*.pdb" -File | ForEach-Object {
-            $Arch = $_.BaseName -replace "jetsocat_Windows_${Version}_", ""
-            Rename-Item -Path $_.FullName -NewName "jetsocat-windows-$Arch.pdb"
+          foreach ($Arch in @('x64', 'arm64')) {
+            $SymbolsPath = Join-Path $Dl jetsocat windows $Arch jetsocat.symbols.zip
+            if (Test-Path $SymbolsPath) {
+              Move-Item $SymbolsPath "$Release/jetsocat-${Version}-windows-${Arch}.symbols.zip"
+            } else {
+              throw "Jetsocat Windows symbols not found: $SymbolsPath"
+            }
           }
         shell: pwsh
 
       - name: Create GitHub release
         run: |
-          Set-PSDebug -Trace 1
-
           $Version = "${{ needs.preflight.outputs.version }}"
-          $HashPath = 'checksums'
-          $Files = Get-ChildItem -Recurse -File -Exclude 'CHANGELOG.md', '*.dll' | % { Get-FileHash -Algorithm SHA256 $_.FullName }
-          $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
+          $Files = Get-ChildItem -Path release -Recurse -File | % { Get-FileHash -Algorithm SHA256 $_.FullName }
 
+          $HashPath = 'checksums'
+          $Files | % { "$($_.Hash)  $(Split-Path $_.Path -leaf)" } | Out-File -FilePath $HashPath -Append -Encoding ASCII
           echo "::group::checksums"
           Get-Content $HashPath
           echo "::endgroup::"
 
           $ChangesPath = 'changes'
-          parse-changelog $(Join-Path changelog CHANGELOG.md) $Version | Out-File -Encoding UTF8NoBOM $ChangesPath
-
+          parse-changelog $(Join-Path downloads changelog CHANGELOG.md) $Version | Out-File -Encoding UTF8NoBOM $ChangesPath
           echo "::group::changes"
           Get-Content $ChangesPath
           echo "::endgroup::"
@@ -455,7 +375,7 @@ jobs:
           $GhCmd = $(@('gh', 'release', 'create', "v$Version", "--repo", $Env:GITHUB_REPOSITORY, "--notes-file", $ChangesPath, $HashPath) + $Files.Path) -Join ' '
           Write-Host $GhCmd
 
-          $DryRun =  [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
+          $DryRun = [System.Convert]::ToBoolean('${{ inputs.dry-run }}')
           if (-Not $DryRun) {
             Invoke-Expression $GhCmd
           }
@@ -544,7 +464,9 @@ jobs:
           github_token: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
 
       - name: Download artifacts
-        run: gh run download ${{ needs.preflight.outputs.run }} -n devolutions-gateway-signed --repo $Env:GITHUB_REPOSITORY
+        run: |
+          gh run download ${{ needs.preflight.outputs.run }} -n devolutions-gateway-signed -n native-libs -n webapp-client -n webapp-player --repo $Env:GITHUB_REPOSITORY
+          Move-Item devolutions-gateway-signed devolutions-gateway
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -552,24 +474,59 @@ jobs:
       - name: Prepare upload
         id: prepare
         run: |
-          Set-PSDebug -Trace 1
-
           $destinationFolder = "${{ runner.temp }}/artifacts"
-          $version="${{ needs.preflight.outputs.version }}"
+          $version = "${{ needs.preflight.outputs.version }}"
           # Note that ".0" is appended here (required by release tooling downstream)
-          $versionFull="$version.0"
+          $versionFull = "$version.0"
+          Write-Host "Preparing Gateway artifacts in $destinationFolder for version $versionFull"
 
           echo "version=${versionFull}" >> $Env:GITHUB_OUTPUT
           echo "files-to-upload=$destinationFolder" >> $Env:GITHUB_OUTPUT
 
-          New-Item -Path "$destinationFolder" -ItemType "directory"
+          New-Item -Path $destinationFolder -ItemType Directory
 
-          Move-Item -Path "./windows/x86_64/DevolutionsGateway-x86_64-${version}.msi" -Destination "$destinationFolder/DevolutionsGateway-x86_64-${versionFull}.msi"
-          Move-Item -Path "./windows/x86_64/DevolutionsGateway_Windows_${version}_x86_64.pdb" -Destination "$destinationFolder/DevolutionsGateway-x86_64-${versionFull}.pdb"
-          Move-Item -Path "./linux/x86_64/devolutions-gateway_${version}-1_amd64.deb" -Destination "$destinationFolder/devolutions-gateway_${versionFull}_amd64.deb"
-          Move-Item -Path "./linux/x86_64/devolutions-gateway_${version}-1_x86_64.rpm" -Destination "$destinationFolder/devolutions-gateway_${versionFull}_x86_64.rpm"
-          Move-Item -Path "./linux/arm64/devolutions-gateway_${version}-1_arm64.deb" -Destination "$destinationFolder/devolutions-gateway_${versionFull}_arm64.deb"
-          Move-Item -Path "./linux/arm64/devolutions-gateway_${version}-1_arm64.rpm" -Destination "$destinationFolder/devolutions-gateway_${versionFull}_arm64.rpm"
+          Move-Item -Path "./devolutions-gateway/windows/x64/DevolutionsGateway.msi" -Destination "$destinationFolder/DevolutionsGateway-${versionFull}-x64.msi"
+          Move-Item -Path "./devolutions-gateway/windows/x64/DevolutionsGateway.symbols.zip" -Destination "$destinationFolder/DevolutionsGateway-${versionFull}-x64.symbols.zip"
+
+          $StageDir = Join-Path $Env:RUNNER_TEMP "dgw-windows-x64"
+          New-Item -Path $StageDir -ItemType Directory -Force | Out-Null
+          Copy-Item -Path "./devolutions-gateway/windows/x64/DevolutionsGateway.exe" -Destination (Join-Path $StageDir 'DevolutionsGateway.exe')
+          Copy-Item -Path "./native-libs/windows/x64/xmf.dll" -Destination (Join-Path $StageDir 'xmf.dll')
+          $ClientTarget = Join-Path $StageDir "webapp" "client"
+          New-Item -Path $ClientTarget -ItemType Directory -Force | Out-Null
+          Copy-Item -Path "webapp-client/*" -Destination $ClientTarget -Recurse
+          $PlayerTarget = Join-Path $StageDir "webapp" "player"
+          New-Item -Path $PlayerTarget -ItemType Directory -Force | Out-Null
+          Copy-Item -Path "webapp-player/*" -Destination $PlayerTarget -Recurse
+          Compress-Archive -Path (Join-Path $StageDir '*') -DestinationPath "$destinationFolder/DevolutionsGateway-${versionFull}-windows-x64.zip" -Force
+          Write-Host "Created DevolutionsGateway-${versionFull}-windows-x64.zip"
+          Remove-Item -Path $StageDir -Recurse -Force
+
+          foreach ($Arch in @('x64', 'arm64')) {
+            Move-Item -Path "./devolutions-gateway/linux/${Arch}/devolutions-gateway.deb" -Destination "$destinationFolder/devolutions-gateway-${versionFull}-${Arch}.deb"
+            Move-Item -Path "./devolutions-gateway/linux/${Arch}/devolutions-gateway.rpm" -Destination "$destinationFolder/devolutions-gateway-${versionFull}-${Arch}.rpm"
+            Move-Item -Path "./devolutions-gateway/linux/${Arch}/devolutions-gateway.changes" -Destination "$destinationFolder/devolutions-gateway-${versionFull}-${Arch}.changes"
+
+            $BinaryPath = "./devolutions-gateway/linux/${Arch}/devolutions-gateway"
+            $StageDir = Join-Path $Env:RUNNER_TEMP "dgw-linux-$Arch"
+            New-Item -Path $StageDir -ItemType Directory -Force | Out-Null
+            Copy-Item -Path $BinaryPath -Destination (Join-Path $StageDir 'devolutions-gateway')
+            chmod +x (Join-Path $StageDir 'devolutions-gateway')
+            Copy-Item -Path "./native-libs/linux/${Arch}/libxmf.so" -Destination (Join-Path $StageDir 'libxmf.so')
+
+            $ClientTarget = Join-Path $StageDir "webapp" "client"
+            New-Item -Path $ClientTarget -ItemType Directory -Force | Out-Null
+            Copy-Item -Path "webapp-client/*" -Destination $ClientTarget -Recurse
+
+            $PlayerTarget = Join-Path $StageDir "webapp" "player"
+            New-Item -Path $PlayerTarget -ItemType Directory -Force | Out-Null
+            Copy-Item -Path "webapp-player/*" -Destination $PlayerTarget -Recurse
+
+            $TarPath = "$destinationFolder/devolutions-gateway-${versionFull}-linux-${Arch}.tar.xz"
+            tar -cJf $TarPath -C $StageDir .
+            Write-Host "Created devolutions-gateway-${versionFull}-linux-${Arch}.tar.xz"
+            Remove-Item -Path $StageDir -Recurse -Force
+          }
         shell: pwsh
 
       - name: Attest build provenance
@@ -617,7 +574,9 @@ jobs:
           github_token: ${{ secrets.DEVOLUTIONSBOT_TOKEN }}
 
       - name: Download artifacts
-        run: gh run download ${{ needs.preflight.outputs.run }} -n devolutions-agent-signed --repo $Env:GITHUB_REPOSITORY
+        run: |
+          gh run download ${{ needs.preflight.outputs.run }} -n devolutions-agent-signed --repo $Env:GITHUB_REPOSITORY
+          Move-Item devolutions-agent-signed devolutions-agent
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -625,23 +584,27 @@ jobs:
       - name: Prepare upload
         id: prepare
         run: |
-          Set-PSDebug -Trace 1
-
           $destinationFolder = "${{ runner.temp }}/artifacts"
           $version="${{ needs.preflight.outputs.version }}"
           # Note that ".0" is appended here (required by release tooling downstream)
           $versionFull="$version.0"
+          Write-Host "Preparing Agent artifacts in $destinationFolder for version $versionFull"
 
           echo "version=${versionFull}" >> $Env:GITHUB_OUTPUT
           echo "files-to-upload=$destinationFolder" >> $Env:GITHUB_OUTPUT
 
           New-Item -Path "$destinationFolder" -ItemType "directory"
 
-          Move-Item -Path "./windows/arm64/DevolutionsAgent-arm64-${version}.msi" -Destination "$destinationFolder/DevolutionsAgent-arm64-${versionFull}.msi"
-          Move-Item -Path "./windows/x86_64/DevolutionsAgent-x86_64-${version}.msi" -Destination "$destinationFolder/DevolutionsAgent-x86_64-${versionFull}.msi"
-          Move-Item -Path "./windows/x86_64/DevolutionsAgent-x86_64-${version}.symbols.zip" -Destination "$destinationFolder/DevolutionsAgent-x86_64-${versionFull}.symbols.zip"
-          Move-Item -Path "./linux/x86_64/devolutions-agent_${version}-1_amd64.deb" -Destination "$destinationFolder/devolutions-agent_${versionFull}_amd64.deb"
-          Move-Item -Path "./linux/x86_64/devolutions-agent_${version}-1_x86_64.rpm" -Destination "$destinationFolder/devolutions-agent_${versionFull}_x86_64.rpm"
+          foreach ($Arch in @('x64', 'arm64')) {
+            Move-Item -Path "./devolutions-agent/windows/${Arch}/DevolutionsAgent.msi" -Destination "$destinationFolder/DevolutionsAgent-${versionFull}-${Arch}.msi"
+            Move-Item -Path "./devolutions-agent/windows/${Arch}/DevolutionsAgent.symbols.zip" -Destination "$destinationFolder/DevolutionsAgent-${versionFull}-${Arch}.symbols.zip"
+          }
+
+          foreach ($Arch in @('x64', 'arm64')) {
+            Move-Item -Path "./devolutions-agent/linux/${Arch}/devolutions-agent.deb" -Destination "$destinationFolder/devolutions-agent-${versionFull}-${Arch}.deb"
+            Move-Item -Path "./devolutions-agent/linux/${Arch}/devolutions-agent.rpm" -Destination "$destinationFolder/devolutions-agent-${versionFull}-${Arch}.rpm"
+            Move-Item -Path "./devolutions-agent/linux/${Arch}/devolutions-agent.changes" -Destination "$destinationFolder/devolutions-agent-${versionFull}-${Arch}.changes"
+          }
         shell: pwsh
 
       - name: Attest build provenance
@@ -685,8 +648,6 @@ jobs:
 
       - name: Publish Jetsocat NuGet package
         run: |
-          Set-PSDebug -Trace 1
-
           $Package = Get-ChildItem -Recurse -Filter "Devolutions.Jetsocat.*.nupkg" -File | Select-Object -First 1
           Write-Host "Package = $Package"
 

--- a/ci/setup-linux-build-deps.ps1
+++ b/ci/setup-linux-build-deps.ps1
@@ -2,7 +2,7 @@
 
 param(
     [Parameter(Mandatory = $true)]
-    [ValidateSet('x86_64', 'arm64')]
+    [ValidateSet('x64', 'arm64')]
     [string] $Architecture
 )
 

--- a/ci/tlk.ps1
+++ b/ci/tlk.ps1
@@ -97,7 +97,7 @@ function Get-TlkArchitecture {
     )
 
     if (-Not $Architecture) {
-        $Architecture = 'x86_64'
+        $Architecture = 'x64'
     }
 
     $Architecture
@@ -166,7 +166,6 @@ class TlkTarget
         $CargoArchitecture = `
         switch ($this.Architecture) {
             "x86" { "i686" }
-            "x86_64" { "x86_64" }
             "x64" { "x86_64" }
             "aarch64" { "aarch64" }
             "arm64" { "aarch64" }
@@ -189,7 +188,7 @@ class TlkTarget
         $WindowsArchitecture = `
         switch ($this.Architecture) {
             "x86" { "x86" }
-            "x86_64" { "x64" }
+            "x64" { "x64" }
             "aarch64" { "ARM64" }
         }
 
@@ -202,7 +201,7 @@ class TlkTarget
         $DebianArchitecture = `
         switch ($this.Architecture) {
             "x86" { "i386" }
-            "x86_64" { "amd64" }
+            "x64" { "amd64" }
             "arm64" { "arm64" }
         }
 
@@ -979,7 +978,7 @@ function Invoke-TlkStep {
         [string] $PackageOption,
 		[ValidateSet('windows','macos','linux')]
 		[string] $Platform,
-		[ValidateSet('x86','x86_64','arm64')]
+		[ValidateSet('x86','x64','arm64')]
 		[string] $Architecture,
         [ValidateSet('dev', 'release', 'production')]
         [string] $CargoProfile,

--- a/powershell/DevolutionsGateway/Public/DGateway.ps1
+++ b/powershell/DevolutionsGateway/Public/DGateway.ps1
@@ -1219,11 +1219,9 @@ function Get-DGatewayPackage {
     $GitHubDownloadUrl = 'https://github.com/Devolutions/devolutions-gateway/releases/download/'
 
     if ($Platform -eq 'Windows') {
-        $Architecture = 'x86_64'
-        $PackageFileName = "DevolutionsGateway-${Architecture}-${Version}.msi"
+        $PackageFileName = "DevolutionsGateway-${Version}-x64.msi"
     } elseif ($Platform -eq 'Linux') {
-        $Architecture = 'amd64'
-        $PackageFileName = "devolutions-gateway_${Version}.0_${Architecture}.deb"
+        $PackageFileName = "devolutions-gateway-${Version}-x64.deb"
     }
 
     $DownloadUrl = "${GitHubDownloadUrl}v${Version}/$PackageFileName"


### PR DESCRIPTION
Artifact naming conventions:
- Use 'x64' everywhere (drop 'x86_64', 'amd64')
- Files live in os/arch folders with simple basenames

Linux archive:
- Replace ZIP releases with self-contained tar.xz for Gateway and
  Jetsocat on Linux and macOS; Windows uses .zip for Jetsocat

Windows ZIP:
- Add DevolutionsGateway-{Version}-windows-x64.zip (exe + xmf.dll +
  webapp) mirroring the Linux tar.xz structure

Jetsocat archive format:
- Linux and macOS: .tar.xz
- Windows: .zip
- Hard-fail (throw) on any missing binary; no soft-skip

webapp artifact:
- Drop tar.gz wrapper; re-upload raw directories
- Rename job web-app -> webapp

tun2socks:
- Stage under `tun2socks/` per build so files land in arch
  subdirs; per-arch artifacts named tun2socks-windows-{arch}
- Add tun2socks-windows-merge job to produce single tun2socks-windows
  artifact; package.yml downloads it in one line into \/windows

arm64 Agent MSI:
- Loop over @('x64','arm64') in a single
  'Regenerate and Repackage Agent MSI' step: generate, sign runtime
  EXEs, assemble for each arch