### PR TITLE
fix(agent): remove optional agent name from installer side

### DIFF
--- a/crates/devolutions-gateway-generators/src/lib.rs
+++ b/crates/devolutions-gateway-generators/src/lib.rs
@@ -323,8 +323,7 @@ pub fn any_kdc_claims(now: i64, validity_duration: i64) -> impl Strategy<Value =
 #[derive(Debug, Clone, Serialize)]
 pub struct EnrollmentClaims {
     pub jet_gw_url: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub jet_agent_name: Option<String>,
+    pub jet_agent_name: String,
     pub nbf: i64,
     pub exp: i64,
     pub jti: Uuid,
@@ -333,7 +332,7 @@ pub struct EnrollmentClaims {
 pub fn any_enrollment_claims(now: i64, validity_duration: i64) -> impl Strategy<Value = EnrollmentClaims> {
     (
         "https://[a-z]{1,10}\\.[a-z]{1,5}(:[0-9]{3,4})?",
-        option::of("[a-zA-Z0-9_-]{1,25}"),
+        "[a-zA-Z0-9_-]{1,25}",
         uuid_typed(),
     )
         .prop_map(move |(jet_gw_url, jet_agent_name, jti)| EnrollmentClaims {

--- a/devolutions-agent/src/enrollment.rs
+++ b/devolutions-agent/src/enrollment.rs
@@ -22,7 +22,7 @@ use crate::config;
 pub struct EnrollmentJwtClaims {
     /// Gateway URL to connect to for enrollment.
     pub jet_gw_url: String,
-    /// Agent display name set by the provisioner.
+    /// Agent friendly name.
     pub jet_agent_name: String,
 }
 
@@ -100,13 +100,16 @@ pub async fn enroll_agent(
     enrollment_token: &str,
     advertise_subnets: Vec<String>,
 ) -> Result<PersistedEnrollment> {
-    let EnrollmentJwtClaims { jet_agent_name, .. } = parse_enrollment_jwt(enrollment_token)?;
+    let EnrollmentJwtClaims {
+        jet_agent_name: agent_name,
+        ..
+    } = parse_enrollment_jwt(enrollment_token)?;
 
     // Generate key pair and CSR locally — the private key never leaves this machine.
-    let (key_pem, csr_pem) = generate_key_and_csr(&jet_agent_name)?;
+    let (key_pem, csr_pem) = generate_key_and_csr(&agent_name)?;
 
     let enroll_response = request_enrollment(gateway_url, enrollment_token, &csr_pem).await?;
-    persist_enrollment_response(&jet_agent_name, advertise_subnets, enroll_response, &key_pem)
+    persist_enrollment_response(agent_name, advertise_subnets, enroll_response, &key_pem)
 }
 
 /// Generate an ECDSA P-256 key pair and a CSR containing the agent name as CN.
@@ -155,7 +158,7 @@ async fn request_enrollment(gateway_url: &str, enrollment_token: &str, csr_pem: 
 }
 
 fn persist_enrollment_response(
-    agent_name: &str,
+    agent_name: String,
     advertise_subnets: Vec<String>,
     EnrollResponse {
         agent_id,
@@ -277,7 +280,7 @@ fn persist_enrollment_response(
 
     Ok(PersistedEnrollment {
         agent_id,
-        agent_name: agent_name.to_owned(),
+        agent_name,
         client_cert_path,
         client_key_path,
         gateway_ca_path,

--- a/devolutions-agent/src/enrollment.rs
+++ b/devolutions-agent/src/enrollment.rs
@@ -22,9 +22,8 @@ use crate::config;
 pub struct EnrollmentJwtClaims {
     /// Gateway URL to connect to for enrollment.
     pub jet_gw_url: String,
-    /// Suggested agent display name (optional hint).
-    #[serde(default)]
-    pub jet_agent_name: Option<String>,
+    /// Authoritative agent display name.
+    pub jet_agent_name: String,
 }
 
 /// Decode an enrollment JWT to extract agent-side configuration claims.
@@ -61,8 +60,6 @@ pub fn parse_enrollment_jwt(jwt: &str) -> Result<EnrollmentJwtClaims> {
 struct EnrollRequest {
     /// Agent-generated UUID (the agent owns its identity)
     agent_id: Uuid,
-    /// Friendly name for the agent
-    agent_name: String,
     /// PEM-encoded Certificate Signing Request
     csr_pem: String,
     /// Optional hostname of the agent machine (added as DNS SAN in the issued certificate)
@@ -94,20 +91,23 @@ pub struct PersistedEnrollment {
 ///
 /// # Arguments
 /// * `gateway_url` - Base Gateway URL (e.g., "https://gateway.example.com:7171")
-/// * `enrollment_token` - JWT token for enrollment
-/// * `agent_name` - Friendly name for this agent
+/// * `enrollment_token` - JWT token for enrollment. The signed `jet_gw_url`
+///   claim is also used by `up --enrollment-string` when no explicit gateway
+///   URL is provided. The signed `jet_agent_name` claim is the authoritative
+///   enrollment name.
 /// * `advertise_subnets` - List of subnets to advertise (e.g., ["10.0.0.0/8"])
 pub async fn enroll_agent(
     gateway_url: &str,
     enrollment_token: &str,
-    agent_name: &str,
     advertise_subnets: Vec<String>,
 ) -> Result<PersistedEnrollment> {
-    // Generate key pair and CSR locally — the private key never leaves this machine.
-    let (key_pem, csr_pem) = generate_key_and_csr(agent_name)?;
+    let EnrollmentJwtClaims { jet_agent_name, .. } = parse_enrollment_jwt(enrollment_token)?;
 
-    let enroll_response = request_enrollment(gateway_url, enrollment_token, agent_name, &csr_pem).await?;
-    persist_enrollment_response(agent_name, advertise_subnets, enroll_response, &key_pem)
+    // Generate key pair and CSR locally — the private key never leaves this machine.
+    let (key_pem, csr_pem) = generate_key_and_csr(&jet_agent_name)?;
+
+    let enroll_response = request_enrollment(gateway_url, enrollment_token, &csr_pem).await?;
+    persist_enrollment_response(&jet_agent_name, advertise_subnets, enroll_response, &key_pem)
 }
 
 /// Generate an ECDSA P-256 key pair and a CSR containing the agent name as CN.
@@ -127,12 +127,7 @@ fn generate_key_and_csr(agent_name: &str) -> Result<(String, String)> {
     Ok((key_pem, csr_pem))
 }
 
-async fn request_enrollment(
-    gateway_url: &str,
-    enrollment_token: &str,
-    agent_name: &str,
-    csr_pem: &str,
-) -> Result<EnrollResponse> {
+async fn request_enrollment(gateway_url: &str, enrollment_token: &str, csr_pem: &str) -> Result<EnrollResponse> {
     let client = reqwest::Client::new();
     let enroll_url = format!("{}/jet/tunnel/enroll", gateway_url.trim_end_matches('/'));
 
@@ -141,7 +136,6 @@ async fn request_enrollment(
         .bearer_auth(enrollment_token)
         .json(&EnrollRequest {
             agent_id: Uuid::new_v4(),
-            agent_name: agent_name.to_owned(),
             csr_pem: csr_pem.to_owned(),
             agent_hostname: hostname::get()
                 .ok()
@@ -392,6 +386,14 @@ mod tests {
     fn parse_enrollment_jwt_requires_gw_url() {
         let jwt = make_jwt(serde_json::json!({
             "jet_agent_name": "agent-a",
+        }));
+        assert!(parse_enrollment_jwt(&jwt).is_err());
+    }
+
+    #[test]
+    fn parse_enrollment_jwt_requires_agent_name() {
+        let jwt = make_jwt(serde_json::json!({
+            "jet_gw_url": "https://gw.example.com",
         }));
         assert!(parse_enrollment_jwt(&jwt).is_err());
     }

--- a/devolutions-agent/src/enrollment.rs
+++ b/devolutions-agent/src/enrollment.rs
@@ -22,7 +22,7 @@ use crate::config;
 pub struct EnrollmentJwtClaims {
     /// Gateway URL to connect to for enrollment.
     pub jet_gw_url: String,
-    /// Authoritative agent display name.
+    /// Agent display name set by the provisioner.
     pub jet_agent_name: String,
 }
 
@@ -93,8 +93,7 @@ pub struct PersistedEnrollment {
 /// * `gateway_url` - Base Gateway URL (e.g., "https://gateway.example.com:7171")
 /// * `enrollment_token` - JWT token for enrollment. The signed `jet_gw_url`
 ///   claim is also used by `up --enrollment-string` when no explicit gateway
-///   URL is provided. The signed `jet_agent_name` claim is the authoritative
-///   enrollment name.
+///   URL is provided. The signed `jet_agent_name` claim is the enrollment name.
 /// * `advertise_subnets` - List of subnets to advertise (e.g., ["10.0.0.0/8"])
 pub async fn enroll_agent(
     gateway_url: &str,
@@ -319,7 +318,7 @@ pub fn is_cert_expiring(cert_path: &Utf8Path, threshold_days: u32) -> Result<boo
 
 /// Extract the `CommonName` from an existing PEM certificate. The renewal CSR
 /// must reuse the agent's name across renewals — the gateway looks the agent
-/// up in its registry by that name, and the most authoritative source for it
+/// up in its registry by that name, and the source for it
 /// is the cert the gateway itself signed last time.
 pub fn read_agent_name_from_cert(cert_path: &Utf8Path) -> Result<String> {
     use std::io::BufReader;

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -55,7 +55,6 @@ const START_FAILED_ERR_CODE: u32 = 2;
 struct UpCommand {
     gateway_url: String,
     enrollment_token: String,
-    agent_name: String,
     advertise_subnets: Vec<String>,
 }
 
@@ -149,8 +148,6 @@ fn parse_up_command_args(args: &[String]) -> Result<UpCommand> {
 
 fn parse_up_command_args_with_reader<R: BufRead>(args: &[String], mut stdin_reader: R) -> Result<UpCommand> {
     let mut gateway_url = None;
-    let mut enrollment_token = None;
-    let mut agent_name = None;
     let mut enrollment_string = None;
     let mut advertise_subnets = Vec::new();
 
@@ -160,8 +157,6 @@ fn parse_up_command_args_with_reader<R: BufRead>(args: &[String], mut stdin_read
 
         match arg {
             "--gateway" => gateway_url = Some(parse_required_value(args, &mut index, "--gateway")?),
-            "--token" | "--enrollment-token" => enrollment_token = Some(parse_required_value(args, &mut index, arg)?),
-            "--name" | "--agent-name" => agent_name = Some(parse_required_value(args, &mut index, arg)?),
             "--enrollment-string" => enrollment_string = Some(parse_required_value(args, &mut index, arg)?),
             "--advertise-routes" | "--advertise-subnets" => {
                 advertise_subnets.extend(parse_advertise_subnets(&parse_required_value(args, &mut index, arg)?))
@@ -172,37 +167,29 @@ fn parse_up_command_args_with_reader<R: BufRead>(args: &[String], mut stdin_read
         index += 1;
     }
 
-    if let Some(enrollment_string) = enrollment_string {
-        // A single hyphen means "read the enrollment string from stdin".
-        let enrollment_string = if enrollment_string == "-" {
-            let mut line = String::new();
-            stdin_reader
-                .read_line(&mut line)
-                .context("failed to read enrollment string from stdin")?;
-            let trimmed = line.trim().to_owned();
-            if trimmed.is_empty() {
-                bail!("enrollment string read from stdin is empty");
-            }
-            trimmed
-        } else {
-            enrollment_string
-        };
+    let enrollment_string = enrollment_string.context("missing required --enrollment-string")?;
 
-        let claims = parse_enrollment_jwt(&enrollment_string)?;
-
-        // The JWT itself is the Bearer token; the Gateway verifies the signature.
-        gateway_url.get_or_insert(claims.jet_gw_url);
-        enrollment_token.get_or_insert(enrollment_string);
-
-        if agent_name.is_none() {
-            agent_name = claims.jet_agent_name;
+    // A single hyphen means "read the enrollment string from stdin".
+    let enrollment_token = if enrollment_string == "-" {
+        let mut line = String::new();
+        stdin_reader
+            .read_line(&mut line)
+            .context("failed to read enrollment string from stdin")?;
+        let trimmed = line.trim().to_owned();
+        if trimmed.is_empty() {
+            bail!("enrollment string read from stdin is empty");
         }
-    }
+        trimmed
+    } else {
+        enrollment_string
+    };
+
+    let claims = parse_enrollment_jwt(&enrollment_token)?;
+    gateway_url.get_or_insert(claims.jet_gw_url);
 
     Ok(UpCommand {
         gateway_url: gateway_url.context("missing required --gateway")?,
-        enrollment_token: enrollment_token.context("missing required --token")?,
-        agent_name: agent_name.context("missing required --name")?,
+        enrollment_token,
         advertise_subnets,
     })
 }
@@ -253,9 +240,8 @@ fn main() {
                 let gateway_url = env::args()
                     .nth(2)
                     .expect("missing gateway URL (e.g., https://gateway.example.com:7171)");
-                let enrollment_token = env::args().nth(3).expect("missing enrollment token");
-                let agent_name = env::args().nth(4).expect("missing agent name");
-                let subnets_arg = env::args().nth(5).unwrap_or_default();
+                let enrollment_token = env::args().nth(3).expect("missing enrollment string");
+                let subnets_arg = env::args().nth(4).unwrap_or_default();
 
                 let advertise_subnets: Vec<String> = if subnets_arg.is_empty() {
                     Vec::new()
@@ -265,13 +251,9 @@ fn main() {
 
                 let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
                 rt.block_on(async {
-                    if let Err(e) = devolutions_agent::enrollment::enroll_agent(
-                        &gateway_url,
-                        &enrollment_token,
-                        &agent_name,
-                        advertise_subnets,
-                    )
-                    .await
+                    if let Err(e) =
+                        devolutions_agent::enrollment::enroll_agent(&gateway_url, &enrollment_token, advertise_subnets)
+                            .await
                     {
                         eprintln!("[ERROR] Enrollment failed: {e:#}");
                         std::process::exit(1);
@@ -293,7 +275,6 @@ fn main() {
                     devolutions_agent::enrollment::enroll_agent(
                         &command.gateway_url,
                         &command.enrollment_token,
-                        &command.agent_name,
                         command.advertise_subnets,
                     )
                     .await
@@ -320,14 +301,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_up_command_args_uses_default_config_path() {
+    fn parse_up_command_args_accepts_advertise_routes() {
+        let jwt = make_jwt(serde_json::json!({
+            "exp": 1_999_999_999i64,
+            "jti": "00000000-0000-0000-0000-000000000000",
+            "jet_gw_url": "https://gateway.example.com:7171",
+            "jet_agent_name": "site-a-agent",
+        }));
         let args = vec![
-            "--gateway".to_owned(),
-            "https://gateway.example.com:7171".to_owned(),
-            "--token".to_owned(),
-            "bootstrap-token".to_owned(),
-            "--name".to_owned(),
-            "site-a-agent".to_owned(),
+            "--enrollment-string".to_owned(),
+            jwt.clone(),
             "--advertise-routes".to_owned(),
             "10.0.0.0/8,192.168.1.0/24".to_owned(),
         ];
@@ -338,22 +321,25 @@ mod tests {
             parsed,
             UpCommand {
                 gateway_url: "https://gateway.example.com:7171".to_owned(),
-                enrollment_token: "bootstrap-token".to_owned(),
-                agent_name: "site-a-agent".to_owned(),
+                enrollment_token: jwt,
                 advertise_subnets: vec!["10.0.0.0/8".to_owned(), "192.168.1.0/24".to_owned()],
             }
         );
     }
 
     #[test]
-    fn parse_up_command_args_accepts_aliases() {
+    fn parse_up_command_args_accepts_advertise_subnets_alias() {
+        let jwt = make_jwt(serde_json::json!({
+            "exp": 1_999_999_999i64,
+            "jti": "00000000-0000-0000-0000-000000000000",
+            "jet_gw_url": "https://gateway.example.com:7171",
+            "jet_agent_name": "site-a-agent",
+        }));
         let args = vec![
             "--gateway".to_owned(),
             "https://gateway.example.com:7171".to_owned(),
-            "--enrollment-token".to_owned(),
-            "bootstrap-token".to_owned(),
-            "--agent-name".to_owned(),
-            "site-a-agent".to_owned(),
+            "--enrollment-string".to_owned(),
+            jwt,
             "--advertise-subnets".to_owned(),
             "10.0.0.0/8".to_owned(),
         ];
@@ -391,6 +377,22 @@ mod tests {
         assert_eq!(parsed.gateway_url, "https://gateway.example.com:7171");
         // The JWT itself is used as the Bearer token for /jet/tunnel/enroll.
         assert_eq!(parsed.enrollment_token, jwt);
-        assert_eq!(parsed.agent_name, "site-a-agent");
+    }
+
+    #[test]
+    fn parse_up_command_args_rejects_split_inputs() {
+        for flag in ["--name", "--agent-name", "--token", "--enrollment-token"] {
+            let args = vec![flag.to_owned(), "site-a-agent".to_owned()];
+            let error = parse_up_command_args(&args).expect_err("argument should be rejected");
+
+            assert!(error.to_string().contains("unknown argument"));
+        }
+    }
+
+    #[test]
+    fn parse_up_command_args_requires_enrollment_string() {
+        let args = Vec::new();
+
+        assert!(parse_up_command_args(&args).is_err());
     }
 }

--- a/devolutions-gateway/src/api/tunnel.rs
+++ b/devolutions-gateway/src/api/tunnel.rs
@@ -44,7 +44,7 @@ pub fn make_router<S>(state: DgwState) -> Router<S> {
 /// Enroll a new agent.
 ///
 /// Requires a Bearer token: an `ENROLLMENT` JWT signed by the configured provisioner key
-/// (e.g. DVLS, Hub, or any PEM service).
+/// (e.g. any compatible provisioner).
 ///
 /// The agent generates its own key pair and sends a CSR. The gateway signs it
 /// and returns the certificate. The private key never leaves the agent.

--- a/devolutions-gateway/src/api/tunnel.rs
+++ b/devolutions-gateway/src/api/tunnel.rs
@@ -44,7 +44,7 @@ pub fn make_router<S>(state: DgwState) -> Router<S> {
 /// Enroll a new agent.
 ///
 /// Requires a Bearer token: an `ENROLLMENT` JWT signed by the configured provisioner key
-/// (e.g. any compatible provisioner).
+/// (e.g. DVLS, Hub, PAM service, or any other compatible provisioner).
 ///
 /// The agent generates its own key pair and sends a CSR. The gateway signs it
 /// and returns the certificate. The private key never leaves the agent.

--- a/devolutions-gateway/src/api/tunnel.rs
+++ b/devolutions-gateway/src/api/tunnel.rs
@@ -11,8 +11,6 @@ use crate::http::HttpError;
 pub struct EnrollRequest {
     /// Agent-generated UUID (the agent owns its identity).
     pub agent_id: Uuid,
-    /// Friendly name for the agent.
-    pub agent_name: String,
     /// PEM-encoded Certificate Signing Request from the agent.
     pub csr_pem: String,
     /// Optional hostname of the agent machine (added as DNS SAN in the issued certificate).
@@ -51,7 +49,7 @@ pub fn make_router<S>(state: DgwState) -> Router<S> {
 /// The agent generates its own key pair and sends a CSR. The gateway signs it
 /// and returns the certificate. The private key never leaves the agent.
 async fn enroll_agent(
-    _: crate::extract::EnrollmentToken,
+    crate::extract::EnrollmentToken(token_claims): crate::extract::EnrollmentToken,
     State(DgwState {
         conf_handle,
         agent_tunnel_handle,
@@ -59,11 +57,12 @@ async fn enroll_agent(
     }): State<DgwState>,
     Json(EnrollRequest {
         agent_id,
-        agent_name,
         csr_pem,
         agent_hostname,
     }): Json<EnrollRequest>,
 ) -> Result<Json<EnrollResponse>, HttpError> {
+    let agent_name = token_claims.jet_agent_name;
+
     // Validate agent name: 1-255 printable ASCII characters.
     if agent_name.is_empty() || 255 < agent_name.len() || agent_name.bytes().any(|b| !(0x20..=0x7E).contains(&b)) {
         return Err(HttpError::bad_request().msg("agent name must be 1-255 printable ASCII characters"));

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -504,7 +504,8 @@ pub struct ScopeTokenClaims {
 /// `jet_agent_name` locally (without verifying the signature, since it is
 /// the intended recipient), then sends the JWT as the Bearer token to
 /// `/jet/tunnel/enroll`, where the Gateway verifies the signature, content
-/// type, and expiry against the configured provisioner key.
+/// type, expiry, and authoritative agent name against the configured
+/// provisioner key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnrollmentTokenClaims {
     /// JWT expiration time claim.
@@ -516,9 +517,8 @@ pub struct EnrollmentTokenClaims {
     /// Gateway URL the agent should connect to for enrollment.
     pub jet_gw_url: String,
 
-    /// Suggested agent display name (optional hint).
-    #[serde(default)]
-    pub jet_agent_name: Option<String>,
+    /// Authoritative agent display name.
+    pub jet_agent_name: String,
 }
 
 // ----- bridge claims ----- //

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -499,8 +499,7 @@ pub struct ScopeTokenClaims {
 
 /// Claims carried by an agent-tunnel enrollment JWT.
 ///
-/// The agent reads `jet_gw_url` and `jet_agent_name` locally (without
-/// verifying the signature, since it is the intended recipient), then sends
+/// The agent reads `jet_gw_url` and `jet_agent_name` locally, then sends
 /// the JWT as the Bearer token to `/jet/tunnel/enroll`, where the Gateway
 /// verifies the signature, content type, expiry, and agent name against
 /// the configured provisioner key.
@@ -1433,7 +1432,7 @@ mod serde_impl {
 
     #[derive(Serialize, Deserialize)]
     struct AssociationClaimsHelper {
-        #[serde(default = "Uuid::new_v4")] // Older provisioners may not generate this claim.
+        #[serde(default = "Uuid::new_v4")] // DVLS up to 2021.2.10 do not generate this claim.
         jet_aid: Uuid,
         jet_ap: ApplicationProtocol,
         #[serde(flatten)]

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -499,13 +499,11 @@ pub struct ScopeTokenClaims {
 
 /// Claims carried by an agent-tunnel enrollment JWT.
 ///
-/// The JWT itself is copy-pasted by the operator into the agent's
-/// `--enrollment-string` argument. Agent reads `jet_gw_url` and
-/// `jet_agent_name` locally (without verifying the signature, since it is
-/// the intended recipient), then sends the JWT as the Bearer token to
-/// `/jet/tunnel/enroll`, where the Gateway verifies the signature, content
-/// type, expiry, and authoritative agent name against the configured
-/// provisioner key.
+/// The agent reads `jet_gw_url` and `jet_agent_name` locally (without
+/// verifying the signature, since it is the intended recipient), then sends
+/// the JWT as the Bearer token to `/jet/tunnel/enroll`, where the Gateway
+/// verifies the signature, content type, expiry, and agent name against
+/// the configured provisioner key.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EnrollmentTokenClaims {
     /// JWT expiration time claim.
@@ -517,7 +515,7 @@ pub struct EnrollmentTokenClaims {
     /// Gateway URL the agent should connect to for enrollment.
     pub jet_gw_url: String,
 
-    /// Authoritative agent display name.
+    /// Agent display name set by the provisioner.
     pub jet_agent_name: String,
 }
 
@@ -1435,7 +1433,7 @@ mod serde_impl {
 
     #[derive(Serialize, Deserialize)]
     struct AssociationClaimsHelper {
-        #[serde(default = "Uuid::new_v4")] // DVLS up to 2021.2.10 do not generate this claim.
+        #[serde(default = "Uuid::new_v4")] // Older provisioners may not generate this claim.
         jet_aid: Uuid,
         jet_ap: ApplicationProtocol,
         #[serde(flatten)]

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -514,7 +514,7 @@ pub struct EnrollmentTokenClaims {
     /// Gateway URL the agent should connect to for enrollment.
     pub jet_gw_url: String,
 
-    /// Agent display name set by the provisioner.
+    /// Agent friendly name.
     pub jet_agent_name: String,
 }
 

--- a/package/AgentWindowsManaged/Actions/AgentActions.cs
+++ b/package/AgentWindowsManaged/Actions/AgentActions.cs
@@ -294,7 +294,6 @@ internal static class AgentActions
         UsesProperties = string.Join(";", new[]
         {
             AgentProperties.AgentTunnelEnrollmentString,
-            AgentProperties.AgentTunnelAgentName,
             AgentProperties.AgentTunnelAdvertiseSubnets,
             AgentProperties.AgentTunnelAdvertiseDomains,
             AgentProperties.InstallDir,

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -13,7 +13,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Claims;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WixSharp;
@@ -364,8 +363,6 @@ namespace DevolutionsAgent.Actions
             string enrollmentString = session.Property(AgentProperties.AgentTunnelEnrollmentString)?.Trim() ?? string.Empty;
             string subnetsArg = session.Property(AgentProperties.AgentTunnelAdvertiseSubnets)?.Trim() ?? string.Empty;
             string domainsArg = session.Property(AgentProperties.AgentTunnelAdvertiseDomains)?.Trim() ?? string.Empty;
-            string agentNameArg = session.Property(AgentProperties.AgentTunnelAgentName)?.Trim() ?? string.Empty;
-
             ActionResult Fail(string msg)
             {
                 session.Log(msg);
@@ -432,31 +429,15 @@ namespace DevolutionsAgent.Actions
                     session.Log($"failed to snapshot pre-enrollment tunnel state (rollback will not restore): {e}");
                 }
 
-                // agent.exe `up` requires an agent name. Resolution: dialog value > JWT's
-                // jet_agent_name (left to the agent CLI by omitting --name) > local computer name.
-                string resolvedName = agentNameArg;
-                if (resolvedName.Length == 0 && !JwtHasAgentName(enrollmentString))
-                {
-                    resolvedName = Environment.MachineName;
-                    session.Log($"JWT carried no jet_agent_name and no name was provided in the wizard; falling back to computer name '{resolvedName}'");
-                }
-
-                // Only `--enrollment-string` is mandatory at enroll time — the gateway needs the
-                // JWT to authenticate. `--name` is conditionally passed because the gateway
-                // embeds it in the issued client cert and registers the agent under it; agent.json
-                // can't carry it before `up` runs because the file doesn't exist yet. Everything
-                // else (advertise subnets, advertise domains) is patched into agent.json *after*
-                // enrollment, so we don't accumulate parallel CLI surfaces for what is ultimately
-                // configuration data.
+                // Only `--enrollment-string` is mandatory at enroll time. The signed
+                // jet_agent_name claim is authoritative for the CSR, certificate CN, and
+                // persisted config. Everything else (advertise subnets, advertise domains) is
+                // patched into agent.json *after* enrollment, so we don't accumulate parallel CLI
+                // surfaces for what is ultimately configuration data.
                 //
                 // The JWT is passed via stdin (sentinel `-`) to avoid exposing it in the process
                 // command line (visible to any local process via WMI / Process Explorer / ETW).
                 string arguments = "up --enrollment-string -";
-                if (resolvedName.Length != 0)
-                {
-                    arguments += $" --name {EscapeArg(resolvedName)}";
-                }
-
                 string Redact(string s) => s.Replace(enrollmentString, "***");
                 session.Log($"Running enrollment: {exePath} {Redact(arguments)}");
 
@@ -631,69 +612,6 @@ namespace DevolutionsAgent.Actions
             {
                 return Fail($"Agent tunnel enrollment failed: {e.Message}");
             }
-        }
-
-        private static bool JwtHasAgentName(string jwt)
-        {
-            try
-            {
-                string[] parts = jwt.Split('.');
-                if (parts.Length != 3) return false;
-                string payload = parts[1].Replace('-', '+').Replace('_', '/');
-                payload = payload.PadRight((payload.Length + 3) & ~3, '=');
-                string json = Encoding.UTF8.GetString(Convert.FromBase64String(payload));
-                string name = JObject.Parse(json)["jet_agent_name"]?.ToString();
-                return !string.IsNullOrWhiteSpace(name);
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        /// <summary>
-        /// Escape a single argument for the Windows command line using the
-        /// <c>CommandLineToArgvW</c> rules: internal double-quotes are escaped
-        /// as <c>\"</c>, backslash runs immediately before a quote are doubled,
-        /// and the whole value is wrapped in double quotes.
-        /// </summary>
-        private static string EscapeArg(string arg)
-        {
-            StringBuilder sb = new();
-            sb.Append('"');
-
-            for (int i = 0; i < arg.Length; i++)
-            {
-                int backslashes = 0;
-                while (i < arg.Length && arg[i] == '\\')
-                {
-                    backslashes++;
-                    i++;
-                }
-
-                if (i == arg.Length)
-                {
-                    // Trailing backslashes must be doubled because the
-                    // closing quote follows immediately.
-                    sb.Append('\\', backslashes * 2);
-                    break;
-                }
-                else if (arg[i] == '"')
-                {
-                    // Backslashes before a double-quote must be doubled,
-                    // plus one extra to escape the quote itself.
-                    sb.Append('\\', backslashes * 2 + 1);
-                    sb.Append('"');
-                }
-                else
-                {
-                    sb.Append('\\', backslashes);
-                    sb.Append(arg[i]);
-                }
-            }
-
-            sb.Append('"');
-            return sb.ToString();
         }
 
         /// <summary>

--- a/package/AgentWindowsManaged/Dialogs/AgentTunnelDialog.Designer.cs
+++ b/package/AgentWindowsManaged/Dialogs/AgentTunnelDialog.Designer.cs
@@ -35,9 +35,6 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.labelEnrollmentString = new System.Windows.Forms.Label();
             this.enrollmentString = new System.Windows.Forms.TextBox();
-            this.labelAgentName = new System.Windows.Forms.Label();
-            this.agentName = new System.Windows.Forms.TextBox();
-            this.labelAgentNameHint = new System.Windows.Forms.Label();
             this.labelSubnets = new System.Windows.Forms.Label();
             this.advertiseSubnets = new System.Windows.Forms.TextBox();
             this.labelSubnetsHint = new System.Windows.Forms.Label();
@@ -81,24 +78,18 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel2.Controls.Add(this.labelEnrollmentString, 0, 0);
             this.tableLayoutPanel2.Controls.Add(this.enrollmentString, 0, 1);
-            this.tableLayoutPanel2.Controls.Add(this.labelAgentName, 0, 2);
-            this.tableLayoutPanel2.Controls.Add(this.agentName, 0, 3);
-            this.tableLayoutPanel2.Controls.Add(this.labelAgentNameHint, 0, 4);
-            this.tableLayoutPanel2.Controls.Add(this.labelSubnets, 0, 5);
-            this.tableLayoutPanel2.Controls.Add(this.advertiseSubnets, 0, 6);
-            this.tableLayoutPanel2.Controls.Add(this.labelSubnetsHint, 0, 7);
-            this.tableLayoutPanel2.Controls.Add(this.labelDomains, 0, 8);
-            this.tableLayoutPanel2.Controls.Add(this.advertiseDomains, 0, 9);
-            this.tableLayoutPanel2.Controls.Add(this.labelDomainsHint, 0, 10);
+            this.tableLayoutPanel2.Controls.Add(this.labelSubnets, 0, 2);
+            this.tableLayoutPanel2.Controls.Add(this.advertiseSubnets, 0, 3);
+            this.tableLayoutPanel2.Controls.Add(this.labelSubnetsHint, 0, 4);
+            this.tableLayoutPanel2.Controls.Add(this.labelDomains, 0, 5);
+            this.tableLayoutPanel2.Controls.Add(this.advertiseDomains, 0, 6);
+            this.tableLayoutPanel2.Controls.Add(this.labelDomainsHint, 0, 7);
             this.tableLayoutPanel2.AutoSize = true;
             this.tableLayoutPanel2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Top;
             this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
             this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 11;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel2.RowCount = 8;
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -131,36 +122,6 @@ namespace WixSharpSetup.Dialogs
             this.enrollmentString.Name = "enrollmentString";
             this.enrollmentString.Size = new System.Drawing.Size(443, 60);
             this.enrollmentString.TabIndex = 1;
-            //
-            // labelAgentName
-            //
-            this.labelAgentName.AutoSize = true;
-            this.labelAgentName.BackColor = System.Drawing.Color.Transparent;
-            this.labelAgentName.Margin = new System.Windows.Forms.Padding(3, 8, 3, 3);
-            this.labelAgentName.Name = "labelAgentName";
-            this.labelAgentName.Size = new System.Drawing.Size(200, 13);
-            this.labelAgentName.TabIndex = 11;
-            this.labelAgentName.Text = "[AgentTunnelDlgAgentNameLabel]";
-            //
-            // agentName
-            //
-            this.agentName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.agentName.Name = "agentName";
-            this.agentName.Size = new System.Drawing.Size(443, 20);
-            this.agentName.TabIndex = 12;
-            //
-            // labelAgentNameHint
-            //
-            this.labelAgentNameHint.AutoSize = true;
-            this.labelAgentNameHint.BackColor = System.Drawing.Color.Transparent;
-            this.labelAgentNameHint.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.labelAgentNameHint.Margin = new System.Windows.Forms.Padding(3, 3, 3, 3);
-            this.labelAgentNameHint.Name = "labelAgentNameHint";
-            this.labelAgentNameHint.Size = new System.Drawing.Size(300, 13);
-            this.labelAgentNameHint.TabIndex = 13;
-            this.labelAgentNameHint.Text = "[AgentTunnelDlgAgentNameHint]";
-            //
             // labelSubnets
             //
             this.labelSubnets.AutoSize = true;
@@ -399,9 +360,6 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.Label labelEnrollmentString;
         private System.Windows.Forms.TextBox enrollmentString;
-        private System.Windows.Forms.Label labelAgentName;
-        private System.Windows.Forms.TextBox agentName;
-        private System.Windows.Forms.Label labelAgentNameHint;
         private System.Windows.Forms.Label labelSubnets;
         private System.Windows.Forms.TextBox advertiseSubnets;
         private System.Windows.Forms.Label labelSubnetsHint;

--- a/package/AgentWindowsManaged/Dialogs/AgentTunnelDialog.cs
+++ b/package/AgentWindowsManaged/Dialogs/AgentTunnelDialog.cs
@@ -20,7 +20,6 @@ public partial class AgentTunnelDialog : AgentDialog
     public override bool ToProperties()
     {
         Runtime.Session[AgentProperties.AgentTunnelEnrollmentString] = enrollmentString.Text.Trim();
-        Runtime.Session[AgentProperties.AgentTunnelAgentName] = agentName.Text.Trim();
         Runtime.Session[AgentProperties.AgentTunnelAdvertiseSubnets] = advertiseSubnets.Text.Trim();
         Runtime.Session[AgentProperties.AgentTunnelAdvertiseDomains] = advertiseDomains.Text.Trim();
 
@@ -32,7 +31,6 @@ public partial class AgentTunnelDialog : AgentDialog
         banner.Image = Runtime.Session.GetResourceBitmap("WixUI_Bmp_Banner");
 
         enrollmentString.Text = Runtime.Session.Property(AgentProperties.AgentTunnelEnrollmentString);
-        agentName.Text = Runtime.Session.Property(AgentProperties.AgentTunnelAgentName);
         advertiseSubnets.Text = Runtime.Session.Property(AgentProperties.AgentTunnelAdvertiseSubnets);
         advertiseDomains.Text = Runtime.Session.Property(AgentProperties.AgentTunnelAdvertiseDomains);
 
@@ -43,10 +41,10 @@ public partial class AgentTunnelDialog : AgentDialog
     {
         // The dialog is only reached when the Agent Tunnel feature is selected
         // (see Wizard.ShouldSkip), so an enrollment string is required here.
-        // Structural validation of the string itself happens server-side at
-        // enrollment time — surface that gateway error verbatim rather than
-        // half-validating implementation details (signature, encoding, etc.)
-        // here.
+        // We only check for non-emptiness: `agent.exe up` parses the JWT locally
+        // (requiring jet_gw_url and jet_agent_name) and the gateway then verifies
+        // the signature, content type, and expiry — surface those errors verbatim
+        // rather than half-validating implementation details here.
         if (string.IsNullOrWhiteSpace(enrollmentString.Text))
         {
             ShowValidationErrorString("An enrollment string is required. Paste the enrollment string provided by your gateway operator, or go back and deselect the Agent Tunnel feature.");

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -352,7 +352,6 @@ internal class Program
         // Agent tunnel properties: must be declared Secure so the values set in the wizard UI
         // survive the UAC boundary and reach the deferred CA via CustomActionData.
         projectProperties.Add(new Property(AgentProperties.AgentTunnelEnrollmentString, "") { Hidden = true, Secure = true });
-        projectProperties.Add(new Property(AgentProperties.AgentTunnelAgentName, "") { Secure = true });
         projectProperties.Add(new Property(AgentProperties.AgentTunnelAdvertiseSubnets, "") { Secure = true });
         projectProperties.Add(new Property(AgentProperties.AgentTunnelAdvertiseDomains, "") { Secure = true });
 

--- a/package/AgentWindowsManaged/Properties/AgentProperties.cs
+++ b/package/AgentWindowsManaged/Properties/AgentProperties.cs
@@ -31,12 +31,6 @@ namespace DevolutionsAgent.Properties
         /// </summary>
         public static string AgentTunnelAdvertiseDomains = "AGENT_TUNNEL_ADVERTISE_DOMAINS";
 
-        /// <summary>
-        /// Optional agent display name. Resolution order at install time:
-        /// dialog value (if non-empty) > JWT's jet_agent_name claim (if present) > local computer name.
-        /// </summary>
-        public static string AgentTunnelAgentName = "AGENT_TUNNEL_AGENT_NAME";
-
         public AgentProperties(ISession runtimeSession)
         {
             this.runtimeSession = runtimeSession;

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_en-us.wxl
@@ -60,8 +60,6 @@ If it appears minimized then active it from the taskbar.</String>
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Welcome to the [ProductName] 20[ProductVersion] Setup Wizard</String>
                     <!-- dialogs.agentTunnel -->
-                <String Id="AgentTunnelDlgAgentNameHint">Identifies this agent in your gateway's management console. If left blank, the name embedded in the enrollment string is used, falling back to this computer's name.</String>
-                <String Id="AgentTunnelDlgAgentNameLabel">Agent Name (Optional):</String>
                 <String Id="AgentTunnelDlgDescription">Connect this agent to a Devolutions Gateway.</String>
                 <String Id="AgentTunnelDlgDomainsHint">Optional. Comma-separated DNS suffixes the agent can resolve, e.g. corp.example.com, lab.example.com.</String>
                 <String Id="AgentTunnelDlgDomainsLabel">Advertise Domains:</String>

--- a/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
+++ b/package/AgentWindowsManaged/Resources/DevolutionsAgent_fr-fr.wxl
@@ -54,8 +54,6 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Bienvenue dans l'assistant d'installation de [ProductName] 20[ProductVersion]</String>
                     <!-- dialogs.agentTunnel -->
-                <String Id="AgentTunnelDlgAgentNameHint">Identifie cet agent dans la console de gestion de votre passerelle. Si laissé vide, le nom contenu dans la chaîne d'enrôlement est utilisé, à défaut le nom de cet ordinateur.</String>
-                <String Id="AgentTunnelDlgAgentNameLabel">Nom de l'agent (facultatif) :</String>
                 <String Id="AgentTunnelDlgDescription">Connectez cet agent à une passerelle Devolutions.</String>
                 <String Id="AgentTunnelDlgDomainsHint">Facultatif. Suffixes DNS séparés par des virgules que l'agent peut résoudre, p. ex. corp.example.com, lab.example.com.</String>
                 <String Id="AgentTunnelDlgDomainsLabel">Domaines annoncés :</String>

--- a/package/AgentWindowsManaged/Resources/Strings.g.cs
+++ b/package/AgentWindowsManaged/Resources/Strings.g.cs
@@ -197,14 +197,6 @@ namespace DevolutionsAgent.Resources
 		/// </summary>
 		public const string AgentTunnelDlgEnrollmentStringLabel = "AgentTunnelDlgEnrollmentStringLabel";		
 		/// <summary>
-		/// Agent Name (Optional):
-		/// </summary>
-		public const string AgentTunnelDlgAgentNameLabel = "AgentTunnelDlgAgentNameLabel";		
-		/// <summary>
-		/// Identifies this agent in your gateway's management console. If left blank, the name embedded in the enrollment string is used, falling back to this computer's name.
-		/// </summary>
-		public const string AgentTunnelDlgAgentNameHint = "AgentTunnelDlgAgentNameHint";		
-		/// <summary>
 		/// Advertise Subnets:
 		/// </summary>
 		public const string AgentTunnelDlgSubnetsLabel = "AgentTunnelDlgSubnetsLabel";		

--- a/package/AgentWindowsManaged/Resources/Strings_en-US.json
+++ b/package/AgentWindowsManaged/Resources/Strings_en-US.json
@@ -219,14 +219,6 @@
             "text": "Enrollment String (provided by your gateway operator):"
           },
           {
-            "id": "AgentTunnelDlgAgentNameLabel",
-            "text": "Agent Name (Optional):"
-          },
-          {
-            "id": "AgentTunnelDlgAgentNameHint",
-            "text": "Identifies this agent in your gateway's management console. If left blank, the name embedded in the enrollment string is used, falling back to this computer's name."
-          },
-          {
             "id": "AgentTunnelDlgSubnetsLabel",
             "text": "Advertise Subnets:"
           },

--- a/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/AgentWindowsManaged/Resources/Strings_fr-FR.json
@@ -195,14 +195,6 @@
             "text": "Chaîne d'enrôlement (fournie par l'opérateur de votre passerelle) :"
           },
           {
-            "id": "AgentTunnelDlgAgentNameLabel",
-            "text": "Nom de l'agent (facultatif) :"
-          },
-          {
-            "id": "AgentTunnelDlgAgentNameHint",
-            "text": "Identifie cet agent dans la console de gestion de votre passerelle. Si laissé vide, le nom contenu dans la chaîne d'enrôlement est utilisé, à défaut le nom de cet ordinateur."
-          },
-          {
             "id": "AgentTunnelDlgSubnetsLabel",
             "text": "Sous-réseaux annoncés :"
           },

--- a/tools/tokengen/src/lib.rs
+++ b/tools/tokengen/src/lib.rs
@@ -62,8 +62,7 @@ pub struct EnrollmentClaims<'a> {
     pub nbf: i64,
     pub jti: Uuid,
     pub jet_gw_url: &'a str,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub jet_agent_name: Option<&'a str>,
+    pub jet_agent_name: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jet_gw_id: Option<Uuid>,
 }
@@ -255,7 +254,7 @@ pub enum SubCommandArgs {
     },
     Enrollment {
         jet_gw_url: String,
-        jet_agent_name: Option<String>,
+        jet_agent_name: String,
     },
     Bridge {
         target_host: String,
@@ -412,7 +411,7 @@ pub fn generate_token(
                 nbf,
                 jti,
                 jet_gw_url: &jet_gw_url,
-                jet_agent_name: jet_agent_name.as_deref(),
+                jet_agent_name: &jet_agent_name,
                 jet_gw_id,
             };
             ("ENROLLMENT", serde_json::to_value(claims)?)

--- a/tools/tokengen/src/main.rs
+++ b/tools/tokengen/src/main.rs
@@ -238,7 +238,7 @@ enum SignSubCommand {
         #[clap(long)]
         jet_gw_url: String,
         #[clap(long)]
-        jet_agent_name: Option<String>,
+        jet_agent_name: String,
     },
     Bridge {
         #[clap(long)]

--- a/tools/tokengen/src/server/server_impl.rs
+++ b/tools/tokengen/src/server/server_impl.rs
@@ -339,8 +339,7 @@ pub(crate) struct EnrollRequest {
     #[serde(flatten)]
     common: CommonRequest,
     jet_gw_url: String,
-    #[serde(default)]
-    jet_agent_name: Option<String>,
+    jet_agent_name: String,
 }
 
 #[derive(Deserialize)]

--- a/utils/dotnet/Devolutions.Gateway.Utils.Tests/JsonSerializationTests.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils.Tests/JsonSerializationTests.cs
@@ -197,16 +197,6 @@ public class JsonSerializationTests
     }
 
     [Fact]
-    public void EnrollmentClaimsOmitsNullOptionals()
-    {
-        const string EXPECTED = """{"jet_gw_url":"http://gw.example.com:7777"}""";
-
-        var claims = new EnrollmentClaims("http://gw.example.com:7777");
-        string result = JsonSerializer.Serialize(claims);
-        Assert.Equal(EXPECTED, result);
-    }
-
-    [Fact]
     public void NetScanClaims()
     {
         const string EXPECTED = """{"jet_gw_id":"ccbaad3f-4627-4666-8bb5-cb6a1a7db815"}""";

--- a/utils/dotnet/Devolutions.Gateway.Utils/src/EnrollmentClaims.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils/src/EnrollmentClaims.cs
@@ -5,11 +5,10 @@ namespace Devolutions.Gateway.Utils;
 /// <summary>
 /// Claims carried by an agent-tunnel enrollment JWT.
 ///
-/// DVLS signs this with the gateway's provisioner private key and hands the
-/// resulting JWT to the operator. The operator pastes the JWT into
-/// <c>devolutions-agent up --enrollment-string &lt;jwt&gt;</c>; the agent uses
-/// it as the Bearer token on <c>POST /jet/tunnel/enroll</c>, where the
-/// gateway verifies the signature, content type, and lifetime.
+/// The provisioner signs this with the gateway's private key and hands the
+/// resulting JWT to the agent. The agent uses it as the ****** on
+/// <c>POST /jet/tunnel/enroll</c>, where the gateway verifies the signature,
+/// content type, and lifetime.
 ///
 /// The agent reads <see cref="JetGwUrl"/> and <see cref="JetAgentName"/>
 /// locally without verifying the signature (it is the intended recipient).
@@ -21,16 +20,10 @@ public class EnrollmentClaims : IGatewayClaims
     public string JetGwUrl { get; set; }
 
     /// <summary>
-    /// Authoritative agent display name.
+    /// Agent display name set by the provisioner at token generation time.
     ///
     /// The gateway reads this signed claim on <c>POST /jet/tunnel/enroll</c>
     /// and stamps it into the signed client certificate's CN.
-    ///
-    /// The agent-side CLI parses this claim out of the JWT it receives via
-    /// <c>--enrollment-string</c> and uses it as the local enrollment name.
-    /// Setting it here lets DVLS bind the name the admin typed in the
-    /// "Generate Enrollment String" dialog so the agent shows up under that
-    /// name in the registry.
     /// </summary>
     [JsonPropertyName("jet_agent_name")]
     public string JetAgentName { get; set; }

--- a/utils/dotnet/Devolutions.Gateway.Utils/src/EnrollmentClaims.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils/src/EnrollmentClaims.cs
@@ -21,33 +21,21 @@ public class EnrollmentClaims : IGatewayClaims
     public string JetGwUrl { get; set; }
 
     /// <summary>
-    /// Optional agent display-name hint.
+    /// Authoritative agent display name.
     ///
-    /// The gateway never reads this claim — it only verifies the JWT
-    /// signature, content type, and expiry on <c>POST /jet/tunnel/enroll</c>; the
-    /// authoritative agent name is the one the agent sends in its
-    /// <c>EnrollRequest</c> body (which the gateway also stamps into the
-    /// signed client certificate's CN).
+    /// The gateway reads this signed claim on <c>POST /jet/tunnel/enroll</c>
+    /// and stamps it into the signed client certificate's CN.
     ///
     /// The agent-side CLI parses this claim out of the JWT it receives via
-    /// <c>--enrollment-string</c> and uses it as the default for
-    /// <c>--name</c> when the operator did not pass one explicitly. Setting
-    /// it here lets DVLS pre-fill the name the admin typed in the "Generate
-    /// Enrollment String" dialog so the agent shows up under that name in
-    /// the registry without an extra CLI flag.
-    ///
-    /// Name resolution order at install time is: explicit name (CLI
-    /// <c>--name</c> / installer dialog value) &gt; this <c>jet_agent_name</c>
-    /// claim &gt; the local computer name. The computer-name fallback is
-    /// applied by the Windows installer when neither an explicit name nor
-    /// this claim is present; if it is omitted, the agent CLI's own
-    /// <c>up</c> command instead requires <c>--name</c> to be passed.
+    /// <c>--enrollment-string</c> and uses it as the local enrollment name.
+    /// Setting it here lets DVLS bind the name the admin typed in the
+    /// "Generate Enrollment String" dialog so the agent shows up under that
+    /// name in the registry.
     /// </summary>
     [JsonPropertyName("jet_agent_name")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? JetAgentName { get; set; }
+    public string JetAgentName { get; set; }
 
-    public EnrollmentClaims(string jetGwUrl, string? jetAgentName = null)
+    public EnrollmentClaims(string jetGwUrl, string jetAgentName)
     {
         this.JetGwUrl = jetGwUrl;
         this.JetAgentName = jetAgentName;

--- a/utils/dotnet/Devolutions.Gateway.Utils/src/EnrollmentClaims.cs
+++ b/utils/dotnet/Devolutions.Gateway.Utils/src/EnrollmentClaims.cs
@@ -6,12 +6,12 @@ namespace Devolutions.Gateway.Utils;
 /// Claims carried by an agent-tunnel enrollment JWT.
 ///
 /// The provisioner signs this with the gateway's private key and hands the
-/// resulting JWT to the agent. The agent uses it as the ****** on
+/// resulting JWT to the agent. The agent uses it as the Bearer token on
 /// <c>POST /jet/tunnel/enroll</c>, where the gateway verifies the signature,
 /// content type, and lifetime.
 ///
 /// The agent reads <see cref="JetGwUrl"/> and <see cref="JetAgentName"/>
-/// locally without verifying the signature (it is the intended recipient).
+/// locally without verifying the signature.
 /// </summary>
 public class EnrollmentClaims : IGatewayClaims
 {
@@ -20,7 +20,7 @@ public class EnrollmentClaims : IGatewayClaims
     public string JetGwUrl { get; set; }
 
     /// <summary>
-    /// Agent display name set by the provisioner at token generation time.
+    /// Agent friendly name set by the provisioner at token generation time.
     ///
     /// The gateway reads this signed claim on <c>POST /jet/tunnel/enroll</c>
     /// and stamps it into the signed client certificate's CN.


### PR DESCRIPTION
The signed `jet_agent_name` enrollment claim is now authoritative and required, so the installer's optional Agent Name dialog field, the `--name`/`--gateway` CLI flags, and the request-body agent name are all removed. The agent and gateway both read the name (and gateway URL) from the JWT itself, and the gateway stamps the signed name into the client certificate CN and the agent registry. Validated end-to-end on Hyper-V (gateway on IT-HELP-GW, MSI UI install on Win10): the agent enrolls and the tunnel connects with the registered name sourced solely from the token.