### PR TITLE
refactor: clarify agent delete access scope

### DIFF
--- a/devolutions-gateway/src/api/tunnel.rs
+++ b/devolutions-gateway/src/api/tunnel.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::DgwState;
-use crate::extract::{AgentManagementReadAccess, AgentManagementWriteAccess};
+use crate::extract::{AgentManagementDeleteAccess, AgentManagementReadAccess};
 use crate::http::HttpError;
 
 #[derive(Deserialize)]
@@ -148,7 +148,7 @@ async fn get_agent(
 
 /// Delete (unregister) an agent by ID.
 async fn delete_agent(
-    _access: AgentManagementWriteAccess,
+    _access: AgentManagementDeleteAccess,
     State(DgwState {
         agent_tunnel_handle, ..
     }): State<DgwState>,

--- a/devolutions-gateway/src/extract.rs
+++ b/devolutions-gateway/src/extract.rs
@@ -478,13 +478,13 @@ where
     }
 }
 
-/// Grants write access to agent management endpoints.
+/// Grants delete access to agent management endpoints.
 ///
 /// Accepts scope tokens with `AgentDelete` or `Wildcard` scope.
 #[derive(Clone, Copy)]
-pub struct AgentManagementWriteAccess;
+pub struct AgentManagementDeleteAccess;
 
-impl<S> FromRequestParts<S> for AgentManagementWriteAccess
+impl<S> FromRequestParts<S> for AgentManagementDeleteAccess
 where
     S: Send + Sync,
 {
@@ -500,9 +500,9 @@ where
             AccessTokenClaims::Scope(scope) => match scope.scope {
                 AccessScope::Wildcard | AccessScope::AgentDelete => Ok(Self),
                 _ => Err(HttpError::forbidden()
-                    .msg("invalid scope for agent management write (require one of: gateway.agent.delete, *)")),
+                    .msg("invalid scope for agent management delete (require one of: gateway.agent.delete, *)")),
             },
-            _ => Err(HttpError::forbidden().msg("scope token required for agent management write")),
+            _ => Err(HttpError::forbidden().msg("scope token required for agent management delete")),
         }
     }
 }


### PR DESCRIPTION
Renames the agent management delete extractor so the Gateway delete-agent route clearly reflects that it requires \gateway.agent.delete\. Issue: #1806