### PR TITLE
fix(agent-installer): backfill Agent Tunnel localization strings to JSON

### DIFF
--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
@@ -3,14 +3,14 @@
         <!-- metadata -->
                 <String Id="FeatureAgentDescription">Installs the Devolutions Agent service</String>
                 <String Id="FeatureAgentName">Devolutions Agent</String>
+                <String Id="FeatureAgentTunnelDescription">Connects the agent to a Devolutions Gateway. Requires an enrollment string from your gateway operator.</String>
+                <String Id="FeatureAgentTunnelName">Agent Tunnel</String>
                 <String Id="FeatureAgentUpdaterDescription">Enables the Devolutions Gateway updater</String>
                 <String Id="FeatureAgentUpdaterName">Devolutions Gateway Updater</String>
                 <String Id="FeaturePedmDescription">Enables PEDM features and installs the shell extension</String>
                 <String Id="FeaturePedmName">Devolutions PEDM</String>
                 <String Id="FeatureSessionDescription">Installs the RDP Extension</String>
                 <String Id="FeatureSessionName">RDP Extension</String>
-                <String Id="FeatureAgentTunnelName">Agent Tunnel</String>
-                <String Id="FeatureAgentTunnelDescription">Connects the agent to a Devolutions Gateway. Requires an enrollment string from your gateway operator.</String>
                 <String Id="Language">1033</String>
                 <String Id="ProductDescription">System-wide service for extending Devolutions Gateway functionality.</String>
                 <String Id="VendorFullName">Devolutions Inc.</String>
@@ -60,13 +60,13 @@ If it appears minimized then active it from the taskbar.</String>
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Welcome to the [ProductName] 20[ProductVersion] Setup Wizard</String>
                     <!-- dialogs.agentTunnel -->
-                <String Id="AgentTunnelDlgTitle">Agent Tunnel</String>
-                <String Id="AgentTunnelDlgDescription">Connect this agent to a Devolutions Gateway.</String>
-                <String Id="AgentTunnelDlgEnrollmentStringLabel">Enrollment String (provided by your gateway operator):</String>
-                <String Id="AgentTunnelDlgAgentNameLabel">Agent Name (Optional):</String>
                 <String Id="AgentTunnelDlgAgentNameHint">Identifies this agent in your gateway's management console. If left blank, the name embedded in the enrollment string is used, falling back to this computer's name.</String>
-                <String Id="AgentTunnelDlgSubnetsLabel">Advertise Subnets:</String>
-                <String Id="AgentTunnelDlgSubnetsHint">Optional. Comma-separated CIDR ranges, e.g. 10.10.0.0/24, 192.168.1.0/24. If left blank, the agent's local subnets are detected automatically.</String>
-                <String Id="AgentTunnelDlgDomainsLabel">Advertise Domains:</String>
+                <String Id="AgentTunnelDlgAgentNameLabel">Agent Name (Optional):</String>
+                <String Id="AgentTunnelDlgDescription">Connect this agent to a Devolutions Gateway.</String>
                 <String Id="AgentTunnelDlgDomainsHint">Optional. Comma-separated DNS suffixes the agent can resolve, e.g. corp.example.com, lab.example.com.</String>
+                <String Id="AgentTunnelDlgDomainsLabel">Advertise Domains:</String>
+                <String Id="AgentTunnelDlgEnrollmentStringLabel">Enrollment String (provided by your gateway operator):</String>
+                <String Id="AgentTunnelDlgSubnetsHint">Optional. Comma-separated CIDR ranges, e.g. 10.10.0.0/24, 192.168.1.0/24. If left blank, the agent's local subnets are detected automatically.</String>
+                <String Id="AgentTunnelDlgSubnetsLabel">Advertise Subnets:</String>
+                <String Id="AgentTunnelDlgTitle">Agent Tunnel</String>
                     </WixLocalization>

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="fr-fr" Codepage="1252" Language="1036" xmlns="http://schemas.microsoft.com/wix/2006/localization">
         <!-- metadata -->
+                <String Id="FeatureAgentTunnelDescription">Connecte l'agent à une passerelle Devolutions. Nécessite une chaîne d'enrôlement fournie par l'opérateur de votre passerelle.</String>
+                <String Id="FeatureAgentTunnelName">Tunnel d'agent</String>
                 <String Id="FeatureSessionDescription">Installe l'extension RDP</String>
                 <String Id="FeatureSessionName">Extension RDP</String>
-                <String Id="FeatureAgentTunnelName">Tunnel d'agent</String>
-                <String Id="FeatureAgentTunnelDescription">Connecte l'agent à une passerelle Devolutions. Nécessite une chaîne d'enrôlement fournie par l'opérateur de votre passerelle.</String>
                 <String Id="Language">1036</String>
                 <String Id="ProductDescription">Service à l’échelle du système pour étendre les fonctionnalités de Devolutions Gateway.</String>
                 <String Id="VendorFullName">Devolutions Inc.</String>
@@ -54,15 +54,15 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Bienvenue dans l'assistant d'installation de [ProductName] 20[ProductVersion]</String>
                     <!-- dialogs.agentTunnel -->
-                <String Id="AgentTunnelDlgTitle">Tunnel d'agent</String>
-                <String Id="AgentTunnelDlgDescription">Connectez cet agent à une passerelle Devolutions.</String>
-                <String Id="AgentTunnelDlgEnrollmentStringLabel">Chaîne d'enrôlement (fournie par l'opérateur de votre passerelle) :</String>
-                <String Id="AgentTunnelDlgAgentNameLabel">Nom de l'agent (facultatif) :</String>
                 <String Id="AgentTunnelDlgAgentNameHint">Identifie cet agent dans la console de gestion de votre passerelle. Si laissé vide, le nom contenu dans la chaîne d'enrôlement est utilisé, à défaut le nom de cet ordinateur.</String>
-                <String Id="AgentTunnelDlgSubnetsLabel">Sous-réseaux annoncés :</String>
-                <String Id="AgentTunnelDlgSubnetsHint">Facultatif. Plages CIDR séparées par des virgules, p. ex. 10.10.0.0/24, 192.168.1.0/24. Si laissé vide, les sous-réseaux locaux de l'agent sont détectés automatiquement.</String>
-                <String Id="AgentTunnelDlgDomainsLabel">Domaines annoncés :</String>
+                <String Id="AgentTunnelDlgAgentNameLabel">Nom de l'agent (facultatif) :</String>
+                <String Id="AgentTunnelDlgDescription">Connectez cet agent à une passerelle Devolutions.</String>
                 <String Id="AgentTunnelDlgDomainsHint">Facultatif. Suffixes DNS séparés par des virgules que l'agent peut résoudre, p. ex. corp.example.com, lab.example.com.</String>
+                <String Id="AgentTunnelDlgDomainsLabel">Domaines annoncés :</String>
+                <String Id="AgentTunnelDlgEnrollmentStringLabel">Chaîne d'enrôlement (fournie par l'opérateur de votre passerelle) :</String>
+                <String Id="AgentTunnelDlgSubnetsHint">Facultatif. Plages CIDR séparées par des virgules, p. ex. 10.10.0.0/24, 192.168.1.0/24. Si laissé vide, les sous-réseaux locaux de l'agent sont détectés automatiquement.</String>
+                <String Id="AgentTunnelDlgSubnetsLabel">Sous-réseaux annoncés :</String>
+                <String Id="AgentTunnelDlgTitle">Tunnel d'agent</String>
                     <!-- dialogs.firewall -->
                 <String Id="msierrFirewallCannotConnect">Impossible de se connecter au Pare-feu Windows.  ([2]   [3]   [4]   [5])</String>
                 <String Id="WixExecFirewallExceptionsInstall">Installation de la configuration du Pare-feu Windows</String>

--- a/package/AgentWindowsManaged/Resources/Strings.g.cs
+++ b/package/AgentWindowsManaged/Resources/Strings.g.cs
@@ -57,6 +57,14 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string FeatureSessionDescription = "FeatureSessionDescription";		
 		/// <summary>
+		/// Agent Tunnel
+		/// </summary>
+		public const string FeatureAgentTunnelName = "FeatureAgentTunnelName";		
+		/// <summary>
+		/// Connects the agent to a Devolutions Gateway. Requires an enrollment string from your gateway operator.
+		/// </summary>
+		public const string FeatureAgentTunnelDescription = "FeatureAgentTunnelDescription";		
+		/// <summary>
 		/// There is a problem with the entered data. Please correct the issue and try again.
 		/// </summary>
 		public const string ThereIsAProblemWithTheEnteredData = "ThereIsAProblemWithTheEnteredData";		
@@ -176,5 +184,41 @@ namespace DevolutionsAgent.Resources
 		/// Welcome to the [ProductName] 20[ProductVersion] Setup Wizard
 		/// </summary>
 		public const string WelcomeDlgTitle = "WelcomeDlgTitle";		
+		/// <summary>
+		/// Agent Tunnel
+		/// </summary>
+		public const string AgentTunnelDlgTitle = "AgentTunnelDlgTitle";		
+		/// <summary>
+		/// Connect this agent to a Devolutions Gateway.
+		/// </summary>
+		public const string AgentTunnelDlgDescription = "AgentTunnelDlgDescription";		
+		/// <summary>
+		/// Enrollment String (provided by your gateway operator):
+		/// </summary>
+		public const string AgentTunnelDlgEnrollmentStringLabel = "AgentTunnelDlgEnrollmentStringLabel";		
+		/// <summary>
+		/// Agent Name (Optional):
+		/// </summary>
+		public const string AgentTunnelDlgAgentNameLabel = "AgentTunnelDlgAgentNameLabel";		
+		/// <summary>
+		/// Identifies this agent in your gateway's management console. If left blank, the name embedded in the enrollment string is used, falling back to this computer's name.
+		/// </summary>
+		public const string AgentTunnelDlgAgentNameHint = "AgentTunnelDlgAgentNameHint";		
+		/// <summary>
+		/// Advertise Subnets:
+		/// </summary>
+		public const string AgentTunnelDlgSubnetsLabel = "AgentTunnelDlgSubnetsLabel";		
+		/// <summary>
+		/// Optional. Comma-separated CIDR ranges, e.g. 10.10.0.0/24, 192.168.1.0/24. If left blank, the agent's local subnets are detected automatically.
+		/// </summary>
+		public const string AgentTunnelDlgSubnetsHint = "AgentTunnelDlgSubnetsHint";		
+		/// <summary>
+		/// Advertise Domains:
+		/// </summary>
+		public const string AgentTunnelDlgDomainsLabel = "AgentTunnelDlgDomainsLabel";		
+		/// <summary>
+		/// Optional. Comma-separated DNS suffixes the agent can resolve, e.g. corp.example.com, lab.example.com.
+		/// </summary>
+		public const string AgentTunnelDlgDomainsHint = "AgentTunnelDlgDomainsHint";		
 	}
 }

--- a/package/AgentWindowsManaged/Resources/Strings_en-US.json
+++ b/package/AgentWindowsManaged/Resources/Strings_en-US.json
@@ -49,6 +49,14 @@
         {
           "id": "FeatureSessionDescription",
           "text": "Installs the RDP Extension"
+        },
+        {
+          "id": "FeatureAgentTunnelName",
+          "text": "Agent Tunnel"
+        },
+        {
+          "id": "FeatureAgentTunnelDescription",
+          "text": "Connects the agent to a Devolutions Gateway. Requires an enrollment string from your gateway operator."
         }
       ],
       "messages": [
@@ -195,6 +203,44 @@
             "id": "WelcomeDlgTitle",
             "overridable": "yes",
             "text": "Welcome to the [ProductName] 20[ProductVersion] Setup Wizard"
+          }
+        ],
+        "agentTunnel": [
+          {
+            "id": "AgentTunnelDlgTitle",
+            "text": "Agent Tunnel"
+          },
+          {
+            "id": "AgentTunnelDlgDescription",
+            "text": "Connect this agent to a Devolutions Gateway."
+          },
+          {
+            "id": "AgentTunnelDlgEnrollmentStringLabel",
+            "text": "Enrollment String (provided by your gateway operator):"
+          },
+          {
+            "id": "AgentTunnelDlgAgentNameLabel",
+            "text": "Agent Name (Optional):"
+          },
+          {
+            "id": "AgentTunnelDlgAgentNameHint",
+            "text": "Identifies this agent in your gateway's management console. If left blank, the name embedded in the enrollment string is used, falling back to this computer's name."
+          },
+          {
+            "id": "AgentTunnelDlgSubnetsLabel",
+            "text": "Advertise Subnets:"
+          },
+          {
+            "id": "AgentTunnelDlgSubnetsHint",
+            "text": "Optional. Comma-separated CIDR ranges, e.g. 10.10.0.0/24, 192.168.1.0/24. If left blank, the agent's local subnets are detected automatically."
+          },
+          {
+            "id": "AgentTunnelDlgDomainsLabel",
+            "text": "Advertise Domains:"
+          },
+          {
+            "id": "AgentTunnelDlgDomainsHint",
+            "text": "Optional. Comma-separated DNS suffixes the agent can resolve, e.g. corp.example.com, lab.example.com."
           }
         ]
       }

--- a/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
@@ -25,6 +25,14 @@
         {
           "id": "FeatureSessionDescription",
           "text": "Installe l'extension RDP"
+        },
+        {
+          "id": "FeatureAgentTunnelName",
+          "text": "Tunnel d'agent"
+        },
+        {
+          "id": "FeatureAgentTunnelDescription",
+          "text": "Connecte l'agent à une passerelle Devolutions. Nécessite une chaîne d'enrôlement fournie par l'opérateur de votre passerelle."
         }
       ],
       "messages": [
@@ -171,6 +179,44 @@
             "id": "WelcomeDlgTitle",
             "overridable": "yes",
             "text": "Bienvenue dans l'assistant d'installation de [ProductName] 20[ProductVersion]"
+          }
+        ],
+        "agentTunnel": [
+          {
+            "id": "AgentTunnelDlgTitle",
+            "text": "Tunnel d'agent"
+          },
+          {
+            "id": "AgentTunnelDlgDescription",
+            "text": "Connectez cet agent à une passerelle Devolutions."
+          },
+          {
+            "id": "AgentTunnelDlgEnrollmentStringLabel",
+            "text": "Chaîne d'enrôlement (fournie par l'opérateur de votre passerelle) :"
+          },
+          {
+            "id": "AgentTunnelDlgAgentNameLabel",
+            "text": "Nom de l'agent (facultatif) :"
+          },
+          {
+            "id": "AgentTunnelDlgAgentNameHint",
+            "text": "Identifie cet agent dans la console de gestion de votre passerelle. Si laissé vide, le nom contenu dans la chaîne d'enrôlement est utilisé, à défaut le nom de cet ordinateur."
+          },
+          {
+            "id": "AgentTunnelDlgSubnetsLabel",
+            "text": "Sous-réseaux annoncés :"
+          },
+          {
+            "id": "AgentTunnelDlgSubnetsHint",
+            "text": "Facultatif. Plages CIDR séparées par des virgules, p. ex. 10.10.0.0/24, 192.168.1.0/24. Si laissé vide, les sous-réseaux locaux de l'agent sont détectés automatiquement."
+          },
+          {
+            "id": "AgentTunnelDlgDomainsLabel",
+            "text": "Domaines annoncés :"
+          },
+          {
+            "id": "AgentTunnelDlgDomainsHint",
+            "text": "Facultatif. Suffixes DNS séparés par des virgules que l'agent peut résoudre, p. ex. corp.example.com, lab.example.com."
           }
         ],
         "firewall": [


### PR DESCRIPTION
## Summary

The 11 Agent Tunnel localization strings added in #1789 were hand-edited directly into the generated `.wxl` files without corresponding entries in the JSON sources (`Strings_en-US.json` / `Strings_fr-FR.json`). The next `Strings.g.tt` regeneration would silently delete them — exactly the failure mode Richard flagged.

This backfills all 11 keys to both JSON sources and regenerates.

## Review note

- Real change: JSON sources (+11 each) and the 11 new `Strings.g.cs` constants.
- The `.wxl` diffs are **pure reordering** — the generator sorts by `Id` within each group. Id set vs master is +0/-0 (no keys added/removed, no text changed); those keys already existed in the `.wxl`.
- Regenerated via VS "Run Custom Tool" on `Strings.g.tt`.

No user-visible change.

Changelog: ignore