### PR TITLE
fix(agent-installer): show Agent Tunnel dialog for ADDLOCAL=ALL

### DIFF
--- a/package/AgentWindowsManaged/Dialogs/Wizard.cs
+++ b/package/AgentWindowsManaged/Dialogs/Wizard.cs
@@ -54,7 +54,16 @@ internal static class Wizard
         if (dialogType == typeof(AgentTunnelDialog))
         {
             string addlocal = (current as WixSharp.UI.Forms.ManagedForm)?.MsiRuntime?.Session?["ADDLOCAL"] ?? string.Empty;
-            return !addlocal.Split(',').Select(s => s.Trim()).Contains(Features.AGENT_TUNNEL_FEATURE.Id);
+            // ADDLOCAL=ALL installs every feature (Agent Tunnel included) without naming them, so a
+            // literal feature-id match would miss it and wrongly skip the dialog. Tokens are matched
+            // case-sensitively because Windows Installer treats the ALL keyword and feature names as
+            // case-sensitive; matching the same way keeps this decision in lockstep with whether MSI
+            // will actually install the feature (and therefore run EnrollAgentTunnel).
+            bool installsTunnel = addlocal
+                .Split(',')
+                .Select(s => s.Trim())
+                .Any(f => f == "ALL" || f == Features.AGENT_TUNNEL_FEATURE.Id);
+            return !installsTunnel;
         }
         return false;
     }


### PR DESCRIPTION
## What

`Wizard.ShouldSkip` decided whether to skip the Agent Tunnel wizard dialog by matching the `F.Tunnel` feature id **literally** in `ADDLOCAL`. `ADDLOCAL=ALL` installs every feature (Agent Tunnel included) without naming them, so the dialog was wrongly skipped — the operator never got a chance to enter an enrollment string even though the tunnel feature was being installed.

`ShouldSkip` now also recognizes the `ALL` keyword. Tokens are matched **case-sensitively**, the same way Windows Installer matches `ADDLOCAL` feature names and the `ALL` keyword, so the dialog decision stays in lockstep with whether MSI will actually install the feature (and therefore run `EnrollAgentTunnel`).

## Why

From Benoit's post-merge audit of #1789 (finding **P9**).

## Verification

Truth table over `ALL` / `all` / `F.Tunnel` / `f.tunnel` / `F.Agent,F.Tunnel` / `F.Agent` / empty — every case now agrees with MSI's actual (case-sensitive) install decision: correctly-cased `ALL` / `F.Tunnel` show the dialog, anything that wouldn't install the feature skips it. The interactive path never emits `ADDLOCAL=ALL` (it writes explicit feature names), so the `ALL` branch only matters for command-line installs.

## Note

An earlier revision of this branch also changed the empty-enrollment-string behavior (audit finding **P2**) to a silent no-op skip. **That was reverted** — an empty enrollment string keeps failing the install intentionally: the Agent Tunnel feature is opt-in (not installed by default), so selecting it without a string is a misconfiguration that should surface rather than be silently skipped. Context: https://github.com/Devolutions/devolutions-gateway/pull/1789#discussion_r3300791091