### PR TITLE
fix(dgw): serve standalone web app and recording player static assets

### DIFF
--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -522,37 +522,17 @@ where
 async fn get_player<ReqBody>(
     State(DgwState { conf_handle, .. }): State<DgwState>,
     path: Option<extract::Path<String>>,
-    mut request: axum::http::Request<ReqBody>,
+    request: axum::http::Request<ReqBody>,
 ) -> Result<Response<tower_http::services::fs::ServeFileSystemResponseBody>, HttpError>
 where
     ReqBody: Send + 'static,
 {
-    use tower::ServiceExt as _;
-    use tower_http::services::{ServeDir, ServeFile};
-
     let conf = conf_handle.get_conf();
-
-    let path = path.map(|path| path.0).unwrap_or_else(|| "/".to_owned());
-
-    debug!(path, "Requested player ressource");
-
-    *request.uri_mut() = axum::http::Uri::builder()
-        .path_and_query(path)
-        .build()
-        .map_err(HttpError::internal().with_msg("invalid ressource path").err())?;
 
     let player_root = conf.web_app.static_root_path.join("player/");
     let player_index = conf.web_app.static_root_path.join("player/index.html");
 
-    match ServeDir::new(player_root)
-        .fallback(ServeFile::new(player_index))
-        .append_index_html_on_directories(true)
-        .oneshot(request)
-        .await
-    {
-        Ok(response) => Ok(response),
-        Err(never) => match never {},
-    }
+    crate::http::serve_dir(request, path, player_root, player_index).await
 }
 
 // Code from 4000 to 4999 are reserved for private custom use

--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -12,7 +12,6 @@ use axum_extra::headers::{self, HeaderMapExt as _};
 use picky::key::PrivateKey;
 use secrecy::ExposeSecret as _;
 use tap::prelude::*;
-use tower_http::services::ServeFile;
 use uuid::Uuid;
 
 use crate::DgwState;
@@ -462,40 +461,18 @@ pub(crate) async fn sign_session_token(
 async fn get_client<ReqBody>(
     State(DgwState { conf_handle, .. }): State<DgwState>,
     path: Option<extract::Path<String>>,
-    mut request: http::Request<ReqBody>,
+    request: http::Request<ReqBody>,
 ) -> Result<Response<tower_http::services::fs::ServeFileSystemResponseBody>, HttpError>
 where
     ReqBody: Send + 'static,
 {
-    use tower::ServiceExt as _;
-    use tower_http::services::ServeDir;
-
     let conf = conf_handle.get_conf();
     let conf = extract_conf(&conf)?;
-
-    // The captured wildcard ({*path}) does not include the leading slash,
-    // but `path_and_query` requires the path to start with a slash.
-    let path = format!("/{}", path.map(|path| path.0).unwrap_or_default());
-
-    debug!(path, "Requested client ressource");
-
-    *request.uri_mut() = http::Uri::builder()
-        .path_and_query(path)
-        .build()
-        .map_err(HttpError::internal().with_msg("invalid ressource path").err())?;
 
     let client_root = conf.static_root_path.join("client/");
     let client_index = conf.static_root_path.join("client/index.html");
 
-    match ServeDir::new(client_root)
-        .fallback(ServeFile::new(client_index))
-        .append_index_html_on_directories(true)
-        .oneshot(request)
-        .await
-    {
-        Ok(response) => Ok(response),
-        Err(never) => match never {},
-    }
+    crate::http::serve_dir(request, path, client_root, client_index).await
 }
 
 fn extract_conf(conf: &crate::config::Conf) -> Result<&WebAppConf, HttpError> {

--- a/devolutions-gateway/src/api/webapp.rs
+++ b/devolutions-gateway/src/api/webapp.rs
@@ -473,7 +473,9 @@ where
     let conf = conf_handle.get_conf();
     let conf = extract_conf(&conf)?;
 
-    let path = path.map(|path| path.0).unwrap_or_else(|| "/".to_owned());
+    // The captured wildcard ({*path}) does not include the leading slash,
+    // but `path_and_query` requires the path to start with a slash.
+    let path = format!("/{}", path.map(|path| path.0).unwrap_or_default());
 
     debug!(path, "Requested client ressource");
 

--- a/devolutions-gateway/src/http.rs
+++ b/devolutions-gateway/src/http.rs
@@ -131,3 +131,38 @@ impl IntoResponse for HttpError {
         self.code.into_response()
     }
 }
+
+/// Serves a static directory for a request whose sub-path was captured by a `{*path}` wildcard.
+pub(crate) async fn serve_dir<ReqBody>(
+    mut request: axum::http::Request<ReqBody>,
+    captured_path: Option<axum::extract::Path<String>>,
+    root: std::path::PathBuf,
+    index: std::path::PathBuf,
+) -> Result<Response<tower_http::services::fs::ServeFileSystemResponseBody>, HttpError>
+where
+    ReqBody: Send + 'static,
+{
+    use tower::ServiceExt as _;
+    use tower_http::services::{ServeDir, ServeFile};
+
+    // The captured wildcard ({*path}) does not include the leading slash,
+    // but `path_and_query` requires the path to start with a slash.
+    let path = format!("/{}", captured_path.map(|path| path.0).unwrap_or_default());
+
+    debug!(path, "Requested static ressource");
+
+    *request.uri_mut() = axum::http::Uri::builder()
+        .path_and_query(path)
+        .build()
+        .map_err(HttpError::internal().with_msg("invalid ressource path").err())?;
+
+    match ServeDir::new(root)
+        .fallback(ServeFile::new(index))
+        .append_index_html_on_directories(true)
+        .oneshot(request)
+        .await
+    {
+        Ok(response) => Ok(response),
+        Err(never) => match never {},
+    }
+}

--- a/devolutions-gateway/src/http.rs
+++ b/devolutions-gateway/src/http.rs
@@ -154,7 +154,7 @@ where
     *request.uri_mut() = axum::http::Uri::builder()
         .path_and_query(path)
         .build()
-        .map_err(HttpError::internal().with_msg("invalid ressource path").err())?;
+        .map_err(HttpError::internal().with_msg("invalid resource path").err())?;
 
     match ServeDir::new(root)
         .fallback(ServeFile::new(index))

--- a/devolutions-gateway/src/http.rs
+++ b/devolutions-gateway/src/http.rs
@@ -149,7 +149,7 @@ where
     // but `path_and_query` requires the path to start with a slash.
     let path = format!("/{}", captured_path.map(|path| path.0).unwrap_or_default());
 
-    debug!(path, "Requested static ressource");
+    debug!(path, "Requested static resource");
 
     *request.uri_mut() = axum::http::Uri::builder()
         .path_and_query(path)

--- a/devolutions-gateway/tests/webapp.rs
+++ b/devolutions-gateway/tests/webapp.rs
@@ -165,6 +165,68 @@ async fn custom_authentication_flow() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn client_static_assets_are_served() -> anyhow::Result<()> {
+    // Regression test: sub-resources under `/jet/webapp/client/` must be served.
+    // Since the axum 0.8 migration, the catch-all capture (`{*path}`) no longer includes
+    // the leading slash, which caused `Uri::path_and_query` to reject the path and made every
+    // static asset (JS, CSS, fonts) return 500 ("invalid ressource path") while the index
+    // page kept loading fine.
+
+    let tmp = tempfile::tempdir()?;
+    let client_dir = tmp.path().join("client");
+    std::fs::create_dir_all(client_dir.join("assets"))?;
+    std::fs::write(client_dir.join("index.html"), b"<html>index</html>")?;
+    std::fs::write(client_dir.join("chunk-DV2Y2PNY.js"), b"console.log('chunk');")?;
+    std::fs::write(client_dir.join("assets").join("styles-6RKIPFC3.css"), b"body{margin:0}")?;
+
+    let static_root = tmp
+        .path()
+        .to_str()
+        .context("non UTF-8 temporary path")?
+        .replace('\\', "/");
+
+    // Reuse the provisioner keys from CONFIG, but disable authentication (irrelevant for
+    // serving the public client files) and point the static root at our temporary directory.
+    let config = CONFIG
+        .replace("\"Authentication\": \"Custom\",", "\"Authentication\": \"None\",")
+        .replace(
+            "\"AppTokenMaximumLifetime\": 28800",
+            &format!("\"AppTokenMaximumLifetime\": 28800,\n        \"StaticRootPath\": \"{static_root}\""),
+        );
+
+    let (state, _handle) = devolutions_gateway::DgwState::mock(&config)?;
+
+    let mut app =
+        devolutions_gateway::make_http_service(state).layer(MockConnectInfo(SocketAddr::from(([0, 0, 0, 0], 3000))));
+
+    for (uri, expected_body) in [
+        ("/jet/webapp/client/chunk-DV2Y2PNY.js", "console.log('chunk');"),
+        ("/jet/webapp/client/assets/styles-6RKIPFC3.css", "body{margin:0}"),
+    ] {
+        let response = app
+            .call(
+                Request::builder()
+                    .method(http::Method::GET)
+                    .uri(uri)
+                    .body(Body::empty())?,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK, "unexpected status for {uri}");
+
+        let body = response.into_body().collect().await?.to_bytes();
+        assert_eq!(
+            std::str::from_utf8(&body).context("from_utf8")?,
+            expected_body,
+            "unexpected body for {uri}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn sign_app_token_bad_password() -> anyhow::Result<()> {
     let (cov, _guard) = init_cov_mark();
     initialize_conf();

--- a/devolutions-gateway/tests/webapp.rs
+++ b/devolutions-gateway/tests/webapp.rs
@@ -9,6 +9,7 @@ use axum::extract::connect_info::MockConnectInfo;
 use axum::http::{self, Request, StatusCode};
 use axum_extra::headers::{self, HeaderMapExt as _};
 use http_body_util::BodyExt as _;
+use rstest::rstest;
 use serde_json::json;
 use tap::prelude::*;
 use tower::{Service as _, ServiceExt as _};
@@ -164,48 +165,48 @@ async fn custom_authentication_flow() -> anyhow::Result<()> {
     Ok(())
 }
 
+// Both the standalone web application (`/jet/webapp/client`) and the recording player
+// (`/jet/jrec/play`) serve their static assets (JS, CSS, fonts) as sub-resources of a
+// `{*path}` route. This ensures such nested asset paths, including ones in sub-directories,
+// are served correctly rather than failing the request.
+#[rstest]
+#[case::webapp_client("client", "/jet/webapp/client")]
+#[case::recording_player("player", "/jet/jrec/play")]
 #[tokio::test]
-async fn client_static_assets_are_served() -> anyhow::Result<()> {
-    // The standalone web application references its static assets (JS, CSS, fonts) as
-    // sub-resources under `/jet/webapp/client/`. This test ensures such nested asset paths,
-    // including ones in sub-directories, are served correctly rather than failing the request.
-
+async fn static_assets_are_served(#[case] subdir: &str, #[case] uri_prefix: &str) -> anyhow::Result<()> {
     let tmp = tempfile::tempdir()?;
-    let client_dir = tmp.path().join("client");
-    std::fs::create_dir_all(client_dir.join("assets"))?;
-    std::fs::write(client_dir.join("index.html"), b"<html>index</html>")?;
-    std::fs::write(client_dir.join("chunk-DV2Y2PNY.js"), b"console.log('chunk');")?;
-    std::fs::write(client_dir.join("assets").join("styles-6RKIPFC3.css"), b"body{margin:0}")?;
+    let asset_dir = tmp.path().join(subdir);
+    std::fs::create_dir_all(asset_dir.join("assets"))?;
+    std::fs::write(asset_dir.join("index.html"), b"<html>index</html>")?;
+    std::fs::write(asset_dir.join("main-CHUNK42.js"), b"console.log('asset');")?;
+    std::fs::write(asset_dir.join("assets").join("styles-STYLE99.css"), b"body{margin:0}")?;
 
-    let static_root = tmp
-        .path()
-        .to_str()
-        .context("non UTF-8 temporary path")?
-        .replace('\\', "/");
+    let static_root = tmp.path().to_str().context("non UTF-8 temporary path")?;
 
-    // Reuse the provisioner keys from CONFIG, but disable authentication (irrelevant for
-    // serving the public client files) and point the static root at our temporary directory.
-    let config = CONFIG
-        .replace("\"Authentication\": \"Custom\",", "\"Authentication\": \"None\",")
-        .replace(
-            "\"AppTokenMaximumLifetime\": 28800",
-            &format!("\"AppTokenMaximumLifetime\": 28800,\n        \"StaticRootPath\": \"{static_root}\""),
-        );
+    // Reuse CONFIG, but disable authentication (irrelevant for serving the public static files)
+    // and point the static root at our temporary directory. Mutating the parsed JSON avoids
+    // depending on the exact textual formatting of CONFIG.
+    let mut config: serde_json::Value = serde_json::from_str(CONFIG)?;
+    config["WebApp"]["Authentication"] = json!("None");
+    config["WebApp"]["StaticRootPath"] = json!(static_root);
+    let config = config.to_string();
 
     let (state, _handle) = devolutions_gateway::DgwState::mock(&config)?;
 
     let mut app =
         devolutions_gateway::make_http_service(state).layer(MockConnectInfo(SocketAddr::from(([0, 0, 0, 0], 3000))));
 
-    for (uri, expected_body) in [
-        ("/jet/webapp/client/chunk-DV2Y2PNY.js", "console.log('chunk');"),
-        ("/jet/webapp/client/assets/styles-6RKIPFC3.css", "body{margin:0}"),
+    for (asset_path, expected_body) in [
+        ("main-CHUNK42.js", "console.log('asset');"),
+        ("assets/styles-STYLE99.css", "body{margin:0}"),
     ] {
+        let uri = format!("{uri_prefix}/{asset_path}");
+
         let response = app
             .call(
                 Request::builder()
                     .method(http::Method::GET)
-                    .uri(uri)
+                    .uri(&uri)
                     .body(Body::empty())?,
             )
             .await

--- a/devolutions-gateway/tests/webapp.rs
+++ b/devolutions-gateway/tests/webapp.rs
@@ -166,11 +166,9 @@ async fn custom_authentication_flow() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn client_static_assets_are_served() -> anyhow::Result<()> {
-    // Regression test: sub-resources under `/jet/webapp/client/` must be served.
-    // Since the axum 0.8 migration, the catch-all capture (`{*path}`) no longer includes
-    // the leading slash, which caused `Uri::path_and_query` to reject the path and made every
-    // static asset (JS, CSS, fonts) return 500 ("invalid ressource path") while the index
-    // page kept loading fine.
+    // The standalone web application references its static assets (JS, CSS, fonts) as
+    // sub-resources under `/jet/webapp/client/`. This test ensures such nested asset paths,
+    // including ones in sub-directories, are served correctly rather than failing the request.
 
     let tmp = tempfile::tempdir()?;
     let client_dir = tmp.path().join("client");


### PR DESCRIPTION
The standalone web application and the recording player loaded their main
page but failed to load any static assets (JS, CSS, fonts), which returned
HTTP 500. As a result both UIs were effectively broken.

Requests for sub-resources under /jet/webapp/client/ and /jet/jrec/play/
now resolve correctly, restoring the standalone web application and the
recording player.