### PR TITLE
fix(agent-installer): pin Newtonsoft ToString overload to avoid GAC binding crash

### DIFF
--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -287,7 +287,15 @@ namespace DevolutionsAgent.Actions
                 featureConfig["Enabled"] = enable;
 
                 using StreamWriter writer = new StreamWriter(path);
-                writer.Write(config.ToString(Formatting.None));
+                // WARNING: Always pass an explicit JsonConverter[] to JToken/JObject.ToString(Formatting, ...).
+                // Newtonsoft.Json keeps the same AssemblyVersion (13.0.0.0) across every 13.x patch release, so the
+                // CLR loads whatever 13.x copy is in the GAC in preference to the one bundled in the SFXCA payload,
+                // regardless of what this project references. The single-argument ToString(Formatting) overload was
+                // only added in 13.0.4; binding to it crashes with MissingMethodException when an older 13.x is in
+                // the GAC (common: RDM, PowerShell 7, Dell Command, etc.), which rolls back the whole install. The
+                // two-argument ToString(Formatting, params JsonConverter[]) overload exists in every 13.x, so forcing
+                // it keeps us safe no matter which 13.x wins assembly resolution. See Newtonsoft.Json issue #3084.
+                writer.Write(config.ToString(Formatting.None, Array.Empty<JsonConverter>()));
 
                 return ActionResult.Success;
             }
@@ -674,7 +682,10 @@ namespace DevolutionsAgent.Actions
             // operator's data while falsely reporting success. Write atomically so a mid-write
             // failure can't truncate agent.json — the rollback path re-parses it to restore the
             // original Tunnel section, which a half-written file would make impossible.
-            WriteFileAtomic(configPath, root.ToString(Formatting.Indented));
+            // Pass an explicit JsonConverter[]: the single-argument ToString(Formatting) overload only exists in
+            // Newtonsoft.Json 13.0.4+ and crashes with MissingMethodException against an older 13.x in the GAC.
+            // See the detailed note in ToggleAgentFeature and Newtonsoft.Json issue #3084.
+            WriteFileAtomic(configPath, root.ToString(Formatting.Indented, Array.Empty<JsonConverter>()));
             session.Log($"Wrote {subnets.Length} advertise_subnets and {domains.Length} advertise_domains entries to agent.json");
         }
 
@@ -1020,7 +1031,10 @@ namespace DevolutionsAgent.Actions
                         session.Log("removed Tunnel section from agent.json during enrollment rollback");
                     }
 
-                    WriteFileAtomic(configPath, root.ToString(Formatting.Indented));
+                    // Pass an explicit JsonConverter[]: the single-argument ToString(Formatting) overload only exists
+                    // in Newtonsoft.Json 13.0.4+ and crashes with MissingMethodException against an older 13.x in the
+                    // GAC. See the detailed note in ToggleAgentFeature and Newtonsoft.Json issue #3084.
+                    WriteFileAtomic(configPath, root.ToString(Formatting.Indented, Array.Empty<JsonConverter>()));
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Fixes a failure where installing or reconfiguring the Devolutions Agent could roll back with a `MissingMethodException` on machines that already have an older Newtonsoft.Json in the Global Assembly Cache (GAC).

The installer's managed (DTF) custom actions formatted `agent.json` via `JObject.ToString(Formatting)`. That single-argument overload was introduced in Newtonsoft.Json 13.0.4, and the installer references 13.0.4. However, every Newtonsoft.Json 13.x release ships the same `AssemblyVersion` (13.0.0.0), so the CLR loads whichever 13.x copy is registered in the GAC in preference to the one bundled in the custom-action (SFXCA) payload. When an older 13.x is present in the GAC — commonly installed by Remote Desktop Manager, PowerShell 7, Dell Command, and many other products — the call fails with:

```
System.MissingMethodException: Method not found:
'System.String Newtonsoft.Json.Linq.JToken.ToString(Newtonsoft.Json.Formatting)'
```

and the whole MSI transaction rolls back during `ConfigureFeatures`.

The fix forces the two-argument `ToString(Formatting, params JsonConverter[])` overload (by passing an empty converter array) at all three call sites. That overload exists in every 13.x release, so the custom actions now behave correctly no matter which 13.x wins assembly resolution. This required no version change and no change to what ships in the package.

Affected: Agent 2026.2.2 (first build to reference 13.0.4).

The Gateway installer (`package/WindowsManaged`) was checked as well. It references 13.0.3 and makes no `ToString(Formatting)` calls, so it is not affected today — though it shares the same structural exposure (strong-named Newtonsoft loaded by DTF custom actions, subject to GAC precedence) and should adopt the same overload discipline if it is ever bumped to 13.0.4+.

Reference: https://github.com/JamesNK/Newtonsoft.Json/issues/3084

Issue: DGW-396