### PR TITLE
ci: fix artifact download paths in OneDrive upload job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1280,22 +1280,22 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: jetsocat
-          path: ${{ runner.temp }}/artifacts_raw
+          path: ${{ runner.temp }}/artifacts_raw/jetsocat
 
       - uses: actions/download-artifact@v8
         with:
           name: devolutions-gateway
-          path: ${{ runner.temp }}/artifacts_raw
+          path: ${{ runner.temp }}/artifacts_raw/devolutions-gateway
 
       - uses: actions/download-artifact@v8
         with:
           name: devolutions-agent
-          path: ${{ runner.temp }}/artifacts_raw
+          path: ${{ runner.temp }}/artifacts_raw/devolutions-agent
 
       - uses: actions/download-artifact@v8
         with:
           name: git-log
-          path: ${{ runner.temp }}/artifacts_raw
+          path: ${{ runner.temp }}/artifacts_raw/git-log
 
       - name: Prepare upload
         id: prepare


### PR DESCRIPTION
Each artifact must be downloaded into its own named subdirectory so that the MoveArtifact calls (which prefix paths with the artifact name) can find the files.