### PR TITLE
fix(agent-tunnel): clone ca_manager Arc to unbreak master build

### DIFF
--- a/crates/agent-tunnel/src/listener.rs
+++ b/crates/agent-tunnel/src/listener.rs
@@ -152,7 +152,7 @@ impl AgentTunnelListener {
         let handle = AgentTunnelHandle {
             registry: Arc::clone(&registry),
             agent_connections: Arc::clone(&agent_connections),
-            ca_manager,
+            ca_manager: Arc::clone(&ca_manager),
         };
 
         let listener = Self {


### PR DESCRIPTION
## Summary

Master is currently broken on Linux + Windows (`tests`, `lints` jobs).

`crates/agent-tunnel/src/listener.rs:152-163` moves the same `Arc<CaManager>` into both `AgentTunnelHandle` and `AgentTunnelListener`, which doesn't compile:

```
error[E0382]: use of moved value: `ca_manager`
   --> crates/agent-tunnel/src/listener.rs:162:13
```

The fix is a one-liner: `Arc::clone(&ca_manager)` for the handle so the move into `Self` still type-checks.

## Root cause

PR #1773 added the `ca_manager` field to `AgentTunnelListener`. PR #1775 used `ca_manager` in the same `bind()` body for the handle initializer. Each PR's CI was green against its own base, but the merge of #1775 on top of #1773 produced a semantic conflict that wasn't textually conflicting, so GitHub merged it without re-running CI.

## Test plan

- [x] `cargo check -p agent-tunnel` — clean
- [x] `cargo clippy -p agent-tunnel --tests -- -D warnings` — clean
- [ ] Linux + Windows CI green