### PR TITLE
Install time certificate validation

### DIFF
--- a/package/WindowsManaged/Actions/CustomActions.cs
+++ b/package/WindowsManaged/Actions/CustomActions.cs
@@ -28,6 +28,8 @@ using System.Threading.Tasks;
 using WixSharp;
 using static DevolutionsGateway.Actions.WinAPI;
 using File = System.IO.File;
+using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
+using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
 
 namespace DevolutionsGateway.Actions
 {
@@ -1067,6 +1069,80 @@ namespace DevolutionsGateway.Actions
                 session.Log($"failed to set permissions: {e}");
                 return ActionResult.Failure;
             }
+        }
+
+        [CustomAction]
+        public static ActionResult SetCertificatePrivateKeyPermissions(Session session)
+        {
+            try
+            {
+                // Skip when the gateway will auto-generate a certificate — the selected system-store
+                // cert (if any) isn't actually being used in that case.
+                if (session.Get(GatewayProperties.configureWebApp) && session.Get(GatewayProperties.generateCertificate))
+                {
+                    session.Log("certificate is being auto-generated; skipping private key permission grant");
+                    return ActionResult.Success;
+                }
+
+                StoreLocation location = session.Get(GatewayProperties.certificateLocation);
+                StoreName storeName = session.Get(GatewayProperties.certificateStore);
+                string subjectName = session.Get(GatewayProperties.certificateName);
+
+                if (string.IsNullOrWhiteSpace(subjectName))
+                {
+                    session.Log("certificateName is empty; skipping private key permission grant");
+                    return ActionResult.Success;
+                }
+
+                // Use the same selection logic the Gateway service uses at startup. Fresh installs
+                // initialize gateway.json with tls_verify_strict=true (devolutions-gateway/src/config.rs
+                // generate_new), so we apply the strict filter here too.
+                CertificateSelection.Result selection = CertificateSelection.Select(
+                    location, storeName, subjectName, strictMode: true);
+
+                if (selection.Selected == null)
+                {
+                    if (selection.AllFiltered)
+                    {
+                        session.Log($"found {selection.MatchCount} certificate(s) matching subject {subjectName} in {location}\\{storeName}, but all were filtered out by strict-mode prerequisites (issues: {selection.FilteredReasons})");
+                    }
+                    else
+                    {
+                        session.Log($"no certificate matching subject {subjectName} found in {location}\\{storeName}");
+                    }
+                    return ActionResult.Success;
+                }
+
+                try
+                {
+                    X509Certificate2 certificate = selection.Selected;
+                    session.Log($"selected certificate {certificate.Thumbprint} (NotAfter={certificate.NotAfter:o}) for subject {subjectName}");
+
+                    if (PrivateKeyPermissions.HasNetworkServiceReadPermission(certificate))
+                    {
+                        session.Log("NETWORK SERVICE already has Read access to the certificate's private key");
+                        return ActionResult.Success;
+                    }
+
+                    if (PrivateKeyPermissions.TryGrantNetworkServiceReadPermission(certificate, out Exception grantError))
+                    {
+                        session.Log("granted NETWORK SERVICE Read access to the certificate's private key");
+                        return ActionResult.Success;
+                    }
+
+                    session.Log($"failed to grant NETWORK SERVICE Read access to the certificate's private key: {grantError}");
+                }
+                finally
+                {
+                    selection.Selected.Dispose();
+                }
+            }
+            catch (Exception e)
+            {
+                session.Log($"unexpected error setting certificate private key permissions: {e}");
+            }
+
+            return ActionResult.Success;
         }
 
         [CustomAction]

--- a/package/WindowsManaged/Actions/GatewayActions.cs
+++ b/package/WindowsManaged/Actions/GatewayActions.cs
@@ -355,12 +355,47 @@ internal static class GatewayActions
     );
 
     /// <summary>
+    /// Grant NETWORK SERVICE Read permission on the selected system store certificate's private key
+    /// </summary>
+    /// <remarks>
+    /// The Gateway service runs as NETWORK SERVICE and needs Read access on the private key file.
+    /// Best effort: failures are logged but do not fail the install. Only fires when a system-store
+    /// certificate is selected and the gateway is not auto-generating one.
+    /// </remarks>
+    private static readonly ElevatedManagedAction setCertificatePrivateKeyPermissions = new(
+        new Id($"CA.{nameof(setCertificatePrivateKeyPermissions)}"),
+        CustomActions.SetCertificatePrivateKeyPermissions,
+        Return.ignore,
+        When.After, new Step(configureCertificate.Id),
+        new Condition(string.Join(" AND ", new[]
+        {
+            "(NOT Installed OR REINSTALL)",
+            $"({GatewayProperties.configureGateway.Equal(true)})",
+            $"({GatewayProperties.certificateMode.Equal(Constants.CertificateMode.System)})",
+            $"({GatewayProperties.httpListenerScheme.Equal(Constants.HttpsProtocol)})",
+            $"({GatewayProperties.configureNgrok.Equal(false)})",
+        })),
+        Sequence.InstallExecuteSequence)
+    {
+        Execute = Execute.deferred,
+        Impersonate = false,
+        UsesProperties = UseProperties(new IWixProperty[]
+        {
+            GatewayProperties.certificateLocation,
+            GatewayProperties.certificateStore,
+            GatewayProperties.certificateName,
+            GatewayProperties.configureWebApp,
+            GatewayProperties.generateCertificate,
+        }),
+    };
+
+    /// <summary>
     /// Configure the public key using PowerShell
     /// </summary>
     private static readonly ElevatedManagedAction configurePublicKey = BuildConfigureAction(
         $"CA.{nameof(configurePublicKey)}",
         CustomActions.ConfigurePublicKey,
-        When.After, new Step(configureCertificate.Id),
+        When.After, new Step(setCertificatePrivateKeyPermissions.Id),
         new IWixProperty[]
         {
             GatewayProperties.publicKeyFile,
@@ -500,6 +535,7 @@ internal static class GatewayActions
         configureAccessUri,
         configureListeners,
         configureCertificate,
+        setCertificatePrivateKeyPermissions,
         configureNgrokListeners,
         configurePublicKey,
         configureWebApp,

--- a/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.Designer.cs
@@ -22,8 +22,6 @@ namespace WixSharpSetup.Dialogs
                 components.Dispose();
             }
 
-            //this.SelectedCertificate?.Dispose(); TODO: .net48
-
             base.Dispose(disposing);
         }
 
@@ -41,11 +39,9 @@ namespace WixSharpSetup.Dialogs
             this.middlePanel = new System.Windows.Forms.Panel();
             this.gbSystem = new System.Windows.Forms.GroupBox();
             this.pnlSystem = new System.Windows.Forms.TableLayoutPanel();
-            this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.lblResults = new System.Windows.Forms.Label();
             this.lblCertificateDescription = new System.Windows.Forms.Label();
             this.lblSelectedCertificate = new System.Windows.Forms.Label();
-            this.cmbSearchBy = new System.Windows.Forms.ComboBox();
-            this.label9 = new System.Windows.Forms.Label();
             this.cmbStoreLocation = new System.Windows.Forms.ComboBox();
             this.cmbStore = new System.Windows.Forms.ComboBox();
             this.label8 = new System.Windows.Forms.Label();
@@ -54,6 +50,7 @@ namespace WixSharpSetup.Dialogs
             this.txtSearch = new System.Windows.Forms.TextBox();
             this.butSearchCertificate = new System.Windows.Forms.Button();
             this.butViewCertificate = new System.Windows.Forms.Button();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.gbExternal = new System.Windows.Forms.GroupBox();
             this.pnlExternal = new System.Windows.Forms.TableLayoutPanel();
             this.butBrowsePrivateKeyFile = new DevolutionsGateway.Controls.FileBrowseButton();
@@ -80,12 +77,10 @@ namespace WixSharpSetup.Dialogs
             this.cancel = new System.Windows.Forms.Button();
             this.border1 = new System.Windows.Forms.Panel();
             this.ttCertVerify = new System.Windows.Forms.ToolTip(this.components);
-            this.panel1 = new System.Windows.Forms.Panel();
             this.contextMenuStrip1.SuspendLayout();
             this.middlePanel.SuspendLayout();
             this.gbSystem.SuspendLayout();
             this.pnlSystem.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             this.gbExternal.SuspendLayout();
             this.pnlExternal.SuspendLayout();
             this.topPanel.SuspendLayout();
@@ -140,11 +135,9 @@ namespace WixSharpSetup.Dialogs
             this.pnlSystem.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.pnlSystem.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 30F));
             this.pnlSystem.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.pnlSystem.Controls.Add(this.pictureBox1, 2, 6);
+            this.pnlSystem.Controls.Add(this.lblResults, 2, 4);
             this.pnlSystem.Controls.Add(this.lblCertificateDescription, 1, 6);
             this.pnlSystem.Controls.Add(this.lblSelectedCertificate, 0, 6);
-            this.pnlSystem.Controls.Add(this.cmbSearchBy, 1, 2);
-            this.pnlSystem.Controls.Add(this.label9, 0, 2);
             this.pnlSystem.Controls.Add(this.cmbStoreLocation, 1, 0);
             this.pnlSystem.Controls.Add(this.cmbStore, 1, 1);
             this.pnlSystem.Controls.Add(this.label8, 0, 3);
@@ -170,26 +163,30 @@ namespace WixSharpSetup.Dialogs
             this.pnlSystem.Size = new System.Drawing.Size(464, 205);
             this.pnlSystem.TabIndex = 9;
             // 
-            // pictureBox1
+            // lblResults
             // 
-            this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.pictureBox1.Location = new System.Drawing.Point(354, 154);
-            this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(24, 23);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            this.pictureBox1.TabIndex = 18;
-            this.pictureBox1.TabStop = false;
-            this.pictureBox1.Visible = false;
+            this.lblResults.AutoSize = true;
+            this.pnlSystem.SetColumnSpan(this.lblResults, 2);
+            this.lblResults.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.lblResults.Location = new System.Drawing.Point(354, 89);
+            this.lblResults.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
+            this.lblResults.Name = "lblResults";
+            this.lblResults.Size = new System.Drawing.Size(107, 21);
+            this.lblResults.TabIndex = 20;
+            this.lblResults.Text = "[Results]";
+            this.lblResults.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.lblResults.Visible = false;
             // 
             // lblCertificateDescription
             // 
             this.lblCertificateDescription.AutoSize = true;
             this.lblCertificateDescription.Dock = System.Windows.Forms.DockStyle.Top;
-            this.lblCertificateDescription.Location = new System.Drawing.Point(153, 154);
+            this.lblCertificateDescription.Location = new System.Drawing.Point(153, 125);
             this.lblCertificateDescription.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.lblCertificateDescription.Name = "lblCertificateDescription";
             this.lblCertificateDescription.Size = new System.Drawing.Size(195, 13);
             this.lblCertificateDescription.TabIndex = 17;
+            this.lblCertificateDescription.Text = "[NoCertificateSelected]";
             this.lblCertificateDescription.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblSelectedCertificate
@@ -198,38 +195,13 @@ namespace WixSharpSetup.Dialogs
             this.lblSelectedCertificate.Dock = System.Windows.Forms.DockStyle.Top;
             this.lblSelectedCertificate.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.lblSelectedCertificate.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.lblSelectedCertificate.Location = new System.Drawing.Point(3, 154);
+            this.lblSelectedCertificate.Location = new System.Drawing.Point(3, 125);
             this.lblSelectedCertificate.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.lblSelectedCertificate.Name = "lblSelectedCertificate";
             this.lblSelectedCertificate.Size = new System.Drawing.Size(144, 13);
             this.lblSelectedCertificate.TabIndex = 16;
             this.lblSelectedCertificate.Text = "[SelectedCertificate]";
             this.lblSelectedCertificate.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.lblSelectedCertificate.Visible = false;
-            // 
-            // cmbSearchBy
-            // 
-            this.pnlSystem.SetColumnSpan(this.cmbSearchBy, 3);
-            this.cmbSearchBy.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.cmbSearchBy.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.cmbSearchBy.FormattingEnabled = true;
-            this.cmbSearchBy.Location = new System.Drawing.Point(153, 61);
-            this.cmbSearchBy.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.cmbSearchBy.Name = "cmbSearchBy";
-            this.cmbSearchBy.Size = new System.Drawing.Size(308, 21);
-            this.cmbSearchBy.TabIndex = 3;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label9.Location = new System.Drawing.Point(3, 61);
-            this.label9.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(144, 21);
-            this.label9.TabIndex = 13;
-            this.label9.Text = "[SearchBy]";
-            this.label9.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // cmbStoreLocation
             // 
@@ -259,12 +231,12 @@ namespace WixSharpSetup.Dialogs
             // 
             this.label8.AutoSize = true;
             this.label8.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.label8.Location = new System.Drawing.Point(3, 90);
+            this.label8.Location = new System.Drawing.Point(3, 61);
             this.label8.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(144, 20);
             this.label8.TabIndex = 2;
-            this.label8.Text = "[Search]";
+            this.label8.Text = "Subject";
             this.label8.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // label7
@@ -295,7 +267,7 @@ namespace WixSharpSetup.Dialogs
             // 
             this.pnlSystem.SetColumnSpan(this.txtSearch, 3);
             this.txtSearch.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.txtSearch.Location = new System.Drawing.Point(153, 90);
+            this.txtSearch.Location = new System.Drawing.Point(153, 61);
             this.txtSearch.Margin = new System.Windows.Forms.Padding(3, 3, 3, 5);
             this.txtSearch.Name = "txtSearch";
             this.txtSearch.Size = new System.Drawing.Size(308, 20);
@@ -305,7 +277,7 @@ namespace WixSharpSetup.Dialogs
             // butSearchCertificate
             // 
             this.butSearchCertificate.AutoSize = true;
-            this.butSearchCertificate.Location = new System.Drawing.Point(153, 118);
+            this.butSearchCertificate.Location = new System.Drawing.Point(153, 89);
             this.butSearchCertificate.Name = "butSearchCertificate";
             this.butSearchCertificate.Size = new System.Drawing.Size(88, 23);
             this.butSearchCertificate.TabIndex = 5;
@@ -316,21 +288,32 @@ namespace WixSharpSetup.Dialogs
             // butViewCertificate
             // 
             this.butViewCertificate.AutoSize = true;
-            this.butViewCertificate.Location = new System.Drawing.Point(384, 154);
+            this.butViewCertificate.Enabled = false;
+            this.butViewCertificate.Location = new System.Drawing.Point(384, 125);
             this.butViewCertificate.Name = "butViewCertificate";
             this.butViewCertificate.Size = new System.Drawing.Size(77, 23);
             this.butViewCertificate.TabIndex = 6;
             this.butViewCertificate.Text = "[ViewButton]";
             this.butViewCertificate.UseVisualStyleBackColor = true;
-            this.butViewCertificate.Visible = false;
             this.butViewCertificate.Click += new System.EventHandler(this.butViewCertificate_Click);
+            // 
+            // panel1
+            // 
+            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pnlSystem.SetColumnSpan(this.panel1, 4);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.ForeColor = System.Drawing.SystemColors.ControlDark;
+            this.panel1.Location = new System.Drawing.Point(3, 118);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(458, 1);
+            this.panel1.TabIndex = 19;
             // 
             // gbExternal
             // 
             this.gbExternal.Controls.Add(this.pnlExternal);
             this.gbExternal.Location = new System.Drawing.Point(12, 34);
             this.gbExternal.Name = "gbExternal";
-            this.gbExternal.Size = new System.Drawing.Size(470, 164);
+            this.gbExternal.Size = new System.Drawing.Size(470, 224);
             this.gbExternal.TabIndex = 1;
             this.gbExternal.TabStop = false;
             this.gbExternal.Text = "[BrowseForACertificateToUse]";
@@ -362,7 +345,8 @@ namespace WixSharpSetup.Dialogs
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.pnlExternal.Size = new System.Drawing.Size(464, 145);
+            this.pnlExternal.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.pnlExternal.Size = new System.Drawing.Size(464, 205);
             this.pnlExternal.TabIndex = 8;
             // 
             // butBrowsePrivateKeyFile
@@ -384,6 +368,7 @@ namespace WixSharpSetup.Dialogs
             this.txtPrivateKeyFile.Name = "txtPrivateKeyFile";
             this.txtPrivateKeyFile.Size = new System.Drawing.Size(275, 20);
             this.txtPrivateKeyFile.TabIndex = 3;
+            this.txtPrivateKeyFile.TextChanged += new System.EventHandler(this.txtPrivateKeyFile_TextChanged);
             // 
             // txtCertificatePassword
             // 
@@ -396,6 +381,7 @@ namespace WixSharpSetup.Dialogs
             this.txtCertificatePassword.TabIndex = 2;
             this.txtCertificatePassword.UseSystemPasswordChar = true;
             this.txtCertificatePassword.Visible = false;
+            this.txtCertificatePassword.TextChanged += new System.EventHandler(this.txtCertificatePassword_TextChanged);
             // 
             // lblPrivateKeyFile
             // 
@@ -633,16 +619,6 @@ namespace WixSharpSetup.Dialogs
             this.border1.Size = new System.Drawing.Size(494, 1);
             this.border1.TabIndex = 14;
             // 
-            // panel1
-            // 
-            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.pnlSystem.SetColumnSpan(this.panel1, 4);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.panel1.Location = new System.Drawing.Point(3, 147);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(458, 1);
-            this.panel1.TabIndex = 19;
-            // 
             // CertificateDialog
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -659,7 +635,6 @@ namespace WixSharpSetup.Dialogs
             this.gbSystem.ResumeLayout(false);
             this.pnlSystem.ResumeLayout(false);
             this.pnlSystem.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.gbExternal.ResumeLayout(false);
             this.pnlExternal.ResumeLayout(false);
             this.pnlExternal.PerformLayout();
@@ -703,22 +678,20 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.ComboBox cmbStoreLocation;
         private System.Windows.Forms.ComboBox cmbStore;
         private System.Windows.Forms.TextBox txtSearch;
-        private System.Windows.Forms.ComboBox cmbSearchBy;
-        private System.Windows.Forms.Label label9;
         private System.Windows.Forms.Label lblSelectedCertificate;
         private System.Windows.Forms.Button butViewCertificate;
         private System.Windows.Forms.Label lblCertificateDescription;
         private System.Windows.Forms.GroupBox gbSystem;
         private System.Windows.Forms.GroupBox gbExternal;
-        private System.Windows.Forms.Label lblHint;
-        private FileBrowseButton butBrowsePrivateKeyFile;
-        private System.Windows.Forms.TextBox txtPrivateKeyFile;
         private System.Windows.Forms.TextBox txtCertificatePassword;
-        private System.Windows.Forms.Label lblPrivateKeyFile;
         private System.Windows.Forms.Label lblCertificatePassword;
         private System.Windows.Forms.Label lblCertificateFormats;
-        private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.ToolTip ttCertVerify;
         private System.Windows.Forms.Panel panel1;
+        private FileBrowseButton butBrowsePrivateKeyFile;
+        private System.Windows.Forms.TextBox txtPrivateKeyFile;
+        private System.Windows.Forms.Label lblPrivateKeyFile;
+        private System.Windows.Forms.Label lblHint;
+        private System.Windows.Forms.Label lblResults;
     }
 }

--- a/package/WindowsManaged/Dialogs/CertificateDialog.cs
+++ b/package/WindowsManaged/Dialogs/CertificateDialog.cs
@@ -1,19 +1,20 @@
+using DevolutionsGateway.Actions;
 using DevolutionsGateway.Dialogs;
+using DevolutionsGateway.Helpers;
 using DevolutionsGateway.Properties;
+using DevolutionsGateway.Resources;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.RegularExpressions;
+using System.Text;
 using System.Windows.Forms;
-using DevolutionsGateway.Helpers;
-using DevolutionsGateway.Resources;
 using WixSharp;
 using static DevolutionsGateway.Properties.Constants;
 using File = System.IO.File;
 using StoreLocation = System.Security.Cryptography.X509Certificates.StoreLocation;
 using StoreName = System.Security.Cryptography.X509Certificates.StoreName;
-using DevolutionsGateway.Actions;
 
 namespace WixSharpSetup.Dialogs;
 
@@ -35,13 +36,20 @@ public partial class CertificateDialog : GatewayDialog
 
         label1.MakeTransparentOn(banner);
         label2.MakeTransparentOn(banner);
+    }
 
-        this.pictureBox1.Image =
-            StockIcon.GetStockIcon(StockIcon.SIID_WARNING, StockIcon.SHGSI_SMALLICON).ToBitmap();
+    private enum ValidationOutcome
+    {
+        Ok,
+        KeyAccessOnly,
+        Warnings,
     }
 
     public override bool DoValidate()
     {
+        ValidationOutcome outcome;
+        string[] messages;
+
         if (this.UseExternalCertificate)
         {
             if (string.IsNullOrWhiteSpace(this.txtCertificateFile.Text) ||
@@ -70,6 +78,8 @@ public partial class CertificateDialog : GatewayDialog
                     return false;
                 }
             }
+
+            outcome = ValidateExternalCertificate(out messages);
         }
         else
         {
@@ -78,9 +88,42 @@ public partial class CertificateDialog : GatewayDialog
                 ShowValidationError(I18n(Strings.YouMustSelectACertificateFromTheSystemCertificateStore));
                 return false;
             }
+
+            outcome = ValidateSystemCertificate(out messages);
         }
 
-        return true;
+        switch (outcome)
+        {
+            case ValidationOutcome.Ok:
+                return true;
+
+            case ValidationOutcome.KeyAccessOnly:
+                MessageBox.Show(
+                    messages[0],
+                    this.Localize("[GatewayDlg_Title]"),
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Information);
+                return true;
+
+            case ValidationOutcome.Warnings:
+            default:
+                StringBuilder sb = new();
+                sb.AppendLine(I18n(Strings.ValidationProducedWarnings));
+                sb.AppendLine("");
+                for (int i = 0; i < messages.Length; i++)
+                {
+                    sb.AppendLine($"{i + 1}. {messages[i]}");
+                }
+                sb.AppendLine("");
+                sb.AppendLine(I18n(Strings.DoYouWantToProceedAnyway));
+
+                return MessageBox.Show(
+                    sb.ToString(),
+                    this.Localize("[GatewayDlg_Title]"),
+                    MessageBoxButtons.YesNo,
+                    MessageBoxIcon.Warning,
+                    MessageBoxDefaultButton.Button2) == DialogResult.Yes;
+        }
     }
 
     public override void FromProperties()
@@ -93,23 +136,13 @@ public partial class CertificateDialog : GatewayDialog
         this.txtCertificatePassword.Text = properties.CertificatePassword;
         this.cmbStoreLocation.SetSelected(properties.CertificateLocation);
         this.cmbStore.SetSelected(properties.CertificateStore);
-        this.cmbSearchBy.SetSelected(properties.CertificateFindType);
         this.txtSearch.Text = properties.CertificateSearchText;
 
-        if (this.UseSystemCertificate)
+        if (this.UseSystemCertificate && !string.IsNullOrWhiteSpace(properties.CertificateSearchText))
         {
             try
             {
-                X509Certificate2Collection certificates = this.SearchCertificate(
-                    (StoreLocation) this.cmbStoreLocation.SelectedIndex + 1,
-                    this.cmbStore.Selected<StoreName>(),
-                    CertificateFindType.Thumbprint,
-                    properties.CertificateThumbprint);
-
-                if (certificates?.Count == 1)
-                {
-                    this.SetSelectedCertificate(certificates[0]);
-                }
+                this.SearchCertificate(false);
             }
             catch // Failed to restore state, don't crash
             {
@@ -146,10 +179,8 @@ public partial class CertificateDialog : GatewayDialog
             properties.CertificateLocation = this.cmbStoreLocation.Selected<StoreLocation>();
             properties.CertificateStore = this.cmbStore.Selected<StoreName>();
             properties.CertificateName = this.SelectedCertificate?.GetNameInfo(X509NameType.SimpleName, false);
-            properties.CertificateThumbprint = this.SelectedCertificate?.Thumbprint;
         }
 
-        properties.CertificateFindType = this.cmbSearchBy.Selected<CertificateFindType>();
         properties.CertificateSearchText = this.txtSearch.Text;
 
         return true;
@@ -170,10 +201,8 @@ public partial class CertificateDialog : GatewayDialog
         this.cmbStore.Source<StoreName>(this.MsiRuntime);
         this.cmbStore.SetSelected(StoreName.My);
 
-        this.cmbSearchBy.Source<CertificateFindType>(this.MsiRuntime);
-        this.cmbSearchBy.SetSelected(CertificateFindType.Thumbprint);
-
-        this.ttCertVerify.SetToolTip(this.pictureBox1, I18n(Strings.CertificateCouldNotBeVerified));
+        this.FormClosed += (s, e) => this.SelectedCertificate?.Dispose();
+        this.lblResults.Text = string.Empty;
 
         base.OnLoad(sender, e);
     }
@@ -272,6 +301,16 @@ public partial class CertificateDialog : GatewayDialog
         this.SetControlStates();
     }
 
+    private void txtCertificatePassword_TextChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+
+    private void txtPrivateKeyFile_TextChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
+    }
+
     private void cmbCertificateSource_SelectedIndexChanged(object sender, EventArgs e)
     {
         this.SetControlStates();
@@ -282,84 +321,180 @@ public partial class CertificateDialog : GatewayDialog
         this.SetControlStates();
     }
 
-    private X509Certificate2Collection SearchCertificate(StoreLocation location, StoreName storeName,
-        CertificateFindType findType, string findValue)
-    {
-        X509Store store = null;
-
-        try
-        {
-            store = new X509Store(storeName, location);
-            store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
-
-            X509FindType x509FindType = findType == CertificateFindType.Thumbprint
-                ? X509FindType.FindByThumbprint
-                : X509FindType.FindBySubjectName;
-
-            if (x509FindType == X509FindType.FindByThumbprint)
-            {
-                findValue = Regex.Replace(findValue.ToUpper(), @"[^0-9A-F]+", string.Empty);
-            }
-
-            return store.Certificates.Find(x509FindType, findValue, false);
-        }
-        finally
-        {
-            store?.Close();
-        }
-    }
-
-    private void butSearchCertificate_Click(object sender, EventArgs e)
+    private void SearchCertificate(bool userAction)
     {
         try
         {
-            X509Certificate2Collection certificates = SearchCertificate(
-                (StoreLocation) this.cmbStoreLocation.SelectedIndex + 1,
+            CertificateSelection.Result selection = CertificateSelection.Select(
+                (StoreLocation)this.cmbStoreLocation.SelectedIndex + 1,
                 this.cmbStore.Selected<StoreName>(),
-                this.cmbSearchBy.Selected<CertificateFindType>(),
-                this.txtSearch.Text);
-            
-            if (certificates.Count == 0)
-            {
-                this.SetSelectedCertificate(null);
+                this.txtSearch.Text,
+                strictMode: true);
 
-                MessageBox.Show(I18n(Strings.NoMatchingCertificatesFound), I18n("GatewayDlg_Title"));
-            }
-            else if (certificates.Count == 1)
+            this.lblResults.Visible = true;
+            this.lblResults.Text = string.Format(
+                selection.MatchCount == 1 ? I18n(Strings.SearchResultSingular) : I18n(Strings.SearchResultPlural),
+                selection.MatchCount);
+
+            if (selection.Selected != null)
             {
-                this.SetSelectedCertificate(certificates[0]);
+                this.SetSelectedCertificate(selection.Selected);
             }
             else
             {
-                X509Certificate2Collection selection = X509Certificate2UI.SelectFromCollection(certificates,
-                    I18n("GatewayDlg_Title"),
-                    I18n(Strings.SelectTheCertificateToUse), X509SelectionFlag.SingleSelection, this.Handle);
+                this.SetSelectedCertificate(null);
 
-                if (selection.Count > 0)
+                if (userAction)
                 {
-                    this.SetSelectedCertificate(selection[0]);
+                    if (selection.AllFiltered)
+                    {
+                        StringBuilder sb = new();
+                        sb.AppendLine(string.Format(I18n(Strings.CertificatesFoundButUnusable), selection.MatchCount));
+                        sb.AppendLine("");
+                        DisplayEnum<CertificateIssues> display = new DisplayEnum<CertificateIssues>(this.MsiRuntime);
+                        display.Items
+                            .Where(i => i.Value != CertificateIssues.None)
+                            .Where(i => selection.FilteredReasons.HasFlag(i.Value))
+                            .Select((i, index) => $"{index + 1}. {i.Name}")
+                            .ForEach(sb.AppendLine);
+
+                        ShowValidationErrorString(sb.ToString());
+                    }
+                    else
+                    {
+                        ShowValidationErrorString(I18n(Strings.NoMatchingCertificatesFound));
+                    }
                 }
             }
         }
         catch (Exception exception)
         {
-            ShowValidationErrorString(string.Format(I18n(Strings.AnUnexpectedErrorOccurredAccessingTheSystemCertificateStoreX), exception));
+            if (userAction)
+            {
+                ShowValidationErrorString(string.Format(I18n(Strings.AnUnexpectedErrorOccurredAccessingTheSystemCertificateStoreX), exception));
+            }
         }
+    }
+
+    private void butSearchCertificate_Click(object sender, EventArgs e)
+    {
+        this.SearchCertificate(true);
     }
 
     private void SetSelectedCertificate(X509Certificate2 certificate)
     {
+        this.SelectedCertificate?.Dispose();
+
         this.SelectedCertificate = certificate;
 
-        this.lblCertificateDescription.Text = string.Empty;
-        this.pictureBox1.Visible = false;
-        this.lblSelectedCertificate.Visible = this.lblCertificateDescription.Visible = this.butViewCertificate.Visible = this.SelectedCertificate is not null;
+        this.butViewCertificate.Enabled = this.SelectedCertificate is not null;
+        this.lblCertificateDescription.Text = I18n(Strings.NoCertificateSelected);
 
-        if (this.SelectedCertificate is not null)
+        if (this.SelectedCertificate is null)
         {
-            this.pictureBox1.Visible = !this.SelectedCertificate.Verify();
-            this.lblCertificateDescription.Text = this.SelectedCertificate?.GetNameInfo(X509NameType.SimpleName, false);
+            return;
         }
+
+        this.lblCertificateDescription.Text = this.SelectedCertificate.GetNameInfo(X509NameType.SimpleName, false);
+    }
+
+    private ValidationOutcome ValidateExternalCertificate(out string[] errors)
+    {
+        string certificateFile = this.txtCertificateFile.Text.Trim();
+        string certificatePassword = this.NeedsPassword() ? this.txtCertificatePassword.Text : null;
+        List<string> messages = [];
+        X509Certificate2Collection certificates = null;
+
+        try
+        {
+            if (!CertificateChain.TryLoad(certificateFile, certificatePassword, out certificates, out Exception error))
+            {
+                errors = [string.Format(I18n(Strings.CertificateFileCouldNotBeRead), error.Message.Trim())];
+                return ValidationOutcome.Warnings;
+            }
+
+            if (CertificateChain.FindLeaf(certificates) is not X509Certificate2 leaf)
+            {
+                errors = [I18n(Strings.NoUsableCertificateFoundInFile)];
+                return ValidationOutcome.Warnings;
+            }
+
+            if (CertificateChain.IsCertificateAuthority(leaf))
+            {
+                errors = [I18n(Strings.CertificateIsCaNotServer)];
+                return ValidationOutcome.Warnings;
+            }
+
+            if (CertificateChain.IsSelfSigned(leaf))
+            {
+                messages.Add(I18n(Strings.CertificateIsSelfSigned));
+            }
+            else
+            {
+                CertificateChainStatus chainStatus = CertificateChain.CheckChain(leaf, certificates);
+                if (chainStatus != CertificateChainStatus.Ok)
+                {
+                    messages.Add(new DisplayEnum<CertificateChainStatus>(this.MsiRuntime)
+                        .Items.First(i => i.Value == chainStatus).Name);
+                }
+            }
+
+            CertificateIssues issues = CertificateChain.CheckCertificate(leaf);
+            DisplayEnum<CertificateIssues> display = new DisplayEnum<CertificateIssues>(this.MsiRuntime);
+            display.Items
+                .Where(i => i.Value != CertificateIssues.None)
+                .Where(i => issues.HasFlag(i.Value))
+                .Select(i => i.Name)
+                .ForEach(messages.Add);
+
+            errors = messages.ToArray();
+            return messages.None() ? ValidationOutcome.Ok : ValidationOutcome.Warnings;
+        }
+        finally
+        {
+            CertificateChain.DisposeAll(certificates);
+        }
+    }
+
+    private ValidationOutcome ValidateSystemCertificate(out string[] errors)
+    {
+        bool valid = this.SelectedCertificate.Verify();
+        CertificateIssues issues = CertificateChain.CheckCertificate(this.SelectedCertificate);
+        bool keyRead = PrivateKeyPermissions.HasNetworkServiceReadPermission(this.SelectedCertificate);
+
+        if (valid && issues == CertificateIssues.None)
+        {
+            if (keyRead)
+            {
+                errors = Array.Empty<string>();
+                return ValidationOutcome.Ok;
+            }
+
+            errors = [I18n(Strings.PrivateKeyPermissionWillBeGranted)];
+            return ValidationOutcome.KeyAccessOnly;
+        }
+
+        List<string> messages = [];
+
+        if (!valid)
+        {
+            messages.Add(I18n(Strings.CertificateCouldNotBeVerified));
+        }
+
+        DisplayEnum<CertificateIssues> display = new DisplayEnum<CertificateIssues>(this.MsiRuntime);
+        display.Items
+            .Where(i => i.Value != CertificateIssues.None)
+            .Where(i => issues.HasFlag(i.Value))
+            .Select(i => i.Name)
+            .ForEach(messages.Add);
+
+        if (!keyRead)
+        {
+            messages.Add(I18n(Strings.PrivateKeyPermissionWillBeGranted));
+        }
+
+        errors = messages.ToArray();
+        return ValidationOutcome.Warnings;
     }
 
     private void butViewCertificate_Click(object sender, EventArgs e)

--- a/package/WindowsManaged/Helpers/CertificateChain.cs
+++ b/package/WindowsManaged/Helpers/CertificateChain.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace DevolutionsGateway.Helpers
+{
+    internal enum CertificateChainStatus
+    {
+        /// Chain is complete from the file alone (or self-signed). No warning needed.
+        Ok,
+        /// Chain builds only because the system store has the intermediate. Soft warning:
+        /// the gateway's server.crt won't include it, so clients on other machines may fail.
+        SystemStoreRequired,
+        /// Chain uses a weak signature algorithm (typically MD5 or SHA-1).
+        /// Modern TLS clients are likely to reject the certificate.
+        WeakSignature,
+        /// Chain anchors at a root that is not in the system's Trusted Root store.
+        /// Likely a private CA — clients without that root installed will fail to verify.
+        UntrustedRoot,
+        /// PartialChain even with the system store. Hard warning: no client can verify this cert.
+        Incomplete,
+        /// A certificate in the chain has an invalid signature.
+        /// The chain may have been tampered with or is corrupted.
+        InvalidSignature,
+        /// The issuer is in the system's Untrusted Certificates store (actively distrusted).
+        ExplicitDistrust,
+        /// An exception prevented chain validation from completing.
+        /// Distinct from Ok — the caller should treat this as "unable to determine."
+        ValidationFailed,
+    }
+
+    [Flags]
+    internal enum CertificateIssues
+    {
+        None = 0,
+        /// Certificate validity period has not started yet.
+        NotYetValid = 1 << 0,
+        /// Certificate has expired.
+        Expired = 1 << 1,
+        /// Certificate is valid but expires within the warning threshold.
+        ExpiringSoon = 1 << 2,
+        /// Extended Key Usage extension is absent or does not include serverAuth (1.3.6.1.5.5.7.3.1).
+        /// The gateway rejects this in strict mode; many TLS clients require it unconditionally.
+        MissingServerAuthEku = 1 << 3,
+        /// Subject Alternative Name extension is absent.
+        /// The gateway rejects this in strict mode; all modern TLS clients require it.
+        MissingSubjectAlternativeName = 1 << 4,
+    }
+
+    internal static class CertificateChain
+    {
+        private const string PemCertHeader = "-----BEGIN CERTIFICATE-----";
+        private const string PemCertFooter = "-----END CERTIFICATE-----";
+        private const string ServerAuthOid = "1.3.6.1.5.5.7.3.1";
+        private const string SubjectAlternativeNameOid = "2.5.29.17";
+        private const string ExtendedKeyUsageOid = "2.5.29.37";
+        private const int ExpiringSoonDays = 30;
+
+        /// <summary>
+        /// Disposes every certificate in the collection. Safe to call with a null collection.
+        /// Callers of TryLoad must invoke this once validation is complete to avoid leaking
+        /// transient key files into %APPDATA%\Microsoft\Crypto\Keys.
+        /// </summary>
+        internal static void DisposeAll(X509Certificate2Collection certificates)
+        {
+            if (certificates == null)
+            {
+                return;
+            }
+
+            foreach (X509Certificate2 cert in certificates)
+            {
+                cert?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Loads all certificates from a file. Handles PFX, PEM chains, and DER.
+        /// Callers must pass the returned collection to <see cref="DisposeAll"/> when done.
+        /// </summary>
+        internal static bool TryLoad(string path, string password, out X509Certificate2Collection certificates, out Exception error)
+        {
+            certificates = null;
+            error = null;
+
+            try
+            {
+                string ext = Path.GetExtension(path);
+                bool isPfx = string.Equals(ext, ".pfx", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(ext, ".p12", StringComparison.OrdinalIgnoreCase);
+
+                if (isPfx)
+                {
+                    certificates = ImportPfx(path, password);
+                    return true;
+                }
+
+                byte[] bytes = File.ReadAllBytes(path);
+                string text = TryReadUtf8(bytes);
+
+                if (text != null && text.Contains(PemCertHeader))
+                {
+                    certificates = LoadPemChain(text);
+                    return true;
+                }
+
+                certificates = new X509Certificate2Collection(new X509Certificate2(bytes));
+                return true;
+            }
+            catch (Exception e)
+            {
+                error = e;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns the leaf certificate (non-CA) from a collection, or the first cert if none qualifies.
+        /// Returns null if the collection is null, empty, or an error occurs.
+        /// </summary>
+        internal static X509Certificate2 FindLeaf(X509Certificate2Collection certificates)
+        {
+            try
+            {
+                if (certificates == null || certificates.Count == 0)
+                {
+                    return null;
+                }
+
+                return certificates.Cast<X509Certificate2>().FirstOrDefault(c => !IsCa(c))
+                       ?? certificates.Cast<X509Certificate2>().First();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Returns true when the certificate is self-signed (subject == issuer by raw bytes).
+        /// Returns false if the certificate is null or an error occurs.
+        /// </summary>
+        internal static bool IsSelfSigned(X509Certificate2 certificate)
+        {
+            try
+            {
+                if (certificate == null)
+                {
+                    return false;
+                }
+
+                return certificate.SubjectName.RawData.SequenceEqual(certificate.IssuerName.RawData);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the certificate is a CA certificate (BasicConstraints CA=true).
+        /// Returns false if the certificate is null, lacks BasicConstraints, or an error occurs.
+        /// </summary>
+        internal static bool IsCertificateAuthority(X509Certificate2 certificate)
+        {
+            try
+            {
+                if (certificate == null)
+                {
+                    return false;
+                }
+
+                return IsCa(certificate);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Evaluates the chain completeness for a leaf certificate against the certs in the file.
+        /// Returns Ok when the leaf is null (nothing to validate). Returns ValidationFailed when an
+        /// exception is thrown during chain building, so callers can distinguish a clean build from
+        /// an indeterminate outcome.
+        /// </summary>
+        internal static CertificateChainStatus CheckChain(X509Certificate2 leaf, X509Certificate2Collection fileCertificates)
+        {
+            if (leaf == null)
+            {
+                return CertificateChainStatus.Ok;
+            }
+
+            try
+            {
+                using (X509Chain chain = new X509Chain())
+                {
+                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    chain.ChainPolicy.ExtraStore.AddRange(fileCertificates);
+                    chain.Build(leaf);
+
+                    // Order is severity-first: a fundamental chain failure or a tampered/distrusted
+                    // chain takes precedence over weaker issues like an untrusted root or weak hash.
+                    if (HasStatus(chain, X509ChainStatusFlags.PartialChain))
+                    {
+                        return CertificateChainStatus.Incomplete;
+                    }
+
+                    if (HasStatus(chain, X509ChainStatusFlags.NotSignatureValid))
+                    {
+                        return CertificateChainStatus.InvalidSignature;
+                    }
+
+                    if (HasStatus(chain, X509ChainStatusFlags.ExplicitDistrust))
+                    {
+                        return CertificateChainStatus.ExplicitDistrust;
+                    }
+
+                    if (HasStatus(chain, X509ChainStatusFlags.UntrustedRoot))
+                    {
+                        return CertificateChainStatus.UntrustedRoot;
+                    }
+
+                    if (HasStatus(chain, X509ChainStatusFlags.HasWeakSignature))
+                    {
+                        return CertificateChainStatus.WeakSignature;
+                    }
+
+                    if (IntermediatesFromSystemStore(chain, fileCertificates))
+                    {
+                        return CertificateChainStatus.SystemStoreRequired;
+                    }
+                }
+
+                return CertificateChainStatus.Ok;
+            }
+            catch
+            {
+                return CertificateChainStatus.ValidationFailed;
+            }
+        }
+
+        private static bool HasStatus(X509Chain chain, X509ChainStatusFlags flag)
+        {
+            return chain.ChainStatus.Any(s => s.Status.HasFlag(flag));
+        }
+
+        /// <summary>
+        /// Checks a leaf certificate for common issues that will cause the gateway or TLS clients to reject it.
+        /// Returns None if the certificate is null or an error occurs, to avoid false positives.
+        /// </summary>
+        internal static CertificateIssues CheckCertificate(X509Certificate2 certificate)
+        {
+            if (certificate == null)
+            {
+                return CertificateIssues.None;
+            }
+
+            try
+            {
+                CertificateIssues issues = CertificateIssues.None;
+                DateTime now = DateTime.Now;
+
+                if (now < certificate.NotBefore)
+                {
+                    issues |= CertificateIssues.NotYetValid;
+                }
+                else if (now > certificate.NotAfter)
+                {
+                    issues |= CertificateIssues.Expired;
+                }
+                else if (certificate.NotAfter < now.AddDays(ExpiringSoonDays))
+                {
+                    issues |= CertificateIssues.ExpiringSoon;
+                }
+
+                bool hasServerAuthEku = false;
+                bool hasEkuExtension = false;
+                bool hasSan = false;
+
+                foreach (X509Extension ext in certificate.Extensions)
+                {
+                    switch (ext.Oid.Value)
+                    {
+                        case ExtendedKeyUsageOid:
+                            hasEkuExtension = true;
+                            X509EnhancedKeyUsageExtension eku = ext as X509EnhancedKeyUsageExtension;
+                            if (eku != null)
+                            {
+                                foreach (Oid usage in eku.EnhancedKeyUsages)
+                                {
+                                    if (usage.Value == ServerAuthOid)
+                                    {
+                                        hasServerAuthEku = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            break;
+
+                        case SubjectAlternativeNameOid:
+                            hasSan = true;
+                            break;
+                    }
+                }
+
+                // Absence of the EKU extension entirely is treated the same as EKU present
+                // but serverAuth missing: the gateway flags both cases identically.
+                if (!hasEkuExtension || !hasServerAuthEku)
+                {
+                    issues |= CertificateIssues.MissingServerAuthEku;
+                }
+
+                if (!hasSan)
+                {
+                    issues |= CertificateIssues.MissingSubjectAlternativeName;
+                }
+
+                return issues;
+            }
+            catch
+            {
+                return CertificateIssues.None;
+            }
+        }
+
+        private static bool IntermediatesFromSystemStore(X509Chain chain, X509Certificate2Collection fileCertificates)
+        {
+            HashSet<string> fileThumbprints = new HashSet<string>(
+                fileCertificates.Cast<X509Certificate2>().Select(c => c.Thumbprint),
+                StringComparer.OrdinalIgnoreCase);
+
+            // ChainElements[0] is the leaf, ChainElements[last] is the root.
+            // Only intermediates (everything between) could have come from the system store.
+            for (int i = 1; i < chain.ChainElements.Count - 1; i++)
+            {
+                if (!fileThumbprints.Contains(chain.ChainElements[i].Certificate.Thumbprint))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static X509Certificate2Collection ImportPfx(string path, string password)
+        {
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                // Null and empty string map to different Win32 PFXImportCertStore calls.
+                // Try null first (most common), then empty string as a fallback for PFX files
+                // that were created with an explicit empty password.
+                try
+                {
+                    X509Certificate2Collection col = new X509Certificate2Collection();
+                    col.Import(path, null, X509KeyStorageFlags.DefaultKeySet);
+                    return col;
+                }
+                catch
+                {
+                    X509Certificate2Collection col = new X509Certificate2Collection();
+                    col.Import(path, string.Empty, X509KeyStorageFlags.DefaultKeySet);
+                    return col;
+                }
+            }
+
+            X509Certificate2Collection result = new X509Certificate2Collection();
+            result.Import(path, password, X509KeyStorageFlags.DefaultKeySet);
+            return result;
+        }
+
+        private static X509Certificate2Collection LoadPemChain(string pem)
+        {
+            X509Certificate2Collection col = new X509Certificate2Collection();
+            int pos = 0;
+
+            while (true)
+            {
+                int start = pem.IndexOf(PemCertHeader, pos, StringComparison.Ordinal);
+                if (start < 0)
+                {
+                    break;
+                }
+
+                int end = pem.IndexOf(PemCertFooter, start, StringComparison.Ordinal);
+                if (end < 0)
+                {
+                    break;
+                }
+
+                end += PemCertFooter.Length;
+
+                string body = pem.Substring(start + PemCertHeader.Length, end - PemCertFooter.Length - start - PemCertHeader.Length);
+                byte[] der = Convert.FromBase64String(body.Trim());
+                col.Add(new X509Certificate2(der));
+
+                pos = end;
+            }
+
+            return col;
+        }
+
+        private static bool IsCa(X509Certificate2 certificate)
+        {
+            foreach (X509Extension ext in certificate.Extensions)
+            {
+                if (ext is X509BasicConstraintsExtension bc)
+                {
+                    return bc.CertificateAuthority;
+                }
+            }
+
+            return false;
+        }
+
+        private static string TryReadUtf8(byte[] bytes)
+        {
+            try
+            {
+                return Encoding.UTF8.GetString(bytes);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/package/WindowsManaged/Helpers/CertificateSelection.cs
+++ b/package/WindowsManaged/Helpers/CertificateSelection.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace DevolutionsGateway.Helpers
+{
+    /// <summary>
+    /// Replicates the Devolutions Gateway TLS certificate selection algorithm
+    /// (<c>devolutions-gateway/src/tls.rs</c>). Used so installer-side cert selection — both in
+    /// the UI and in deferred custom actions — picks the same certificate the Gateway service
+    /// will pick at startup.
+    /// </summary>
+    internal static class CertificateSelection
+    {
+        /// <summary>
+        /// Outcome of a <see cref="Select"/> call.
+        /// </summary>
+        internal sealed class Result
+        {
+            /// <summary>
+            /// The certificate the Gateway would select, or <c>null</c> when no certificate
+            /// qualified (either nothing matched the subject substring, or every match was
+            /// filtered out by the prerequisites).
+            /// </summary>
+            internal X509Certificate2 Selected { get; set; }
+
+            /// <summary>
+            /// Total number of certificates whose subject simple-name matched the search
+            /// string before any filtering. Zero when nothing matched at all.
+            /// </summary>
+            internal int MatchCount { get; set; }
+
+            /// <summary>
+            /// Number of matched certificates that were filtered out by the prerequisites.
+            /// </summary>
+            internal int FilteredCount { get; set; }
+
+            /// <summary>
+            /// Bitwise union of the issues that caused certificates to be filtered out.
+            /// Together with <see cref="AllFiltered"/>, this explains why a search returned
+            /// candidates but no usable certificate.
+            /// </summary>
+            internal CertificateIssues FilteredReasons { get; set; }
+
+            /// <summary>
+            /// Whether strict-mode filtering (requires <c>serverAuth</c> EKU and a SAN) was applied.
+            /// </summary>
+            internal bool StrictMode { get; set; }
+
+            /// <summary>
+            /// True when matches existed but every match was filtered out. Lets the caller
+            /// distinguish "no matches" (cert just isn't there) from "matches but unusable"
+            /// (cert exists but doesn't meet prerequisites — the user-facing warning case).
+            /// </summary>
+            internal bool AllFiltered => this.Selected == null && this.MatchCount > 0;
+        }
+
+        /// <summary>
+        /// Performs the same selection the Gateway performs at startup:
+        /// <list type="number">
+        ///   <item>Open the requested store.</item>
+        ///   <item>Find all certificates whose subject simple-name contains <paramref name="subjectName"/>
+        ///         (case-insensitive substring, matching Windows <c>CERT_FIND_SUBJECT_STR</c>).</item>
+        ///   <item>Reject not-yet-valid certificates. In strict mode, also reject certificates
+        ///         missing the <c>serverAuth</c> EKU or a Subject Alternative Name extension.</item>
+        ///   <item>Sort the remainder by <c>NotAfter</c> descending and take the first.</item>
+        /// </list>
+        /// The Gateway's private-key-accessibility filter (skip a cert whose key the service
+        /// cannot acquire) is intentionally NOT replicated. The installer runs elevated and may
+        /// need to operate on a cert even when NETWORK SERVICE cannot read its key today —
+        /// which is exactly the case we're often here to fix.
+        ///
+        /// Ownership: the caller owns <see cref="Result.Selected"/> and must dispose it. All
+        /// filtered and unselected candidates are disposed internally.
+        /// </summary>
+        internal static Result Select(
+            StoreLocation location,
+            StoreName storeName,
+            string subjectName,
+            bool strictMode)
+        {
+            Result result = new Result { StrictMode = strictMode };
+
+            if (string.IsNullOrWhiteSpace(subjectName))
+            {
+                return result;
+            }
+
+            X509Certificate2Collection matches;
+
+            try
+            {
+                using X509Store store = new X509Store(storeName, location);
+                store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
+                matches = store.Certificates.Find(X509FindType.FindBySubjectName, subjectName, validOnly: false);
+            }
+            catch
+            {
+                return result;
+            }
+
+            CertificateIssues disqualifiers = strictMode
+                ? CertificateIssues.NotYetValid
+                  | CertificateIssues.MissingServerAuthEku
+                  | CertificateIssues.MissingSubjectAlternativeName
+                : CertificateIssues.NotYetValid;
+
+            List<X509Certificate2> kept = new List<X509Certificate2>();
+
+            foreach (X509Certificate2 candidate in matches)
+            {
+                CertificateIssues disqualifying = CertificateChain.CheckCertificate(candidate) & disqualifiers;
+
+                if (disqualifying != CertificateIssues.None)
+                {
+                    result.FilteredReasons |= disqualifying;
+                    candidate.Dispose();
+                    continue;
+                }
+
+                kept.Add(candidate);
+            }
+
+            result.MatchCount = matches.Count;
+            result.FilteredCount = matches.Count - kept.Count;
+            result.Selected = kept.OrderByDescending(c => c.NotAfter).FirstOrDefault();
+
+            foreach (X509Certificate2 candidate in kept)
+            {
+                if (!ReferenceEquals(candidate, result.Selected))
+                {
+                    candidate.Dispose();
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/package/WindowsManaged/Helpers/PrivateKeyPermissions.cs
+++ b/package/WindowsManaged/Helpers/PrivateKeyPermissions.cs
@@ -1,0 +1,225 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.AccessControl;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+
+namespace DevolutionsGateway.Helpers
+{
+    internal static class PrivateKeyPermissions
+    {
+        /// <summary>
+        /// Returns true if the NETWORK SERVICE account has an explicit Allow rule granting Read
+        /// permission on the certificate's private key file. Returns false if the key file cannot
+        /// be located, the ACL cannot be read, or no such Allow rule is present.
+        /// </summary>
+        /// <remarks>
+        /// This is an approximation of effective access — it does not honor:
+        /// <list type="bullet">
+        ///   <item>Explicit Deny rules on the NETWORK SERVICE SID (which would override an Allow
+        ///   and block read access).</item>
+        ///   <item>Permissions granted via group membership (NETWORK SERVICE is a member of
+        ///   Authenticated Users and Users; if either group has Read on this file, NETWORK SERVICE
+        ///   effectively does too — but this method returns false).</item>
+        /// </list>
+        /// Acceptable for the use case this helper serves: cert key files in
+        /// <c>%ProgramData%\Microsoft\Crypto\Keys\</c> default to explicit per-identity ACLs without
+        /// group inheritance for NETWORK SERVICE and without Deny rules, so the approximation is
+        /// accurate in practice. A false negative leads to a redundant idempotent grant via
+        /// <see cref="TryGrantNetworkServiceReadPermission"/>. A false positive (effective Deny we
+        /// can't see) surfaces as a service start-time failure rather than at install time.
+        /// </remarks>
+        internal static bool HasNetworkServiceReadPermission(X509Certificate2 certificate)
+        {
+            if (!TryGetKeyFilePath(certificate, out string keyFilePath))
+            {
+                return false;
+            }
+
+            try
+            {
+                FileSecurity security = new FileInfo(keyFilePath).GetAccessControl();
+                SecurityIdentifier networkService = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null);
+
+                AuthorizationRuleCollection rules = security.GetAccessRules(includeExplicit: true, includeInherited: true, typeof(SecurityIdentifier));
+
+                return rules
+                    .Cast<FileSystemAccessRule>()
+                    .Any(r =>
+                        r.IdentityReference.Equals(networkService) &&
+                        r.AccessControlType == AccessControlType.Allow &&
+                        (r.FileSystemRights & FileSystemRights.Read) == FileSystemRights.Read);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Grants NETWORK SERVICE Read permission on the certificate's private key file.
+        /// Returns false (with error) if the key file cannot be located or the ACL cannot be modified.
+        /// </summary>
+        internal static bool TryGrantNetworkServiceReadPermission(X509Certificate2 certificate, out Exception error)
+        {
+            error = null;
+
+            if (!TryGetKeyFilePath(certificate, out string keyFilePath))
+            {
+                error = new InvalidOperationException("Could not locate the private key file for this certificate.");
+                return false;
+            }
+
+            try
+            {
+                FileInfo keyFileInfo = new FileInfo(keyFilePath);
+                FileSecurity security = keyFileInfo.GetAccessControl();
+                SecurityIdentifier networkService = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null);
+
+                // Skip if an identical explicit Allow rule already exists, so repeat calls don't
+                // grow the ACL with duplicate entries.
+                bool alreadyGranted = security
+                    .GetAccessRules(includeExplicit: true, includeInherited: false, typeof(SecurityIdentifier))
+                    .Cast<FileSystemAccessRule>()
+                    .Any(r =>
+                        r.IdentityReference.Equals(networkService) &&
+                        r.AccessControlType == AccessControlType.Allow &&
+                        (r.FileSystemRights & FileSystemRights.Read) == FileSystemRights.Read);
+
+                if (alreadyGranted)
+                {
+                    return true;
+                }
+
+                security.AddAccessRule(new FileSystemAccessRule(networkService, FileSystemRights.Read, AccessControlType.Allow));
+                keyFileInfo.SetAccessControl(security);
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                error = e;
+                return false;
+            }
+        }
+
+        private static bool TryGetKeyFilePath(X509Certificate2 certificate, out string path)
+        {
+            path = null;
+
+            if (certificate == null || !certificate.HasPrivateKey)
+            {
+                return false;
+            }
+
+            try
+            {
+                using (RSA rsa = certificate.GetRSAPrivateKey())
+                {
+                    if (rsa is RSACng rsaCng)
+                    {
+                        return TryFindKeyFileByUniqueName(rsaCng.Key.UniqueName, out path);
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                using (ECDsa ecdsa = certificate.GetECDsaPrivateKey())
+                {
+                    if (ecdsa is ECDsaCng ecdsaCng)
+                    {
+                        return TryFindKeyFileByUniqueName(ecdsaCng.Key.UniqueName, out path);
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                if (certificate.PrivateKey is RSACryptoServiceProvider csp)
+                {
+                    return TryFindCapiKeyFile(csp.CspKeyContainerInfo, out path);
+                }
+            }
+            catch
+            {
+            }
+
+            return false;
+        }
+
+        // On Windows 10+, `GetRSAPrivateKey` returns `RSACng` even for keys provisioned via a legacy
+        // CAPI provider (e.g. "Microsoft Enhanced Cryptographic Provider v1.0"), because Windows
+        // wraps CAPI keys through the CNG compatibility layer. The `UniqueName` returned by the
+        // wrapper is a filename of the same shape in both cases — only the parent directory differs.
+        // We therefore probe both the CNG (`Crypto\Keys`) and CAPI (`Crypto\RSA\MachineKeys`)
+        // locations rather than trusting the wrapper type to imply storage location.
+        private static bool TryFindKeyFileByUniqueName(string uniqueName, out string path)
+        {
+            path = null;
+
+            if (string.IsNullOrEmpty(uniqueName))
+            {
+                return false;
+            }
+
+            string programData = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+            string roamingAppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
+            string[] candidates = new[]
+            {
+                Path.Combine(programData,    "Microsoft", "Crypto", "Keys",            uniqueName), // CNG  machine
+                Path.Combine(programData,    "Microsoft", "Crypto", "RSA", "MachineKeys", uniqueName), // CAPI machine
+                Path.Combine(roamingAppData, "Microsoft", "Crypto", "Keys",            uniqueName), // CNG  user
+            };
+
+            foreach (string candidate in candidates)
+            {
+                if (File.Exists(candidate))
+                {
+                    path = candidate;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool TryFindCapiKeyFile(CspKeyContainerInfo info, out string path)
+        {
+            path = null;
+
+            if (info == null || string.IsNullOrEmpty(info.UniqueKeyContainerName))
+            {
+                return false;
+            }
+
+            // User-key CAPI paths require the user SID in the path and are not relevant
+            // for server certificates, which are always stored in the machine key store.
+            if (!info.MachineKeyStore)
+            {
+                return false;
+            }
+
+            string candidate = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                "Microsoft", "Crypto", "RSA", "MachineKeys", info.UniqueKeyContainerName);
+
+            if (!File.Exists(candidate))
+            {
+                return false;
+            }
+
+            path = candidate;
+            return true;
+        }
+    }
+}

--- a/package/WindowsManaged/Properties/GatewayProperties.g.cs
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.cs
@@ -32,12 +32,6 @@ namespace DevolutionsGateway.Properties
             System,
         }
  
-        public enum CertificateFindType 
-        {
-            Thumbprint,
-            SubjectName,
-        }
- 
         public enum CustomizeMode 
         {
             Now,
@@ -385,34 +379,6 @@ namespace DevolutionsGateway.Properties
         }
 
  
-        internal static readonly WixProperty<CertificateFindType> certificateFindType = new()
-        {
-            Id = "P.CertificateFindType",
-            Default = CertificateFindType.Thumbprint,
-            Name = "CertificateFindType",
-            Secure = false,
-            Hidden = false,
-            Public = false,
-            Encode = false,
-        };
-
-        public CertificateFindType CertificateFindType
-        {
-            get
-            {
-                string stringValue = this.FnGetPropValue(certificateFindType.Id);
-                return WixProperties.GetPropertyValue<CertificateFindType>(stringValue);
-            }
-            set 
-            { 
-                if (this.runtimeSession is not null)
-                {
-                    this.runtimeSession.Set(certificateFindType, value); 
-                }
-            }
-        }
-
- 
         internal static readonly WixProperty<String> certificateSearchText = new()
         {
             Id = "P.CertificateSearchText",
@@ -436,34 +402,6 @@ namespace DevolutionsGateway.Properties
                 if (this.runtimeSession is not null)
                 {
                     this.runtimeSession.Set(certificateSearchText, value); 
-                }
-            }
-        }
-
- 
-        internal static readonly WixProperty<String> certificateThumbprint = new()
-        {
-            Id = "P.CertificateThumbprint",
-            Default = "",
-            Name = "CertificateThumbprint",
-            Secure = false,
-            Hidden = true,
-            Public = false,
-            Encode = false,
-        };
-
-        public String CertificateThumbprint
-        {
-            get
-            {
-                string stringValue = this.FnGetPropValue(certificateThumbprint.Id);
-                return WixProperties.GetPropertyValue<String>(stringValue);
-            }
-            set 
-            { 
-                if (this.runtimeSession is not null)
-                {
-                    this.runtimeSession.Set(certificateThumbprint, value); 
                 }
             }
         }
@@ -1571,13 +1509,7 @@ namespace DevolutionsGateway.Properties
             generateCertificate,
  
  
-            certificateFindType,
- 
- 
             certificateSearchText,
- 
- 
-            certificateThumbprint,
  
  
             devolutionsServerUrl,

--- a/package/WindowsManaged/Properties/GatewayProperties.g.tt
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.tt
@@ -142,12 +142,6 @@ namespace DevolutionsGateway.Properties
             System
         }
 
-        public enum CertificateFindType
-        {
-            Thumbprint,
-            SubjectName
-        }
-
         public enum CustomizeMode
         {
             Now,
@@ -166,7 +160,6 @@ namespace DevolutionsGateway.Properties
     {
         typeof(Statics.AuthenticationMode),
         typeof(Statics.CertificateMode),
-        typeof(Statics.CertificateFindType),
         typeof(Statics.CustomizeMode),
     };
 
@@ -272,9 +265,7 @@ namespace DevolutionsGateway.Properties
     new PropertyDefinition<bool>("GenerateCertificate", false),
 
     // UI Helpers
-    new PropertyDefinition<Statics.CertificateFindType>("CertificateFindType", Statics.CertificateFindType.Thumbprint, isPublic: false, secure: false),
     new PropertyDefinition<string>("CertificateSearchText", "", isPublic: false, hidden: true, secure: false),
-    new PropertyDefinition<string>("CertificateThumbprint", "", isPublic: false, hidden: true, secure: false),
 
     new PropertyDefinition<string>("DevolutionsServerUrl", "", isPublic: true, hidden: false, secure: true),
     new PropertyDefinition<string>("DevolutionsServerCertificateExceptions", "", isPublic: true, hidden: false, secure: true, encode: true),

--- a/package/WindowsManaged/Resources/DevolutionsGateway_de-de.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_de-de.wxl
@@ -60,8 +60,19 @@
                     <!-- enums -->
                 <String Id="AuthenticationMode_Custom">Benutzerdefiniert</String>
                 <String Id="AuthenticationMode_None">Keine</String>
-                <String Id="CertificateFindType_SubjectName">Antragstellername</String>
-                <String Id="CertificateFindType_Thumbprint">Fingerabdruck</String>
+                <String Id="CertificateChainStatus_ExplicitDistrust">Der Aussteller des Zertifikats wurde vom System ausdrücklich als nicht vertrauenswürdig eingestuft. Stellen Sie das Zertifikat bei einer vertrauenswürdigen CA neu aus.</String>
+                <String Id="CertificateChainStatus_Incomplete">In der Zertifikatsdatei fehlen ein oder mehrere Zwischenzertifikate. Exportieren Sie sie erneut mit den enthaltenen Zwischenzertifikaten, damit Clients das Zertifikat verifizieren können.</String>
+                <String Id="CertificateChainStatus_InvalidSignature">Ein Zertifikat in der Kette hat eine ungültige Signatur. Die Kette wurde möglicherweise manipuliert oder ist beschädigt.</String>
+                <String Id="CertificateChainStatus_SystemStoreRequired">In der Zertifikatsdatei fehlen ein oder mehrere Zwischenzertifikate. Exportieren Sie sie erneut mit den enthaltenen Zwischenzertifikaten, damit Clients das Zertifikat verifizieren können.</String>
+                <String Id="CertificateChainStatus_UntrustedRoot">Das Zertifikat hat als Stamm eine CA, die nicht im Speicher für vertrauenswürdige Stammzertifizierungsstellen des Systems enthalten ist. Wenn es sich um eine private CA handelt, können Clients, bei denen dieser Stamm nicht installiert ist, das Zertifikat nicht verifizieren.</String>
+                <String Id="CertificateChainStatus_ValidationFailed">Die Zertifikatskette konnte nicht validiert werden.</String>
+                <String Id="CertificateChainStatus_WeakSignature">Die Zertifikatskette verwendet einen schwachen Signaturalgorithmus (z. B. MD5 oder SHA-1). Moderne TLS-Clients werden sie wahrscheinlich ablehnen.</String>
+                <String Id="CertificateIssues_Expired">Das Zertifikat ist abgelaufen</String>
+                <String Id="CertificateIssues_ExpiringSoon">Das Zertifikat läuft bald ab</String>
+                <String Id="CertificateIssues_MissingServerAuthEku">Im Zertifikat fehlt die EKU-Erweiterung Server Authentication</String>
+                <String Id="CertificateIssues_MissingSubjectAlternativeName">Im Zertifikat fehlt die Erweiterung Subject Alternative Name</String>
+                <String Id="CertificateIssues_None">Keine Probleme</String>
+                <String Id="CertificateIssues_NotYetValid">Das Zertifikat ist noch nicht gültig</String>
                 <String Id="CertificateMode_External">Extern</String>
                 <String Id="CertificateMode_System">System</String>
                 <String Id="CustomizeMode_Later">Später</String>
@@ -160,23 +171,33 @@ Wenn sie minimiert erscheint, aktivieren Sie sie über die Taskleiste.</String>
                     <!-- dialogs.certificate -->
                 <String Id="AnX509CertificateInBinaryOrPemEncoded">Ein X.509-Zertifikat im binären PKCS#12-Format (PFX/P12) oder PEM-kodiert</String>
                 <String Id="BrowseForACertificateToUse">Zu verwendendes Zertifikat durchsuchen</String>
-                <String Id="CertificateCouldNotBeVerified">Zertifikat konnte nicht verifiziert werden</String>
+                <String Id="CertificateCouldNotBeVerified">Windows hat die Vertrauenskette dieses Zertifikats nicht validiert. Dies kann auf einen nicht vertrauenswürdigen Aussteller oder einen anderen Verstoß gegen die Validierungsrichtlinie hinweisen.</String>
                 <String Id="CertificateDlgCertConfigLabel">Zertifikatkonfiguration</String>
                 <String Id="CertificateDlgCertFileLabel">Zertifikatsdatei</String>
                 <String Id="CertificateDlgCertKeyFileLabel">Datei mit privatem Schlüssel</String>
                 <String Id="CertificateDlgCertPasswordLabel">Zertifikatpasswort</String>
                 <String Id="CertificateDlgDescription">Bei Verwendung eines HTTPS-Listeners ist ein Zertifikat erforderlich.</String>
                 <String Id="CertificateDlgTitle">Zertifikat</String>
+                <String Id="CertificateFileCouldNotBeRead">Die Zertifikatsdatei konnte nicht gelesen werden ({0})</String>
+                <String Id="CertificateIsCaNotServer">Das Zertifikat ist ein CA-Zertifikat, kein Serverzertifikat. Stellen Sie sicher, dass Sie die richtige Datei ausgewählt haben.</String>
+                <String Id="CertificateIsSelfSigned">Das Zertifikat ist selbstsigniert. Clients werden es nur dann als vertrauenswürdig einstufen, wenn sie dem Zertifikat explizit vertrauen.</String>
+                <String Id="CertificatesFoundButUnusable">{0} Zertifikate wurden gefunden, sind aber aus einem oder mehreren der folgenden Gründe unbrauchbar:</String>
                 <String Id="CertificateSource">Zertifikatquelle</String>
                 <String Id="CertificateStore">Zertifikatspeicher</String>
+                <String Id="DoYouWantToProceedAnyway">Möchten Sie trotzdem fortfahren?</String>
                 <String Id="EncryptedPrivateKeysAreNotSupported">Verschlüsselte private Schlüssel werden nicht unterstützt</String>
                 <String Id="EnterTextToSearch">Suchtext eingeben</String>
+                <String Id="NoCertificateSelected">Keine Auswahl</String>
+                <String Id="NoUsableCertificateFoundInFile">In der Datei wurde kein verwendbares Zertifikat gefunden.</String>
+                <String Id="PrivateKeyPermissionWillBeGranted">Das Konto Network Service verfügt möglicherweise nicht über die Berechtigung, den privaten Schlüssel des Zertifikats zu lesen. Das Installationsprogramm wird versuchen, den erforderlichen Zugriff zu gewähren.</String>
                 <String Id="Search">Suchen</String>
-                <String Id="SearchBy">Suchen nach</String>
                 <String Id="SearchForACertificateToUse">Zu verwendendes Zertifikat suchen</String>
+                <String Id="SearchResultPlural">{0} Ergebnisse</String>
+                <String Id="SearchResultSingular">{0} Ergebnis</String>
                 <String Id="SelectedCertificate">Ausgewähltes Zertifikat</String>
                 <String Id="SelectTheCertificateToUse">Das zu verwendende Zertifikat auswählen</String>
                 <String Id="StoreLocation">Speicherort</String>
+                <String Id="ValidationProducedWarnings">Die Validierung des ausgewählten Zertifikats hat folgende Warnungen ergeben:</String>
                     <!-- dialogs.listeners -->
                 <String Id="AnHttpListenerDoesNotRequireACert">Ein HTTP-Listener erfordert kein Zertifikat.</String>
                 <String Id="AnHttpsListenerRequiresACert">Ein HTTPS-Listener erfordert ein Zertifikat. Sie werden aufgefordert, eines zu konfigurieren.</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
@@ -60,8 +60,19 @@
                     <!-- enums -->
                 <String Id="AuthenticationMode_Custom">Custom</String>
                 <String Id="AuthenticationMode_None">None</String>
-                <String Id="CertificateFindType_SubjectName">Subject Name</String>
-                <String Id="CertificateFindType_Thumbprint">Thumbprint</String>
+                <String Id="CertificateChainStatus_ExplicitDistrust">The certificate's issuer has been explicitly distrusted by the system. Re-issue the certificate from a trusted CA.</String>
+                <String Id="CertificateChainStatus_Incomplete">The certificate file is missing one or more intermediate certificates. Re-export it with the intermediates included so clients can verify the certificate.</String>
+                <String Id="CertificateChainStatus_InvalidSignature">A certificate in the chain has an invalid signature. The chain may have been tampered with or is corrupted.</String>
+                <String Id="CertificateChainStatus_SystemStoreRequired">The certificate file is missing one or more intermediate certificates. Re-export it with the intermediates included so clients can verify the certificate.</String>
+                <String Id="CertificateChainStatus_UntrustedRoot">The certificate is rooted in a CA that is not in the system's Trusted Root store. If this is a private CA, clients without that root installed will fail to verify the certificate.</String>
+                <String Id="CertificateChainStatus_ValidationFailed">The certificate chain could not be validated.</String>
+                <String Id="CertificateChainStatus_WeakSignature">The certificate chain uses a weak signature algorithm (such as MD5 or SHA-1). Modern TLS clients are likely to reject it.</String>
+                <String Id="CertificateIssues_Expired">The certificate is expired</String>
+                <String Id="CertificateIssues_ExpiringSoon">The certificate will expire soon</String>
+                <String Id="CertificateIssues_MissingServerAuthEku">The certificate is missing the Server Authentication EKU extension</String>
+                <String Id="CertificateIssues_MissingSubjectAlternativeName">The certificate is missing the Subject Alternative Name extension</String>
+                <String Id="CertificateIssues_None">No issues</String>
+                <String Id="CertificateIssues_NotYetValid">The certificate is not yet valid</String>
                 <String Id="CertificateMode_External">External</String>
                 <String Id="CertificateMode_System">System</String>
                 <String Id="CustomizeMode_Later">Later</String>
@@ -160,23 +171,33 @@ If it appears minimized then active it from the taskbar.</String>
                     <!-- dialogs.certificate -->
                 <String Id="AnX509CertificateInBinaryOrPemEncoded">An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded</String>
                 <String Id="BrowseForACertificateToUse">Browse for a certificate to use</String>
-                <String Id="CertificateCouldNotBeVerified">Certificate could not be verified</String>
+                <String Id="CertificateCouldNotBeVerified">Windows did not validate this certificate's trust chain. This may indicate an untrusted issuer or another chain policy violation.</String>
                 <String Id="CertificateDlgCertConfigLabel">Certificate Configuration</String>
                 <String Id="CertificateDlgCertFileLabel">Certificate File</String>
                 <String Id="CertificateDlgCertKeyFileLabel">Private Key File</String>
                 <String Id="CertificateDlgCertPasswordLabel">Certificate Password</String>
                 <String Id="CertificateDlgDescription">A certificate is required when using an HTTPS listener.</String>
                 <String Id="CertificateDlgTitle">Certificate</String>
+                <String Id="CertificateFileCouldNotBeRead">The certificate file could not be read ({0})</String>
+                <String Id="CertificateIsCaNotServer">The certificate is a CA certificate, not a server certificate. Verify that you have selected the correct file.</String>
+                <String Id="CertificateIsSelfSigned">The certificate is self-signed. Clients will not trust it unless they explicitly trust the certificate.</String>
+                <String Id="CertificatesFoundButUnusable">{0} certificates were found, but are unusable for one or more of the following reasons:</String>
                 <String Id="CertificateSource">Certificate Source</String>
                 <String Id="CertificateStore">Certificate Store</String>
+                <String Id="DoYouWantToProceedAnyway">Do you want to proceed anyway?</String>
                 <String Id="EncryptedPrivateKeysAreNotSupported">Encrypted private keys are not supported</String>
                 <String Id="EnterTextToSearch">Enter text to search</String>
+                <String Id="NoCertificateSelected">No selection</String>
+                <String Id="NoUsableCertificateFoundInFile">No usable certificate was found in the file.</String>
+                <String Id="PrivateKeyPermissionWillBeGranted">The Network Service account may not have permission to read the certificate's private key. The installer will attempt to grant the required access.</String>
                 <String Id="Search">Search</String>
-                <String Id="SearchBy">Search By</String>
                 <String Id="SearchForACertificateToUse">Search for a certificate to use</String>
+                <String Id="SearchResultPlural">{0} results</String>
+                <String Id="SearchResultSingular">{0} result</String>
                 <String Id="SelectedCertificate">Selected Certificate</String>
                 <String Id="SelectTheCertificateToUse">Select the certificate to use</String>
                 <String Id="StoreLocation">Store Location</String>
+                <String Id="ValidationProducedWarnings">Validation of the selected certificate produced the following warnings:</String>
                     <!-- dialogs.listeners -->
                 <String Id="AnHttpListenerDoesNotRequireACert">An HTTP listener does not require a certificate.</String>
                 <String Id="AnHttpsListenerRequiresACert">An HTTPS listener requires a certificate. You will be prompted to configure one.</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
@@ -26,8 +26,19 @@
                     <!-- enums -->
                 <String Id="AuthenticationMode_Custom">Personnalisée</String>
                 <String Id="AuthenticationMode_None">Aucune</String>
-                <String Id="CertificateFindType_SubjectName">Nom du sujet</String>
-                <String Id="CertificateFindType_Thumbprint">Empreinte</String>
+                <String Id="CertificateChainStatus_ExplicitDistrust">L'émetteur du certificat a été explicitement marqué comme non fiable par le système. Réémettez le certificat auprès d'une AC approuvée.</String>
+                <String Id="CertificateChainStatus_Incomplete">Le fichier de certificat ne contient pas un ou plusieurs certificats intermédiaires. Réexportez-le en incluant les certificats intermédiaires pour que les clients puissent vérifier le certificat.</String>
+                <String Id="CertificateChainStatus_InvalidSignature">Un certificat de la chaîne a une signature invalide. La chaîne a peut-être été altérée ou est corrompue.</String>
+                <String Id="CertificateChainStatus_SystemStoreRequired">Le fichier de certificat ne contient pas un ou plusieurs certificats intermédiaires. Réexportez-le en incluant les certificats intermédiaires pour que les clients puissent vérifier le certificat.</String>
+                <String Id="CertificateChainStatus_UntrustedRoot">Le certificat est rattaché à une AC qui ne figure pas dans le magasin Autorités de certification racine de confiance du système. S'il s'agit d'une AC privée, les clients qui n'ont pas cette racine installée ne pourront pas vérifier le certificat.</String>
+                <String Id="CertificateChainStatus_ValidationFailed">La chaîne de certificats n'a pas pu être validée.</String>
+                <String Id="CertificateChainStatus_WeakSignature">La chaîne de certificats utilise un algorithme de signature faible (comme MD5 ou SHA-1). Les clients TLS modernes risquent de la rejeter.</String>
+                <String Id="CertificateIssues_Expired">Le certificat est expiré</String>
+                <String Id="CertificateIssues_ExpiringSoon">Le certificat expirera bientôt</String>
+                <String Id="CertificateIssues_MissingServerAuthEku">Le certificat n'a pas l'extension EKU Server Authentication</String>
+                <String Id="CertificateIssues_MissingSubjectAlternativeName">Le certificat n'a pas l'extension Subject Alternative Name</String>
+                <String Id="CertificateIssues_None">Aucun problème</String>
+                <String Id="CertificateIssues_NotYetValid">Le certificat n'est pas encore valide</String>
                 <String Id="CertificateMode_External">Externe</String>
                 <String Id="CertificateMode_System">Système</String>
                 <String Id="CustomizeMode_Later">Plus tard</String>
@@ -178,23 +189,33 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                     <!-- dialogs.certificate -->
                 <String Id="AnX509CertificateInBinaryOrPemEncoded">Un certificat X.509 en format binaire PKCS#12 (PFX/P12) ou codé en PEM</String>
                 <String Id="BrowseForACertificateToUse">Parcourir pour un certificat à utiliser</String>
-                <String Id="CertificateCouldNotBeVerified">Le certificat n'a pas pu être vérifié</String>
+                <String Id="CertificateCouldNotBeVerified">Windows n'a pas validé la chaîne de confiance de ce certificat. Cela peut indiquer un émetteur non approuvé ou une autre violation de la politique de validation.</String>
                 <String Id="CertificateDlgCertConfigLabel">Configuration de certificat</String>
                 <String Id="CertificateDlgCertFileLabel">Fichier de certificat</String>
                 <String Id="CertificateDlgCertKeyFileLabel">Fichier de clé privée</String>
                 <String Id="CertificateDlgCertPasswordLabel">Mot de passe du certificat</String>
                 <String Id="CertificateDlgDescription">Un certificat est nécessaire pour utiliser HTTPS.</String>
                 <String Id="CertificateDlgTitle">Certificat</String>
+                <String Id="CertificateFileCouldNotBeRead">Le fichier de certificat n'a pas pu être lu ({0})</String>
+                <String Id="CertificateIsCaNotServer">Le certificat est un certificat d'autorité de certification (AC), et non un certificat de serveur. Vérifiez que vous avez sélectionné le bon fichier.</String>
+                <String Id="CertificateIsSelfSigned">Le certificat est auto-signé. Les clients ne lui feront pas confiance à moins qu'ils n'approuvent explicitement le certificat.</String>
+                <String Id="CertificatesFoundButUnusable">{0} certificats ont été trouvés, mais sont inutilisables pour une ou plusieurs des raisons suivantes :</String>
                 <String Id="CertificateSource">Source du certificat</String>
                 <String Id="CertificateStore">Magasin de certificats</String>
+                <String Id="DoYouWantToProceedAnyway">Voulez-vous continuer malgré tout ?</String>
                 <String Id="EncryptedPrivateKeysAreNotSupported">Les clés de chiffrement privées ne sont pas prises en charge</String>
                 <String Id="EnterTextToSearch">Saisir le texte à rechercher</String>
+                <String Id="NoCertificateSelected">Aucune sélection</String>
+                <String Id="NoUsableCertificateFoundInFile">Aucun certificat utilisable n'a été trouvé dans le fichier.</String>
+                <String Id="PrivateKeyPermissionWillBeGranted">Le compte Network Service n'a peut-être pas l'autorisation de lire la clé privée du certificat. Le programme d'installation tentera de lui accorder l'accès requis.</String>
                 <String Id="Search">Rechercher</String>
-                <String Id="SearchBy">Rechercher selon</String>
                 <String Id="SearchForACertificateToUse">Trouver un certificat à utiliser</String>
+                <String Id="SearchResultPlural">{0} résultats</String>
+                <String Id="SearchResultSingular">{0} résultat</String>
                 <String Id="SelectedCertificate">Certificat sélectionné</String>
                 <String Id="SelectTheCertificateToUse">Sélectionner le certificat à utiliser</String>
                 <String Id="StoreLocation">Emplacement du magasin</String>
+                <String Id="ValidationProducedWarnings">La validation du certificat sélectionné a produit les avertissements suivants :</String>
                     <!-- dialogs.listeners -->
                 <String Id="AnHttpListenerDoesNotRequireACert">Un écouteur HTTP ne nécessite pas de certificat.</String>
                 <String Id="AnHttpsListenerRequiresACert">Un écouteur HTTPS nécessite un certificat. Vous serez invité à en configurer un.</String>

--- a/package/WindowsManaged/Resources/Strings.g.cs
+++ b/package/WindowsManaged/Resources/Strings.g.cs
@@ -233,14 +233,6 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string CertificateMode_System = "CertificateMode_System";		
 		/// <summary>
-		/// Thumbprint
-		/// </summary>
-		public const string CertificateFindType_Thumbprint = "CertificateFindType_Thumbprint";		
-		/// <summary>
-		/// Subject Name
-		/// </summary>
-		public const string CertificateFindType_SubjectName = "CertificateFindType_SubjectName";		
-		/// <summary>
 		/// None
 		/// </summary>
 		public const string AuthenticationMode_None = "AuthenticationMode_None";		
@@ -308,6 +300,58 @@ namespace DevolutionsGateway.Resources
 		/// Disabled
 		/// </summary>
 		public const string ServiceStartMode_Disabled = "ServiceStartMode_Disabled";		
+		/// <summary>
+		/// No issues
+		/// </summary>
+		public const string CertificateIssues_None = "CertificateIssues_None";		
+		/// <summary>
+		/// The certificate is not yet valid
+		/// </summary>
+		public const string CertificateIssues_NotYetValid = "CertificateIssues_NotYetValid";		
+		/// <summary>
+		/// The certificate is expired
+		/// </summary>
+		public const string CertificateIssues_Expired = "CertificateIssues_Expired";		
+		/// <summary>
+		/// The certificate will expire soon
+		/// </summary>
+		public const string CertificateIssues_ExpiringSoon = "CertificateIssues_ExpiringSoon";		
+		/// <summary>
+		/// The certificate is missing the Server Authentication EKU extension
+		/// </summary>
+		public const string CertificateIssues_MissingServerAuthEku = "CertificateIssues_MissingServerAuthEku";		
+		/// <summary>
+		/// The certificate is missing the Subject Alternative Name extension
+		/// </summary>
+		public const string CertificateIssues_MissingSubjectAlternativeName = "CertificateIssues_MissingSubjectAlternativeName";		
+		/// <summary>
+		/// The certificate file is missing one or more intermediate certificates. Re-export it with the intermediates included so clients can verify the certificate.
+		/// </summary>
+		public const string CertificateChainStatus_Incomplete = "CertificateChainStatus_Incomplete";		
+		/// <summary>
+		/// The certificate file is missing one or more intermediate certificates. Re-export it with the intermediates included so clients can verify the certificate.
+		/// </summary>
+		public const string CertificateChainStatus_SystemStoreRequired = "CertificateChainStatus_SystemStoreRequired";		
+		/// <summary>
+		/// The certificate is rooted in a CA that is not in the system's Trusted Root store. If this is a private CA, clients without that root installed will fail to verify the certificate.
+		/// </summary>
+		public const string CertificateChainStatus_UntrustedRoot = "CertificateChainStatus_UntrustedRoot";		
+		/// <summary>
+		/// The certificate chain uses a weak signature algorithm (such as MD5 or SHA-1). Modern TLS clients are likely to reject it.
+		/// </summary>
+		public const string CertificateChainStatus_WeakSignature = "CertificateChainStatus_WeakSignature";		
+		/// <summary>
+		/// A certificate in the chain has an invalid signature. The chain may have been tampered with or is corrupted.
+		/// </summary>
+		public const string CertificateChainStatus_InvalidSignature = "CertificateChainStatus_InvalidSignature";		
+		/// <summary>
+		/// The certificate's issuer has been explicitly distrusted by the system. Re-issue the certificate from a trusted CA.
+		/// </summary>
+		public const string CertificateChainStatus_ExplicitDistrust = "CertificateChainStatus_ExplicitDistrust";		
+		/// <summary>
+		/// The certificate chain could not be validated.
+		/// </summary>
+		public const string CertificateChainStatus_ValidationFailed = "CertificateChainStatus_ValidationFailed";		
 		/// <summary>
 		/// Certificate Source
 		/// </summary>
@@ -605,10 +649,6 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string CertificateStore = "CertificateStore";		
 		/// <summary>
-		/// Search By
-		/// </summary>
-		public const string SearchBy = "SearchBy";		
-		/// <summary>
 		/// Search
 		/// </summary>
 		public const string Search = "Search";		
@@ -629,13 +669,57 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string SelectTheCertificateToUse = "SelectTheCertificateToUse";		
 		/// <summary>
-		/// Certificate could not be verified
+		/// Windows did not validate this certificate's trust chain. This may indicate an untrusted issuer or another chain policy violation.
 		/// </summary>
-		public const string CertificateCouldNotBeVerified = "CertificateCouldNotBeVerified";
+		public const string CertificateCouldNotBeVerified = "CertificateCouldNotBeVerified";		
 		/// <summary>
 		/// An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded
 		/// </summary>
 		public const string AnX509CertificateInBinaryOrPemEncoded = "AnX509CertificateInBinaryOrPemEncoded";		
+		/// <summary>
+		/// No selection
+		/// </summary>
+		public const string NoCertificateSelected = "NoCertificateSelected";		
+		/// <summary>
+		/// The certificate file could not be read ({0})
+		/// </summary>
+		public const string CertificateFileCouldNotBeRead = "CertificateFileCouldNotBeRead";		
+		/// <summary>
+		/// No usable certificate was found in the file.
+		/// </summary>
+		public const string NoUsableCertificateFoundInFile = "NoUsableCertificateFoundInFile";		
+		/// <summary>
+		/// The certificate is a CA certificate, not a server certificate. Verify that you have selected the correct file.
+		/// </summary>
+		public const string CertificateIsCaNotServer = "CertificateIsCaNotServer";		
+		/// <summary>
+		/// The certificate is self-signed. Clients will not trust it unless they explicitly trust the certificate.
+		/// </summary>
+		public const string CertificateIsSelfSigned = "CertificateIsSelfSigned";		
+		/// <summary>
+		/// The Network Service account may not have permission to read the certificate's private key. The installer will attempt to grant the required access.
+		/// </summary>
+		public const string PrivateKeyPermissionWillBeGranted = "PrivateKeyPermissionWillBeGranted";		
+		/// <summary>
+		/// Validation of the selected certificate produced the following warnings:
+		/// </summary>
+		public const string ValidationProducedWarnings = "ValidationProducedWarnings";		
+		/// <summary>
+		/// Do you want to proceed anyway?
+		/// </summary>
+		public const string DoYouWantToProceedAnyway = "DoYouWantToProceedAnyway";		
+		/// <summary>
+		/// {0} result
+		/// </summary>
+		public const string SearchResultSingular = "SearchResultSingular";		
+		/// <summary>
+		/// {0} results
+		/// </summary>
+		public const string SearchResultPlural = "SearchResultPlural";		
+		/// <summary>
+		/// {0} certificates were found, but are unusable for one or more of the following reasons:
+		/// </summary>
+		public const string CertificatesFoundButUnusable = "CertificatesFoundButUnusable";		
 		/// <summary>
 		/// Listeners
 		/// </summary>

--- a/package/WindowsManaged/Resources/Strings_de-DE.json
+++ b/package/WindowsManaged/Resources/Strings_de-DE.json
@@ -237,14 +237,6 @@
           "text": "System"
         },
         {
-          "id": "CertificateFindType_Thumbprint",
-          "text": "Fingerabdruck"
-        },
-        {
-          "id": "CertificateFindType_SubjectName",
-          "text": "Antragstellername"
-        },
-        {
           "id": "AuthenticationMode_None",
           "text": "Keine"
         },
@@ -311,6 +303,58 @@
         {
           "id": "ServiceStartMode_Disabled",
           "text": "Deaktiviert"
+        },
+        {
+          "id": "CertificateIssues_None",
+          "text": "Keine Probleme"
+        },
+        {
+          "id": "CertificateIssues_NotYetValid",
+          "text": "Das Zertifikat ist noch nicht gültig"
+        },
+        {
+          "id": "CertificateIssues_Expired",
+          "text": "Das Zertifikat ist abgelaufen"
+        },
+        {
+          "id": "CertificateIssues_ExpiringSoon",
+          "text": "Das Zertifikat läuft bald ab"
+        },
+        {
+          "id": "CertificateIssues_MissingServerAuthEku",
+          "text": "Im Zertifikat fehlt die EKU-Erweiterung Server Authentication"
+        },
+        {
+          "id": "CertificateIssues_MissingSubjectAlternativeName",
+          "text": "Im Zertifikat fehlt die Erweiterung Subject Alternative Name"
+        },
+        {
+          "id": "CertificateChainStatus_Incomplete",
+          "text": "In der Zertifikatsdatei fehlen ein oder mehrere Zwischenzertifikate. Exportieren Sie sie erneut mit den enthaltenen Zwischenzertifikaten, damit Clients das Zertifikat verifizieren können."
+        },
+        {
+          "id": "CertificateChainStatus_SystemStoreRequired",
+          "text": "In der Zertifikatsdatei fehlen ein oder mehrere Zwischenzertifikate. Exportieren Sie sie erneut mit den enthaltenen Zwischenzertifikaten, damit Clients das Zertifikat verifizieren können."
+        },
+        {
+          "id": "CertificateChainStatus_UntrustedRoot",
+          "text": "Das Zertifikat hat als Stamm eine CA, die nicht im Speicher für vertrauenswürdige Stammzertifizierungsstellen des Systems enthalten ist. Wenn es sich um eine private CA handelt, können Clients, bei denen dieser Stamm nicht installiert ist, das Zertifikat nicht verifizieren."
+        },
+        {
+          "id": "CertificateChainStatus_WeakSignature",
+          "text": "Die Zertifikatskette verwendet einen schwachen Signaturalgorithmus (z. B. MD5 oder SHA-1). Moderne TLS-Clients werden sie wahrscheinlich ablehnen."
+        },
+        {
+          "id": "CertificateChainStatus_InvalidSignature",
+          "text": "Ein Zertifikat in der Kette hat eine ungültige Signatur. Die Kette wurde möglicherweise manipuliert oder ist beschädigt."
+        },
+        {
+          "id": "CertificateChainStatus_ExplicitDistrust",
+          "text": "Der Aussteller des Zertifikats wurde vom System ausdrücklich als nicht vertrauenswürdig eingestuft. Stellen Sie das Zertifikat bei einer vertrauenswürdigen CA neu aus."
+        },
+        {
+          "id": "CertificateChainStatus_ValidationFailed",
+          "text": "Die Zertifikatskette konnte nicht validiert werden."
         }
       ],
       "properties": [
@@ -635,10 +679,6 @@
             "text": "Zertifikatspeicher"
           },
           {
-            "id": "SearchBy",
-            "text": "Suchen nach"
-          },
-          {
             "id": "Search",
             "text": "Suchen"
           },
@@ -660,11 +700,55 @@
           },
           {
             "id": "CertificateCouldNotBeVerified",
-            "text": "Zertifikat konnte nicht verifiziert werden"
+            "text": "Windows hat die Vertrauenskette dieses Zertifikats nicht validiert. Dies kann auf einen nicht vertrauenswürdigen Aussteller oder einen anderen Verstoß gegen die Validierungsrichtlinie hinweisen."
           },
           {
             "id": "AnX509CertificateInBinaryOrPemEncoded",
             "text": "Ein X.509-Zertifikat im binären PKCS#12-Format (PFX/P12) oder PEM-kodiert"
+          },
+          {
+            "id": "NoCertificateSelected",
+            "text": "Keine Auswahl"
+          },
+          {
+            "id": "CertificateFileCouldNotBeRead",
+            "text": "Die Zertifikatsdatei konnte nicht gelesen werden ({0})"
+          },
+          {
+            "id": "NoUsableCertificateFoundInFile",
+            "text": "In der Datei wurde kein verwendbares Zertifikat gefunden."
+          },
+          {
+            "id": "CertificateIsCaNotServer",
+            "text": "Das Zertifikat ist ein CA-Zertifikat, kein Serverzertifikat. Stellen Sie sicher, dass Sie die richtige Datei ausgewählt haben."
+          },
+          {
+            "id": "CertificateIsSelfSigned",
+            "text": "Das Zertifikat ist selbstsigniert. Clients werden es nur dann als vertrauenswürdig einstufen, wenn sie dem Zertifikat explizit vertrauen."
+          },
+          {
+            "id": "PrivateKeyPermissionWillBeGranted",
+            "text": "Das Konto Network Service verfügt möglicherweise nicht über die Berechtigung, den privaten Schlüssel des Zertifikats zu lesen. Das Installationsprogramm wird versuchen, den erforderlichen Zugriff zu gewähren."
+          },
+          {
+            "id": "ValidationProducedWarnings",
+            "text": "Die Validierung des ausgewählten Zertifikats hat folgende Warnungen ergeben:"
+          },
+          {
+            "id": "DoYouWantToProceedAnyway",
+            "text": "Möchten Sie trotzdem fortfahren?"
+          },
+          {
+            "id": "SearchResultSingular",
+            "text": "{0} Ergebnis"
+          },
+          {
+            "id": "SearchResultPlural",
+            "text": "{0} Ergebnisse"
+          },
+          {
+            "id": "CertificatesFoundButUnusable",
+            "text": "{0} Zertifikate wurden gefunden, sind aber aus einem oder mehreren der folgenden Gründe unbrauchbar:"
           }
         ],
         "listeners": [

--- a/package/WindowsManaged/Resources/Strings_en-US.json
+++ b/package/WindowsManaged/Resources/Strings_en-US.json
@@ -237,14 +237,6 @@
           "text": "System"
         },
         {
-          "id": "CertificateFindType_Thumbprint",
-          "text": "Thumbprint"
-        },
-        {
-          "id": "CertificateFindType_SubjectName",
-          "text": "Subject Name"
-        },
-        {
           "id": "AuthenticationMode_None",
           "text": "None"
         },
@@ -311,6 +303,58 @@
         {
           "id": "ServiceStartMode_Disabled",
           "text": "Disabled"
+        },
+        {
+          "id": "CertificateIssues_None",
+          "text": "No issues"
+        },
+        {
+          "id": "CertificateIssues_NotYetValid",
+          "text": "The certificate is not yet valid"
+        },
+        {
+          "id": "CertificateIssues_Expired",
+          "text": "The certificate is expired"
+        },
+        {
+          "id": "CertificateIssues_ExpiringSoon",
+          "text": "The certificate will expire soon"
+        },
+        {
+          "id": "CertificateIssues_MissingServerAuthEku",
+          "text": "The certificate is missing the Server Authentication EKU extension"
+        },
+        {
+          "id": "CertificateIssues_MissingSubjectAlternativeName",
+          "text": "The certificate is missing the Subject Alternative Name extension"
+        },
+        {
+          "id": "CertificateChainStatus_Incomplete",
+          "text": "The certificate file is missing one or more intermediate certificates. Re-export it with the intermediates included so clients can verify the certificate."
+        },
+        {
+          "id": "CertificateChainStatus_SystemStoreRequired",
+          "text": "The certificate file is missing one or more intermediate certificates. Re-export it with the intermediates included so clients can verify the certificate."
+        },
+        {
+          "id": "CertificateChainStatus_UntrustedRoot",
+          "text": "The certificate is rooted in a CA that is not in the system's Trusted Root store. If this is a private CA, clients without that root installed will fail to verify the certificate."
+        },
+        {
+          "id": "CertificateChainStatus_WeakSignature",
+          "text": "The certificate chain uses a weak signature algorithm (such as MD5 or SHA-1). Modern TLS clients are likely to reject it."
+        },
+        {
+          "id": "CertificateChainStatus_InvalidSignature",
+          "text": "A certificate in the chain has an invalid signature. The chain may have been tampered with or is corrupted."
+        },
+        {
+          "id": "CertificateChainStatus_ExplicitDistrust",
+          "text": "The certificate's issuer has been explicitly distrusted by the system. Re-issue the certificate from a trusted CA."
+        },
+        {
+          "id": "CertificateChainStatus_ValidationFailed",
+          "text": "The certificate chain could not be validated."
         }
       ],
       "properties": [
@@ -635,10 +679,6 @@
             "text": "Certificate Store"
           },
           {
-            "id": "SearchBy",
-            "text": "Search By"
-          },
-          {
             "id": "Search",
             "text": "Search"
           },
@@ -660,11 +700,55 @@
           },
           {
             "id": "CertificateCouldNotBeVerified",
-            "text": "Certificate could not be verified"
+            "text": "Windows did not validate this certificate's trust chain. This may indicate an untrusted issuer or another chain policy violation."
           },
           {
             "id": "AnX509CertificateInBinaryOrPemEncoded",
             "text": "An X.509 certificate in PKCS#12 (PFX/P12) binary format or PEM-encoded"
+          },
+          {
+            "id": "NoCertificateSelected",
+            "text": "No selection"
+          },
+          {
+            "id": "CertificateFileCouldNotBeRead",
+            "text": "The certificate file could not be read ({0})"
+          },
+          {
+            "id": "NoUsableCertificateFoundInFile",
+            "text": "No usable certificate was found in the file."
+          },
+          {
+            "id": "CertificateIsCaNotServer",
+            "text": "The certificate is a CA certificate, not a server certificate. Verify that you have selected the correct file."
+          },
+          {
+            "id": "CertificateIsSelfSigned",
+            "text": "The certificate is self-signed. Clients will not trust it unless they explicitly trust the certificate."
+          },
+          {
+            "id": "PrivateKeyPermissionWillBeGranted",
+            "text": "The Network Service account may not have permission to read the certificate's private key. The installer will attempt to grant the required access."
+          },
+          {
+            "id": "ValidationProducedWarnings",
+            "text": "Validation of the selected certificate produced the following warnings:"
+          },
+          {
+            "id": "DoYouWantToProceedAnyway",
+            "text": "Do you want to proceed anyway?"
+          },
+          {
+            "id": "SearchResultSingular",
+            "text": "{0} result"
+          },
+          {
+            "id": "SearchResultPlural",
+            "text": "{0} results"
+          },
+          {
+            "id": "CertificatesFoundButUnusable",
+            "text": "{0} certificates were found, but are unusable for one or more of the following reasons:"
           }
         ],
         "listeners": [

--- a/package/WindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/WindowsManaged/Resources/Strings_fr-FR.json
@@ -105,14 +105,6 @@
           "text": "Système"
         },
         {
-          "id": "CertificateFindType_Thumbprint",
-          "text": "Empreinte"
-        },
-        {
-          "id": "CertificateFindType_SubjectName",
-          "text": "Nom du sujet"
-        },
-        {
           "id": "AuthenticationMode_None",
           "text": "Aucune"
         },
@@ -179,6 +171,58 @@
         {
           "id": "ServiceStartMode_Disabled",
           "text": "Désactivé"
+        },
+        {
+          "id": "CertificateIssues_None",
+          "text": "Aucun problème"
+        },
+        {
+          "id": "CertificateIssues_NotYetValid",
+          "text": "Le certificat n'est pas encore valide"
+        },
+        {
+          "id": "CertificateIssues_Expired",
+          "text": "Le certificat est expiré"
+        },
+        {
+          "id": "CertificateIssues_ExpiringSoon",
+          "text": "Le certificat expirera bientôt"
+        },
+        {
+          "id": "CertificateIssues_MissingServerAuthEku",
+          "text": "Le certificat n'a pas l'extension EKU Server Authentication"
+        },
+        {
+          "id": "CertificateIssues_MissingSubjectAlternativeName",
+          "text": "Le certificat n'a pas l'extension Subject Alternative Name"
+        },
+        {
+          "id": "CertificateChainStatus_Incomplete",
+          "text": "Le fichier de certificat ne contient pas un ou plusieurs certificats intermédiaires. Réexportez-le en incluant les certificats intermédiaires pour que les clients puissent vérifier le certificat."
+        },
+        {
+          "id": "CertificateChainStatus_SystemStoreRequired",
+          "text": "Le fichier de certificat ne contient pas un ou plusieurs certificats intermédiaires. Réexportez-le en incluant les certificats intermédiaires pour que les clients puissent vérifier le certificat."
+        },
+        {
+          "id": "CertificateChainStatus_UntrustedRoot",
+          "text": "Le certificat est rattaché à une AC qui ne figure pas dans le magasin Autorités de certification racine de confiance du système. S'il s'agit d'une AC privée, les clients qui n'ont pas cette racine installée ne pourront pas vérifier le certificat."
+        },
+        {
+          "id": "CertificateChainStatus_WeakSignature",
+          "text": "La chaîne de certificats utilise un algorithme de signature faible (comme MD5 ou SHA-1). Les clients TLS modernes risquent de la rejeter."
+        },
+        {
+          "id": "CertificateChainStatus_InvalidSignature",
+          "text": "Un certificat de la chaîne a une signature invalide. La chaîne a peut-être été altérée ou est corrompue."
+        },
+        {
+          "id": "CertificateChainStatus_ExplicitDistrust",
+          "text": "L'émetteur du certificat a été explicitement marqué comme non fiable par le système. Réémettez le certificat auprès d'une AC approuvée."
+        },
+        {
+          "id": "CertificateChainStatus_ValidationFailed",
+          "text": "La chaîne de certificats n'a pas pu être validée."
         }
       ],
 
@@ -704,10 +748,6 @@
             "text": "Magasin de certificats"
           },
           {
-            "id": "SearchBy",
-            "text": "Rechercher selon"
-          },
-          {
             "id": "Search",
             "text": "Rechercher"
           },
@@ -729,11 +769,55 @@
           },
           {
             "id": "CertificateCouldNotBeVerified",
-            "text": "Le certificat n'a pas pu être vérifié"
+            "text": "Windows n'a pas validé la chaîne de confiance de ce certificat. Cela peut indiquer un émetteur non approuvé ou une autre violation de la politique de validation."
           },
           {
             "id": "AnX509CertificateInBinaryOrPemEncoded",
             "text": "Un certificat X.509 en format binaire PKCS#12 (PFX/P12) ou codé en PEM"
+          },
+          {
+            "id": "NoCertificateSelected",
+            "text": "Aucune sélection"
+          },
+          {
+            "id": "CertificateFileCouldNotBeRead",
+            "text": "Le fichier de certificat n'a pas pu être lu ({0})"
+          },
+          {
+            "id": "NoUsableCertificateFoundInFile",
+            "text": "Aucun certificat utilisable n'a été trouvé dans le fichier."
+          },
+          {
+            "id": "CertificateIsCaNotServer",
+            "text": "Le certificat est un certificat d'autorité de certification (AC), et non un certificat de serveur. Vérifiez que vous avez sélectionné le bon fichier."
+          },
+          {
+            "id": "CertificateIsSelfSigned",
+            "text": "Le certificat est auto-signé. Les clients ne lui feront pas confiance à moins qu'ils n'approuvent explicitement le certificat."
+          },
+          {
+            "id": "PrivateKeyPermissionWillBeGranted",
+            "text": "Le compte Network Service n'a peut-être pas l'autorisation de lire la clé privée du certificat. Le programme d'installation tentera de lui accorder l'accès requis."
+          },
+          {
+            "id": "ValidationProducedWarnings",
+            "text": "La validation du certificat sélectionné a produit les avertissements suivants :"
+          },
+          {
+            "id": "DoYouWantToProceedAnyway",
+            "text": "Voulez-vous continuer malgré tout ?"
+          },
+          {
+            "id": "SearchResultSingular",
+            "text": "{0} résultat"
+          },
+          {
+            "id": "SearchResultPlural",
+            "text": "{0} résultats"
+          },
+          {
+            "id": "CertificatesFoundButUnusable",
+            "text": "{0} certificats ont été trouvés, mais sont inutilisables pour une ou plusieurs des raisons suivantes :"
           }
         ],
         "listeners": [


### PR DESCRIPTION
First, system certificate selection in the installer now matches runtime behaviour. Previously the user would search for and choose a _specific_ certificate by subject or thumbprint. Now we match the runtime behaviour of Gateway: the user choses the location, store and subject (which can be a fuzzy match) and a matching certificate is shown to the user based on their criteria. There is a "results" label that communicates if multiple certificates were found. 

<img width="494" height="392" alt="Screenshot 2026-05-14 at 12 28 54" src="https://github.com/user-attachments/assets/4916ff71-ef87-4e1c-9f3f-7b2c48ca71bf" />

The missing SAN or Server Auth EKU is enforced because this will only occur on a _new_ install, where strict verification is the default. So install time experience matches runtime expectation.

_If_ certificates were matched but no suitable candidate is found, the user is informed of the reason(s) for the that.

<img width="497" height="396" alt="Screenshot 2026-05-14 at 12 57 19" src="https://github.com/user-attachments/assets/0f40dd62-7db4-4457-9b2a-b7d2444f1dcd" />

Second, the only exception to matching is the read permission for the private key for NETWORK SERVICE. The installer will now attempt to correct that scenario at install time.

Thirdly, we now perform a more comprehensive validation of the chosen certificate. Previously when using the "System" certificate option, we would ask .NET to validate the certificate and, if it could not, a "warning" triangle was display with a tooltip explaining that the certificate "may not be valid".

Now, instead; we perform validation of the chosen (System or External) certificate to the best of our ability:

For external (file) certificates:

- File cannot be parsed (invalid format, wrong password, unreadable - the underlying error is surfaced)
- No usable certificate in the file (parsed but no leaf certificate)
- The leaf is a CA certificate (`BasicConstraints` says `CA=true`)
- Self signed (subject equals issuer)
- Incomplete chain (building an X.509 chain only gives a partial chain; excluding the system store's intermediate certificates)
- Untrusted root (probably a private CA)
- Weak signature (MD5, SHA1, similar)
- Invalid signature (corrupt or tampered)
- Explicitly distrusted (the issuer lives in Untrusted Certificates)
- Validation failed (we could not validate the certificate, internal error)

For system certificates:

- System verification, if Windows refuses to validate the trust chain (untrusted issuer or other policy violations; i.e. certificate shows as untrusted in certificate manager)

Quality checks for both External (file) and System certificates:

- Not yet valid
- Expired
- Expiring soon (within 30 days)
- Missing the server authentication EKU
- Missing the SAN extension

Note that the quality checks in general won't be shown for the System certificates, as they're largely caught and filtered during certificate selection.

Permission checks (System certificates):

- Whether network service can read the private key

When clicking "Next" on the dialog, the user is prompted with the validation reasons. **Importantly** this is a soft-validation, the user is never blocked and can proceed with the installation.

<img width="494" height="389" alt="Screenshot 2026-05-14 at 12 31 32" src="https://github.com/user-attachments/assets/10e37dc5-6ef2-4732-8a6d-b616fe409660" />

In general, when choosing a system certificate, the installer will call out the permission prompt but acknowledge we will try to fix it:

<img width="493" height="393" alt="Screenshot 2026-05-14 at 13 13 23" src="https://github.com/user-attachments/assets/27b01168-b673-40c1-ba41-3e6cb237fcf7" />