### PR TITLE
fix(agent-installer): resolve raw localization keys in custom dialog labels

### DIFF
--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -13,9 +13,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text.RegularExpressions;
 using System.Windows.Forms;
-using System.Xml;
 
 using WixSharp;
 using WixSharp.CommonTasks;
@@ -425,44 +423,32 @@ internal class Program
     private static void Project_UIInitialized(SetupEventArgs e)
     {
         string lcid = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName == "fr" ? frFR.Key : enUS.Key;
+        string resourceName = $"DevolutionsAgent.Resources.{Languages[lcid]}";
 
-        using Stream stream = Assembly.GetExecutingAssembly()
-            .GetManifestResourceStream($"DevolutionsAgent.Resources.{Languages[lcid]}");
+        using Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(resourceName);
 
-        XmlDocument xml = new();
-        xml.Load(stream);
-
-        Dictionary<string, string> strings = new();
-
-        foreach (XmlNode s in xml.GetElementsByTagName("String"))
+        if (stream is null)
         {
-            strings.Add(s.Attributes["Id"].Value, s.InnerText);
+            throw new FileNotFoundException($"Missing localization resource: {resourceName}");
         }
 
-        // TODO(agent-tunnel): these strings are loaded into a LOCAL dict that only feeds the
-        // pre-flight MessageBoxes below (x86 / .NET 4.8 / newer-installed). The custom dialogs
-        // (AgentTunnelDialog, AgentDialog title, etc.) resolve their "[Key]" labels via
-        // MsiRuntime.Localize, which is NOT populated from these custom strings — light.exe only
-        // emits strings referenced via !(loc.X) into the MSI, and the custom "[Key]" labels are
-        // never !(loc.X)-referenced, so they fall back to the raw key name in the UI
-        // (e.g. "AgentTunnelDlgTitle" shows literally). Wire this `strings` dict into the
-        // ManagedUI runtime localization (or have the custom dialogs use a shared I18n backed by
-        // it) so the labels render. Standard dialogs (Welcome/InstallDir) work only because
-        // WixSharp's built-in UI references those standard IDs via !(loc.X).
+        using MemoryStream memory = new();
+        stream.CopyTo(memory);
+
+        if (e.ManagedUI.Shell.RuntimeContext is not InstallerRuntime runtime)
+        {
+            throw new InvalidOperationException("Managed UI runtime is not available");
+        }
+
+        runtime.UIText.InitFromWxl(memory.ToArray(), true);
 
         string I18n(string key)
         {
-            if (!strings.TryGetValue(key, out string result))
+            string localized = $"[{key}]".LocalizeWith(runtime.Localize);
+            return localized.LocalizeWith(name =>
             {
-                return key;
-            }
-
-            return Regex.Replace(result, @"\[(.*?)]", (match) =>
-            {
-                string property = match.Groups[1].Value;
-                string value = e.Session[property];
-
-                return string.IsNullOrEmpty(value) ? property : value;
+                string value = e.Session[name];
+                return string.IsNullOrEmpty(value) ? null : value;
             });
         }
 

--- a/package/AgentWindowsManaged/Program.cs
+++ b/package/AgentWindowsManaged/Program.cs
@@ -439,6 +439,17 @@ internal class Program
             strings.Add(s.Attributes["Id"].Value, s.InnerText);
         }
 
+        // TODO(agent-tunnel): these strings are loaded into a LOCAL dict that only feeds the
+        // pre-flight MessageBoxes below (x86 / .NET 4.8 / newer-installed). The custom dialogs
+        // (AgentTunnelDialog, AgentDialog title, etc.) resolve their "[Key]" labels via
+        // MsiRuntime.Localize, which is NOT populated from these custom strings — light.exe only
+        // emits strings referenced via !(loc.X) into the MSI, and the custom "[Key]" labels are
+        // never !(loc.X)-referenced, so they fall back to the raw key name in the UI
+        // (e.g. "AgentTunnelDlgTitle" shows literally). Wire this `strings` dict into the
+        // ManagedUI runtime localization (or have the custom dialogs use a shared I18n backed by
+        // it) so the labels render. Standard dialogs (Welcome/InstallDir) work only because
+        // WixSharp's built-in UI references those standard IDs via !(loc.X).
+
         string I18n(string key)
         {
             if (!strings.TryGetValue(key, out string result))


### PR DESCRIPTION
Split out of #1831 (draft tracker — the `TODO(agent-tunnel)` marker is placed at the exact code site; not fixed yet).

## Custom installer dialog labels show raw localization keys

**Symptom:** The Agent Tunnel dialog (and the base dialog title) render literal keys — `AgentTunnelDlgTitle`, `AgentTunnelDlgEnrollmentStringLabel`, `AgentDlg_Title`, … — instead of the translated text.

**Root cause:** The strings exist correctly in `Strings_*.json` and `DevolutionsAgent_*.wxl`. At runtime `Project_UIInitialized` loads the embedded `.wxl` into a **local** dict that only feeds the pre-flight MessageBoxes. The custom dialogs resolve `[Key]` via `MsiRuntime.Localize`, which is **not** populated from these custom strings — `light.exe` only emits strings referenced via `!(loc.X)` into the MSI, and the custom `[Key]` labels are never `!(loc.X)`-referenced (verified via `dark.exe`: the strings are absent from the built MSI's localization tables). Standard dialogs (Welcome/InstallDir) work only because WixSharp's built-in UI references those standard IDs via `!(loc.X)`.

**Suggested fix:** wire the loaded `strings` dict into the ManagedUI runtime localization (or back the custom dialogs with a shared `I18n` that reads it). `TODO(agent-tunnel)` marker in `Program.cs`.
