### PR TITLE
feat(agent): --advertise-domains CLI flag

### DIFF
--- a/devolutions-agent/src/enrollment.rs
+++ b/devolutions-agent/src/enrollment.rs
@@ -97,17 +97,28 @@ pub struct PersistedEnrollment {
 /// * `enrollment_token` - JWT token for enrollment
 /// * `agent_name` - Friendly name for this agent
 /// * `advertise_subnets` - List of subnets to advertise (e.g., ["10.0.0.0/8"])
+/// * `advertise_domains` - List of DNS suffixes to advertise (e.g.,
+///   ["corp.example.com"]). Empty preserves the existing config value so the
+///   admin can manage domains via the config file without losing them on
+///   re-enrollment.
 pub async fn enroll_agent(
     gateway_url: &str,
     enrollment_token: &str,
     agent_name: &str,
     advertise_subnets: Vec<String>,
+    advertise_domains: Vec<String>,
 ) -> Result<PersistedEnrollment> {
     // Generate key pair and CSR locally — the private key never leaves this machine.
     let (key_pem, csr_pem) = generate_key_and_csr(agent_name)?;
 
     let enroll_response = request_enrollment(gateway_url, enrollment_token, agent_name, &csr_pem).await?;
-    persist_enrollment_response(agent_name, advertise_subnets, enroll_response, &key_pem)
+    persist_enrollment_response(
+        agent_name,
+        advertise_subnets,
+        advertise_domains,
+        enroll_response,
+        &key_pem,
+    )
 }
 
 /// Generate an ECDSA P-256 key pair and a CSR containing the agent name as CN.
@@ -164,6 +175,7 @@ async fn request_enrollment(
 fn persist_enrollment_response(
     agent_name: &str,
     advertise_subnets: Vec<String>,
+    advertise_domains: Vec<String>,
     EnrollResponse {
         agent_id,
         client_cert_pem,
@@ -214,8 +226,16 @@ fn persist_enrollment_response(
     // configured by the MSI installer or admin.
     let mut conf_file = config::load_conf_file_or_generate_new().context("failed to load existing configuration")?;
 
-    // Preserve existing domain config from previous enrollment/manual configuration.
     let existing_tunnel = conf_file.tunnel.as_ref();
+
+    // An empty `advertise_domains` from the caller means "no override" — fall
+    // back to the value already in the config so re-enrollment from the CLI
+    // does not silently wipe domains the admin set via the config file.
+    let resolved_advertise_domains = if advertise_domains.is_empty() {
+        existing_tunnel.map(|t| t.advertise_domains.clone()).unwrap_or_default()
+    } else {
+        advertise_domains
+    };
 
     let tunnel_conf = config::dto::TunnelConf {
         enabled: true,
@@ -224,7 +244,7 @@ fn persist_enrollment_response(
         client_key_path: Some(client_key_path.clone()),
         gateway_ca_cert_path: Some(gateway_ca_path.clone()),
         advertise_subnets,
-        advertise_domains: existing_tunnel.map(|t| t.advertise_domains.clone()).unwrap_or_default(),
+        advertise_domains: resolved_advertise_domains,
         auto_detect_domain: existing_tunnel.map(|t| t.auto_detect_domain).unwrap_or(true),
         heartbeat_interval_secs: Some(60),
         route_advertise_interval_secs: Some(30),

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -239,11 +239,20 @@ fn main() {
                 }
             }
             "enroll" => {
+                // Positional contract:
+                //   enroll <gateway_url> <enrollment_token> <agent_name> [subnets_csv] [domains_csv]
+                // Example: enroll https://gw.example.com:7171 <token> site-a 10.0.0.0/8 corp.example.com,lab.example.com
+                const ENROLL_USAGE: &str =
+                    "usage: enroll <gateway_url> <enrollment_token> <agent_name> [subnets_csv] [domains_csv]";
                 let gateway_url = env::args()
                     .nth(2)
-                    .expect("missing gateway URL (e.g., https://gateway.example.com:7171)");
-                let enrollment_token = env::args().nth(3).expect("missing enrollment token");
-                let agent_name = env::args().nth(4).expect("missing agent name");
+                    .unwrap_or_else(|| panic!("missing <gateway_url>. {ENROLL_USAGE}"));
+                let enrollment_token = env::args()
+                    .nth(3)
+                    .unwrap_or_else(|| panic!("missing <enrollment_token>. {ENROLL_USAGE}"));
+                let agent_name = env::args()
+                    .nth(4)
+                    .unwrap_or_else(|| panic!("missing <agent_name>. {ENROLL_USAGE}"));
                 let subnets_arg = env::args().nth(5).unwrap_or_default();
                 let domains_arg = env::args().nth(6).unwrap_or_default();
 

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -59,6 +59,7 @@ struct UpCommand {
     enrollment_token: String,
     agent_name: String,
     advertise_subnets: Vec<String>,
+    advertise_domains: Vec<String>,
 }
 
 fn agent_service_main(
@@ -136,11 +137,11 @@ fn parse_required_value(args: &[String], index: &mut usize, flag: &str) -> Resul
         .with_context(|| format!("missing value for {flag}"))
 }
 
-fn parse_advertise_subnets(value: &str) -> Vec<String> {
+fn parse_comma_separated(value: &str) -> Vec<String> {
     value
         .split(',')
         .map(str::trim)
-        .filter(|subnet| !subnet.is_empty())
+        .filter(|item| !item.is_empty())
         .map(ToOwned::to_owned)
         .collect()
 }
@@ -151,6 +152,7 @@ fn parse_up_command_args(args: &[String]) -> Result<UpCommand> {
     let mut agent_name = None;
     let mut enrollment_string = None;
     let mut advertise_subnets = Vec::new();
+    let mut advertise_domains = Vec::new();
 
     let mut index = 0;
     while index < args.len() {
@@ -162,7 +164,10 @@ fn parse_up_command_args(args: &[String]) -> Result<UpCommand> {
             "--name" | "--agent-name" => agent_name = Some(parse_required_value(args, &mut index, arg)?),
             "--enrollment-string" => enrollment_string = Some(parse_required_value(args, &mut index, arg)?),
             "--advertise-routes" | "--advertise-subnets" => {
-                advertise_subnets.extend(parse_advertise_subnets(&parse_required_value(args, &mut index, arg)?))
+                advertise_subnets.extend(parse_comma_separated(&parse_required_value(args, &mut index, arg)?))
+            }
+            "--advertise-domains" => {
+                advertise_domains.extend(parse_comma_separated(&parse_required_value(args, &mut index, arg)?))
             }
             unexpected => bail!("unknown argument for up: {unexpected}"),
         }
@@ -187,6 +192,7 @@ fn parse_up_command_args(args: &[String]) -> Result<UpCommand> {
         enrollment_token: enrollment_token.context("missing required --token")?,
         agent_name: agent_name.context("missing required --name")?,
         advertise_subnets,
+        advertise_domains,
     })
 }
 
@@ -239,12 +245,10 @@ fn main() {
                 let enrollment_token = env::args().nth(3).expect("missing enrollment token");
                 let agent_name = env::args().nth(4).expect("missing agent name");
                 let subnets_arg = env::args().nth(5).unwrap_or_default();
+                let domains_arg = env::args().nth(6).unwrap_or_default();
 
-                let advertise_subnets: Vec<String> = if subnets_arg.is_empty() {
-                    Vec::new()
-                } else {
-                    subnets_arg.split(',').map(|s| s.trim().to_owned()).collect()
-                };
+                let advertise_subnets: Vec<String> = parse_comma_separated(&subnets_arg);
+                let advertise_domains: Vec<String> = parse_comma_separated(&domains_arg);
 
                 let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
                 rt.block_on(async {
@@ -253,6 +257,7 @@ fn main() {
                         &enrollment_token,
                         &agent_name,
                         advertise_subnets,
+                        advertise_domains,
                     )
                     .await
                     {
@@ -278,6 +283,7 @@ fn main() {
                         &command.enrollment_token,
                         &command.agent_name,
                         command.advertise_subnets,
+                        command.advertise_domains,
                     )
                     .await
                 });
@@ -324,7 +330,29 @@ mod tests {
                 enrollment_token: "bootstrap-token".to_owned(),
                 agent_name: "site-a-agent".to_owned(),
                 advertise_subnets: vec!["10.0.0.0/8".to_owned(), "192.168.1.0/24".to_owned()],
+                advertise_domains: vec![],
             }
+        );
+    }
+
+    #[test]
+    fn parse_up_command_args_accepts_advertise_domains() {
+        let args = vec![
+            "--gateway".to_owned(),
+            "https://gateway.example.com:7171".to_owned(),
+            "--token".to_owned(),
+            "bootstrap-token".to_owned(),
+            "--name".to_owned(),
+            "site-a-agent".to_owned(),
+            "--advertise-domains".to_owned(),
+            "corp.example.com, lab.example.com".to_owned(),
+        ];
+
+        let parsed = parse_up_command_args(&args).expect("parse up args");
+
+        assert_eq!(
+            parsed.advertise_domains,
+            vec!["corp.example.com".to_owned(), "lab.example.com".to_owned()]
         );
     }
 


### PR DESCRIPTION
## Summary

Master already plumbs `tunnel_conf.advertise_domains` into the agent's `RouteAdvertise` control message and the gateway's domain-suffix routing table, but there was no way to set the list from the CLI — the field was config-file-only. This PR threads it through both CLI entry points: the `up` subcommand gains a `--advertise-domains` flag (parallel to `--advertise-routes`), and the legacy positional `enroll` command gains a 6th positional arg (`<gateway_url> <token> <agent_name> [subnets_csv] [domains_csv]`). An empty list from the caller preserves whatever is already in the config so an admin who manages domains via the config file does not lose them on re-enrollment from the CLI.