### PR TITLE
ci(publish-libraries): fix NODE_AUTH_TOKEN workaround for PowerShell

### DIFF
--- a/ci/npm-publish.ps1
+++ b/ci/npm-publish.ps1
@@ -35,7 +35,9 @@ try
 	else
 	{
 		Write-Host "Publishing..."
-		NODE_AUTH_TOKEN="" npm publish "$Tarball" "--access=$Access" # NODE_AUTH_TOKEN is a workaround for https://github.com/actions/setup-node/issues/1440
+		# Reset NODE_AUTH_TOKEN to empty is a workaround for https://github.com/actions/setup-node/issues/1440 (OIDC trusted publishing)
+		$env:NODE_AUTH_TOKEN = ""
+		npm publish "$Tarball" "--access=$Access"
 	}
 }
 finally


### PR DESCRIPTION
## Problem

The npm publish step in `publish-libraries.yml` failed on its first real publish ([run #27769512117](https://github.com/Devolutions/devolutions-gateway/actions/runs/27769512117)) with:

```
The term 'NODE_AUTH_TOKEN=' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

## Root cause

The OIDC trusted-publishing workaround introduced in #1636 used **bash-style** inline env assignment:

```powershell
NODE_AUTH_TOKEN="" npm publish "$Tarball" "--access=$Access"
```

But this step runs under `shell: pwsh`. PowerShell parses `NODE_AUTH_TOKEN=""` as a **command name**, can't find it, and throws a (terminating) `CommandNotFoundException` — `npm publish` is never reached.

This branch in `npm-publish.ps1` only executes when a package has a **new** version to publish. Since #1636 merged (Dec 2025), every scheduled run hit only the "skip — version unchanged" path, so the buggy line was never exercised. `@devolutions/web-recorder@0.1.0` is the first genuinely-new package version since then, which is why the latent bug surfaced now.

## Fix

Set the env var the PowerShell way, preserving the OIDC workaround intent (empty `NODE_AUTH_TOKEN` so npm uses OIDC trusted publishing instead of a token):

```powershell
$env:NODE_AUTH_TOKEN = ""
npm publish "$Tarball" "--access=$Access"
```

## Validation

Reproduced locally in pwsh 7.6.3:
- The old line fails at **runtime** (not parse time) with the exact same `CommandNotFoundException` message as CI.
- The new form runs and sets `NODE_AUTH_TOKEN` to empty string as intended.

## Note / follow-up

This fixes the script-syntax blocker only. A separate open question remains: whether npm **OIDC trusted publishing is configured for the brand-new `@devolutions/web-recorder` package** on npmjs.org (trusted publishing typically requires the package/publisher to be pre-configured). That may need an ops check or a one-time token bootstrap for the first publish — out of scope for this PR.