### PR TITLE
Agent Tunnel installer follow-ups: enrollment-success != tunnel connectivity; dialog localization

### DIFF
--- a/devolutions-agent/src/enrollment.rs
+++ b/devolutions-agent/src/enrollment.rs
@@ -109,6 +109,14 @@ pub async fn enroll_agent(
     let (key_pem, csr_pem) = generate_key_and_csr(&agent_name)?;
 
     let enroll_response = request_enrollment(gateway_url, enrollment_token, &csr_pem).await?;
+
+    // TODO(agent-tunnel): enrollment success here only means the HTTPS cert exchange on
+    // POST /jet/tunnel/enroll succeeded and the config was persisted — it does NOT verify the
+    // QUIC tunnel (UDP, quic_endpoint) can actually be established. The installer's
+    // EnrollAgentTunnel custom action reports "success" on this return, so a blocked QUIC port
+    // (e.g. firewall on UDP 4433) yields a green install while the agent never comes online and
+    // silently auto-reconnects forever. Add a short post-enroll QUIC connectivity probe to
+    // enroll_response.quic_endpoint and surface a clear warning/failure when it can't connect.
     persist_enrollment_response(agent_name, advertise_subnets, enroll_response, &key_pem)
 }
 

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -439,6 +439,17 @@ internal class Program
             strings.Add(s.Attributes["Id"].Value, s.InnerText);
         }
 
+        // TODO(agent-tunnel): these strings are loaded into a LOCAL dict that only feeds the
+        // pre-flight MessageBoxes below (x86 / .NET 4.8 / newer-installed). The custom dialogs
+        // (AgentTunnelDialog, AgentDialog title, etc.) resolve their "[Key]" labels via
+        // MsiRuntime.Localize, which is NOT populated from these custom strings — light.exe only
+        // emits strings referenced via !(loc.X) into the MSI, and the custom "[Key]" labels are
+        // never !(loc.X)-referenced, so they fall back to the raw key name in the UI
+        // (e.g. "AgentTunnelDlgTitle" shows literally). Wire this `strings` dict into the
+        // ManagedUI runtime localization (or have the custom dialogs use a shared I18n backed by
+        // it) so the labels render. Standard dialogs (Welcome/InstallDir) work only because
+        // WixSharp's built-in UI references those standard IDs via !(loc.X).
+
         string I18n(string key)
         {
             if (!strings.TryGetValue(key, out string result))


### PR DESCRIPTION
> Draft / tracker — two known gaps found while bringing up the Agent Tunnel end-to-end (DVLS agent-tunnel branch + Gateway master). TODOs are placed at the exact code sites. Not fixed yet.

## 1. Installer reports success on enrollment, not on tunnel connectivity

**Symptom:** MSI install shows the Agent Tunnel step as **success**, but the agent never appears online in the Gateway / DVLS agent list.

**Root cause:** `EnrollAgentTunnel` runs `devolutions-agent up` → `enroll_agent()` (`devolutions-agent/src/enrollment.rs`). Its success criteria is only:
1. `POST https://<gw>:7171/jet/tunnel/enroll` (HTTPS **management** port) returns 2xx and issues the client cert, and
2. the cert/key/CA + `Tunnel` section are persisted to `agent.json`.

The actual data path — the **QUIC tunnel over UDP (`quic_endpoint`, 4433)** — is established later by the agent service (`devolutions_agent::tunnel`, with auto-reconnect) and is **never probed at install time**. Enrollment uses 7171; the tunnel uses 4433. So when 4433 is blocked (e.g. firewall) the install is green while the agent silently fails to connect.

**Reproduced:** Gateway host firewall had no inbound `UDP 4433` rule → agent log: `Tunnel connection lost error=QUIC handshake: timed out` → agent absent from `GET /jet/tunnel/agents`, yet the installer said success.

**Suggested fix:** after `enroll_agent`, do a short QUIC connectivity probe to `enroll_response.quic_endpoint` and surface a clear warning/failure when it can't connect (so admins get actionable feedback at install time). TODO marker in `enrollment.rs`.

## 2. Custom installer dialog labels show raw localization keys

**Symptom:** The Agent Tunnel dialog (and the base dialog title) render literal keys — `AgentTunnelDlgTitle`, `AgentTunnelDlgEnrollmentStringLabel`, `AgentDlg_Title`, … — instead of the translated text.

**Root cause:** The strings exist correctly in `Strings_*.json` and `DevolutionsAgent_*.wxl`. At runtime `Project_UIInitialized` loads the embedded `.wxl` into a **local** dict that only feeds the pre-flight MessageBoxes. The custom dialogs resolve `[Key]` via `MsiRuntime.Localize`, which is **not** populated from these custom strings — `light.exe` only emits strings referenced via `!(loc.X)` into the MSI, and the custom `[Key]` labels are never `!(loc.X)`-referenced (verified via `dark.exe`: the strings are absent from the built MSI's localization tables). Standard dialogs (Welcome/InstallDir) work only because WixSharp's built-in UI references those standard IDs via `!(loc.X)`.

**Suggested fix:** wire the loaded `strings` dict into the ManagedUI runtime localization (or back the custom dialogs with a shared `I18n` that reads it). TODO marker in `Program.cs`.
