### PR TITLE
ci: bump macOS runners to macos-15 and drop CommandLineTools removal

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -17,7 +17,7 @@ jobs:
           - platform: unknown-linux-gnu
             runner: ubuntu-22.04
           - platform: apple-darwin
-            runner: macos-14
+            runner: macos-15
         exclude:
           - platform: pc-windows-msvc
             arch: aarch64
@@ -97,7 +97,7 @@ jobs:
           - platform: pc-windows-msvc
             runner: windows-2022
           - platform: apple-darwin
-            runner: macos-14
+            runner: macos-15
         exclude:
           - platform: pc-windows-msvc
             arch: aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           $Platforms += 'macos'
 
           $Platforms | ForEach-Object {
-              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'macos' { 'macos-14' } 'linux' { 'ubuntu-22.04' } }
+              $Runner = switch ($_) { 'windows' { 'windows-2022' } 'macos' { 'macos-15' } 'linux' { 'ubuntu-22.04' } }
               foreach ($Arch in $Archs) {
                   $Jobs += @{
                       arch = $Arch
@@ -324,10 +324,25 @@ jobs:
           rustup target add aarch64-pc-windows-msvc
         shell: pwsh
 
+      # The macos-15 runner image ships `cargo`, `rustc`, etc. in ~/.cargo/bin as
+      # symlinks to Homebrew's `rustup-init`, which is a shell-script wrapper that
+      # only dispatches on the `rustup`/`rustup-init` names (not on `cargo`/`rustc`/
+      # `clippy`). Invoking `cargo` therefore runs `rustup-init` and fails with
+      # "unexpected argument 'build'". The official rustup installer lays down proper
+      # multi-call hard-link shims, so we run it to repair ~/.cargo/bin.
+      - name: Repair Rust shims (macOS)
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          set -eux
+          rm -rf "$HOME/.cargo/bin"
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | bash -s -- -y --default-toolchain none --no-modify-path --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        shell: bash
+
       - name: Configure macOS (intel) runner
         if: ${{ matrix.os == 'macos' && matrix.arch == 'x64' }}
         run: |
-          sudo rm -rf /Library/Developer/CommandLineTools
           rustup target add x86_64-apple-darwin
 
       - name: Build


### PR DESCRIPTION
Github have [shipped](https://github.com/actions/runner-images/issues/14097) a broken Homebrew `rustup` in their latest runner images. This PR adds a workaround for now.

Other changes

- I note that the maos-14 runners will begin deprecation soon, so take the opportunity to move to macos-15
- The macOS build was running `sudo rm -rf /Library/Developer/CommandLineTools`. This seems to be an artifact of when cross-compiled arm64 from an Intel runner a long time ago. It should not be needed. When we switched to arm64 runners (and Intel became the cross-compile target) it was kept for cargo cult reasons.

