### PR TITLE
fix(agent,agent-installer): fail the install if the agent tunnel can't reach the gateway

### DIFF
--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -42,6 +42,7 @@ mod service;
 use std::env;
 use std::io::{self, BufRead};
 use std::sync::mpsc;
+use std::time::Duration;
 
 use anyhow::{Context as _, Result, bail};
 use ceviche::Service;
@@ -281,7 +282,12 @@ fn main() {
                         &command.enrollment_token,
                         command.advertise_subnets,
                     )
-                    .await
+                    .await?;
+
+                    // Enrollment only proves HTTPS/TCP; fail the install now if the QUIC/UDP tunnel
+                    // path is blocked, while the operator is still here to fix the firewall.
+                    let conf = ConfHandle::init().context("load agent configuration for connectivity probe")?;
+                    devolutions_agent::tunnel::probe_connectivity(&conf.get_conf().tunnel, Duration::from_secs(15)).await
                 });
 
                 if let Err(error) = result {

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -287,7 +287,8 @@ fn main() {
                     // Enrollment only proves HTTPS/TCP; fail the install now if the QUIC/UDP tunnel
                     // path is blocked, while the operator is still here to fix the firewall.
                     let conf = ConfHandle::init().context("load agent configuration for connectivity probe")?;
-                    devolutions_agent::tunnel::probe_connectivity(&conf.get_conf().tunnel, Duration::from_secs(15)).await
+                    devolutions_agent::tunnel::probe_connectivity(&conf.get_conf().tunnel, Duration::from_secs(15))
+                        .await
                 });
 
                 if let Err(error) = result {

--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -276,23 +276,30 @@ fn main() {
                 };
 
                 let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-                let result = rt.block_on(async {
-                    devolutions_agent::enrollment::enroll_agent(
-                        &command.gateway_url,
-                        &command.enrollment_token,
-                        command.advertise_subnets,
-                    )
-                    .await?;
+                let result = rt.block_on(devolutions_agent::enrollment::enroll_agent(
+                    &command.gateway_url,
+                    &command.enrollment_token,
+                    command.advertise_subnets,
+                ));
 
-                    // Enrollment only proves HTTPS/TCP; fail the install now if the QUIC/UDP tunnel
-                    // path is blocked, while the operator is still here to fix the firewall.
+                if let Err(error) = result {
+                    eprintln!("[ERROR] Enrollment failed: {error:#}");
+                    std::process::exit(1);
+                }
+            }
+            "probe" => {
+                // Enrollment only proves the HTTPS/TCP path; this probes the QUIC/UDP tunnel path
+                // separately so it can be run as a standalone diagnostic (and so the installer can
+                // fail the install while the operator is still here to fix the firewall).
+                let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+                let result = rt.block_on(async {
                     let conf = ConfHandle::init().context("load agent configuration for connectivity probe")?;
                     devolutions_agent::tunnel::probe_connectivity(&conf.get_conf().tunnel, Duration::from_secs(15))
                         .await
                 });
 
                 if let Err(error) = result {
-                    eprintln!("[ERROR] Bootstrap failed: {error:#}");
+                    eprintln!("[ERROR] Connectivity probe failed: {error:#}");
                     std::process::exit(1);
                 }
             }

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -451,8 +451,8 @@ async fn connect_to_gateway(
     Ok((endpoint, connection))
 }
 
-/// Confirm the QUIC/UDP path to the gateway is open by completing one mTLS+QUIC handshake, then
-/// draining the connection, bounded by `timeout`.
+/// Confirm the QUIC/UDP path to the gateway is open by completing one mTLS+QUIC handshake within
+/// `timeout`, then draining the connection (a best-effort teardown that adds up to ~3s).
 pub async fn probe_connectivity(tunnel_conf: &crate::config::TunnelConf, timeout: Duration) -> anyhow::Result<()> {
     if !tunnel_conf.enabled {
         bail!("agent tunnel is not enabled");
@@ -707,7 +707,7 @@ mod tests {
     #[tokio::test]
     async fn probe_times_out_when_gateway_unreachable() {
         // Throwaway PEMs so the pre-connect file reads succeed; nothing listens on the target
-        // port, so the handshake never completes and the probe must hit its own timeout.
+        // port, so the probe fails quickly — via its own timeout or an immediate connect error.
         let cert_key =
             rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).expect("generate self-signed cert");
         let dir = tempfile::tempdir().expect("temp dir");

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -189,10 +189,22 @@ enum ConnectionOutcome {
     CertRenewed,
 }
 
-/// Build the route advertisement payload from the current tunnel configuration.
-fn route_advertisements(
-    tunnel_conf: &crate::config::TunnelConf,
-) -> anyhow::Result<(Vec<Ipv4Network>, Vec<agent_tunnel_proto::DomainAdvertisement>)> {
+/// Run a single QUIC tunnel connection lifetime: config → connect → event loop.
+///
+/// - `Ok(Shutdown)`: graceful shutdown, exit the task.
+/// - `Ok(CertRenewed)`: certificate renewed; caller should reconnect immediately.
+/// - `Err(_)`: connection lost or handshake failed — caller should retry with backoff.
+async fn run_single_connection(
+    conf_handle: &ConfHandle,
+    shutdown_signal: &mut ShutdownSignal,
+) -> anyhow::Result<ConnectionOutcome> {
+    let agent_conf = conf_handle.get_conf();
+    let tunnel_conf = &agent_conf.tunnel;
+
+    let cert_path = &tunnel_conf.client_cert_path;
+    let key_path = &tunnel_conf.client_key_path;
+    let ca_path = &tunnel_conf.gateway_ca_cert_path;
+
     let advertise_subnets: Vec<Ipv4Network> = tunnel_conf
         .advertise_subnets
         .iter()
@@ -244,7 +256,86 @@ fn route_advertisements(
         "Advertising subnets and domains"
     );
 
-    Ok((advertise_subnets, advertise_domains))
+    let (_endpoint, connection) = connect_to_gateway(tunnel_conf).await?;
+
+    // -- Open control stream --
+
+    let mut ctrl: ControlStream<_, _> = connection.open_bi().await.context("open control stream")?.into();
+
+    // Send initial RouteAdvertise.
+    let epoch = 1u64;
+    let msg = ControlMessage::route_advertise(epoch, advertise_subnets.clone(), advertise_domains.clone());
+
+    ctrl.send(&msg).await.context("send initial RouteAdvertise")?;
+
+    info!(epoch, "Sent initial RouteAdvertise");
+
+    // -- Certificate renewal (post-connect, pre-traffic) --
+    //
+    // Run once per reconnect rather than on a periodic timer: the QUIC session
+    // has a 120s idle timeout and 15s keep-alive, so any blip / VPN reconnect
+    // / host sleep / gateway restart drops the connection within minutes and
+    // sends us back through this path. With a 1-year cert and a 15-day
+    // threshold, the renewal window will be hit on the first reconnect after
+    // T-15d, which is more than often enough in any real deployment.
+    if let Some(outcome) = try_renew_certificate(&mut ctrl, &connection, cert_path, key_path, ca_path).await? {
+        return Ok(outcome);
+    }
+
+    // Split: recv half goes to a reader task, send half stays for periodic messages.
+    let (mut ctrl_send, ctrl_recv) = ctrl.into_split();
+    let mut task_handles = tokio::task::JoinSet::new();
+    task_handles.spawn(run_control_reader(ctrl_recv));
+
+    // -- Main loop: accept incoming session streams + periodic tasks --
+
+    let route_interval = tunnel_conf.route_advertise_interval_secs;
+    let heartbeat_interval_secs = tunnel_conf.heartbeat_interval_secs;
+    let mut route_tick = tokio::time::interval(Duration::from_secs(route_interval));
+    let mut heartbeat_tick = tokio::time::interval(Duration::from_secs(heartbeat_interval_secs));
+    // Skip the first immediate tick (we already sent the initial RouteAdvertise).
+    route_tick.tick().await;
+    heartbeat_tick.tick().await;
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = shutdown_signal.wait() => {
+                info!("Tunnel task shutting down");
+                connection.close(0u32.into(), b"shutting down");
+                break;
+            }
+
+            _ = route_tick.tick() => {
+                let msg = ControlMessage::route_advertise(epoch, advertise_subnets.clone(), advertise_domains.clone());
+                let _ = ctrl_send.send(&msg).await
+                    .inspect(|_| trace!(epoch, "Sent RouteAdvertise (refresh)"))
+                    .inspect_err(|e| error!(%e, "Failed to send RouteAdvertise"));
+            }
+
+            _ = heartbeat_tick.tick() => {
+                // TODO: track actual active_stream_count instead of hardcoded 0.
+                let msg = ControlMessage::heartbeat(current_time_millis(), 0);
+                let _ = ctrl_send.send(&msg).await
+                    .inspect(|_| trace!("Sent Heartbeat"))
+                    .inspect_err(|e| error!(%e, "Failed to send Heartbeat"));
+            }
+
+            result = connection.accept_bi() => {
+                let (send, recv) = result.context("accept incoming bidi stream")?;
+                let subnets = advertise_subnets.clone();
+                task_handles.spawn(run_session_proxy(subnets, send, recv));
+            }
+
+            // Reap completed session tasks.
+            Some(_) = task_handles.join_next() => {}
+        }
+    }
+
+    task_handles.shutdown().await;
+
+    Ok(ConnectionOutcome::Shutdown)
 }
 
 /// Build the mTLS client config, resolve the gateway endpoint, and perform the
@@ -377,105 +468,6 @@ pub async fn probe_connectivity(tunnel_conf: &crate::config::TunnelConf, timeout
     let _ = tokio::time::timeout(Duration::from_secs(3), endpoint.wait_idle()).await;
 
     Ok(())
-}
-
-/// Run a single QUIC tunnel connection lifetime: config → connect → event loop.
-///
-/// - `Ok(Shutdown)`: graceful shutdown, exit the task.
-/// - `Ok(CertRenewed)`: certificate renewed; caller should reconnect immediately.
-/// - `Err(_)`: connection lost or handshake failed — caller should retry with backoff.
-async fn run_single_connection(
-    conf_handle: &ConfHandle,
-    shutdown_signal: &mut ShutdownSignal,
-) -> anyhow::Result<ConnectionOutcome> {
-    let agent_conf = conf_handle.get_conf();
-    let tunnel_conf = &agent_conf.tunnel;
-
-    let cert_path = &tunnel_conf.client_cert_path;
-    let key_path = &tunnel_conf.client_key_path;
-    let ca_path = &tunnel_conf.gateway_ca_cert_path;
-
-    let (advertise_subnets, advertise_domains) = route_advertisements(tunnel_conf)?;
-    let (_endpoint, connection) = connect_to_gateway(tunnel_conf).await?;
-
-    // -- Open control stream --
-
-    let mut ctrl: ControlStream<_, _> = connection.open_bi().await.context("open control stream")?.into();
-
-    // Send initial RouteAdvertise.
-    let epoch = 1u64;
-    let msg = ControlMessage::route_advertise(epoch, advertise_subnets.clone(), advertise_domains.clone());
-
-    ctrl.send(&msg).await.context("send initial RouteAdvertise")?;
-
-    info!(epoch, "Sent initial RouteAdvertise");
-
-    // -- Certificate renewal (post-connect, pre-traffic) --
-    //
-    // Run once per reconnect rather than on a periodic timer: the QUIC session
-    // has a 120s idle timeout and 15s keep-alive, so any blip / VPN reconnect
-    // / host sleep / gateway restart drops the connection within minutes and
-    // sends us back through this path. With a 1-year cert and a 15-day
-    // threshold, the renewal window will be hit on the first reconnect after
-    // T-15d, which is more than often enough in any real deployment.
-    if let Some(outcome) = try_renew_certificate(&mut ctrl, &connection, cert_path, key_path, ca_path).await? {
-        return Ok(outcome);
-    }
-
-    // Split: recv half goes to a reader task, send half stays for periodic messages.
-    let (mut ctrl_send, ctrl_recv) = ctrl.into_split();
-    let mut task_handles = tokio::task::JoinSet::new();
-    task_handles.spawn(run_control_reader(ctrl_recv));
-
-    // -- Main loop: accept incoming session streams + periodic tasks --
-
-    let route_interval = tunnel_conf.route_advertise_interval_secs;
-    let heartbeat_interval_secs = tunnel_conf.heartbeat_interval_secs;
-    let mut route_tick = tokio::time::interval(Duration::from_secs(route_interval));
-    let mut heartbeat_tick = tokio::time::interval(Duration::from_secs(heartbeat_interval_secs));
-    // Skip the first immediate tick (we already sent the initial RouteAdvertise).
-    route_tick.tick().await;
-    heartbeat_tick.tick().await;
-
-    loop {
-        tokio::select! {
-            biased;
-
-            _ = shutdown_signal.wait() => {
-                info!("Tunnel task shutting down");
-                connection.close(0u32.into(), b"shutting down");
-                break;
-            }
-
-            _ = route_tick.tick() => {
-                let msg = ControlMessage::route_advertise(epoch, advertise_subnets.clone(), advertise_domains.clone());
-                let _ = ctrl_send.send(&msg).await
-                    .inspect(|_| trace!(epoch, "Sent RouteAdvertise (refresh)"))
-                    .inspect_err(|e| error!(%e, "Failed to send RouteAdvertise"));
-            }
-
-            _ = heartbeat_tick.tick() => {
-                // TODO: track actual active_stream_count instead of hardcoded 0.
-                let msg = ControlMessage::heartbeat(current_time_millis(), 0);
-                let _ = ctrl_send.send(&msg).await
-                    .inspect(|_| trace!("Sent Heartbeat"))
-                    .inspect_err(|e| error!(%e, "Failed to send Heartbeat"));
-            }
-
-            result = connection.accept_bi() => {
-                let (send, recv) = result.context("accept incoming bidi stream")?;
-                let subnets = advertise_subnets.clone();
-                task_handles.spawn(run_session_proxy(subnets, send, recv));
-            }
-
-            // Reap completed session tasks.
-            Some(_) = task_handles.join_next() => {}
-        }
-    }
-
-    task_handles.shutdown().await;
-
-    Ok(ConnectionOutcome::Shutdown)
 }
 
 // ---------------------------------------------------------------------------

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -706,7 +706,10 @@ mod tests {
             .await
             .expect_err("probe must fail when the tunnel is disabled");
 
-        assert!(format!("{error:#}").contains("not enabled"), "unexpected error: {error:#}");
+        assert!(
+            format!("{error:#}").contains("not enabled"),
+            "unexpected error: {error:#}"
+        );
     }
 
     #[tokio::test]

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -451,23 +451,85 @@ async fn connect_to_gateway(
     Ok((endpoint, connection))
 }
 
-/// Confirm the QUIC/UDP path to the gateway is open by completing one mTLS+QUIC handshake within
-/// `timeout`, then draining the connection (a best-effort teardown that adds up to ~3s).
+/// Reachability probe: confirm the gateway's QUIC/UDP endpoint answers within `timeout`.
+///
+/// This deliberately does NOT complete a QUIC/mTLS handshake. A real handshake would register
+/// this agent's connection on the gateway (keyed by the enrolled `agent_id`) and, on close,
+/// unregister it — so a probe run against a machine whose service tunnel is live would evict the
+/// real connection. Instead we send a QUIC long-header packet carrying an unsupported version and
+/// wait for the gateway to reply with a Version Negotiation packet. That reply proves UDP/4433
+/// reaches the gateway while creating zero connection state on it, and needs no client cert.
 pub async fn probe_connectivity(tunnel_conf: &crate::config::TunnelConf, timeout: Duration) -> anyhow::Result<()> {
     if !tunnel_conf.enabled {
         bail!("agent tunnel is not enabled");
     }
 
-    let (endpoint, connection) = tokio::time::timeout(timeout, connect_to_gateway(tunnel_conf))
+    // The whole probe — DNS resolution, socket setup, and the retransmit loop — is bounded by
+    // `timeout`, so a stalled resolver or a black-holed path can't hang past it.
+    match tokio::time::timeout(timeout, reach_gateway(tunnel_conf)).await {
+        Ok(result) => result,
+        Err(_elapsed) => bail!("gateway QUIC endpoint did not respond within {timeout:?}"),
+    }
+}
+
+async fn reach_gateway(tunnel_conf: &crate::config::TunnelConf) -> anyhow::Result<()> {
+    let gateway_addr = tokio::net::lookup_host(&tunnel_conf.gateway_endpoint)
         .await
-        .context("tunnel connectivity probe timed out")??;
+        .context("failed to resolve gateway endpoint")?
+        .next()
+        .context("no addresses resolved for gateway endpoint")?;
 
-    // Flush the CONNECTION_CLOSE so the gateway unregisters this probe's connection promptly
-    // (keyed by agent_id) rather than after its idle timeout.
-    connection.close(0u32.into(), b"probe-complete");
-    let _ = tokio::time::timeout(Duration::from_secs(3), endpoint.wait_idle()).await;
+    // Match the local bind family to the resolved gateway address (see connect_to_gateway).
+    let bind_addr: SocketAddr = if gateway_addr.is_ipv4() {
+        (Ipv4Addr::UNSPECIFIED, 0).into()
+    } else {
+        (Ipv6Addr::UNSPECIFIED, 0).into()
+    };
 
-    Ok(())
+    let socket = tokio::net::UdpSocket::bind(bind_addr)
+        .await
+        .with_context(|| format!("bind probe socket ({bind_addr})"))?;
+    socket
+        .connect(gateway_addr)
+        .await
+        .with_context(|| format!("connect probe socket to {gateway_addr}"))?;
+
+    info!(gateway_addr = %gateway_addr, "Probing gateway QUIC reachability");
+
+    let packet = version_negotiation_probe_packet();
+    let mut buf = [0u8; 1500];
+
+    // Retransmit until we get a reply (the caller's timeout cancels us otherwise) — UDP can drop the
+    // probe, and on some platforms a prior ICMP "port unreachable" surfaces here as a recv error.
+    loop {
+        let next_attempt_at = tokio::time::Instant::now() + Duration::from_millis(100);
+
+        let _ = socket.send(&packet).await;
+
+        match tokio::time::timeout(Duration::from_millis(100), socket.recv(&mut buf)).await {
+            Ok(Ok(n)) if n > 0 => {
+                info!("Gateway QUIC endpoint is reachable");
+                return Ok(());
+            }
+            // A fast recv error must not turn the retransmit into a tight resend flood — hold off
+            // until the next interval before trying again.
+            _ => tokio::time::sleep_until(next_attempt_at).await,
+        }
+    }
+}
+
+/// A QUIC long-header packet whose version (`0x1a2a3a4a`) is reserved to always trigger Version
+/// Negotiation (RFC 9000 §15), padded to the 1200-byte minimum so the server won't drop it. Any
+/// reply to it proves the path is open without establishing a connection.
+fn version_negotiation_probe_packet() -> Vec<u8> {
+    let mut packet = Vec::with_capacity(1200);
+    packet.push(0xC0); // long header + fixed bit
+    packet.extend_from_slice(&[0x1a, 0x2a, 0x3a, 0x4a]); // force-VN version
+    packet.push(8); // Destination Connection ID length
+    packet.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe]);
+    packet.push(0); // Source Connection ID length
+    packet.resize(1200, 0);
+    packet
 }
 
 // ---------------------------------------------------------------------------
@@ -694,7 +756,7 @@ mod tests {
         let mut conf = tunnel_conf_template();
         conf.enabled = false;
 
-        let error = probe_connectivity(&conf, Duration::from_secs(5))
+        let error = probe_connectivity(&conf, Duration::from_millis(200))
             .await
             .expect_err("probe must fail when the tunnel is disabled");
 
@@ -706,29 +768,24 @@ mod tests {
 
     #[tokio::test]
     async fn probe_times_out_when_gateway_unreachable() {
-        // Throwaway PEMs so the pre-connect file reads succeed; nothing listens on the target
-        // port, so the probe fails quickly — via its own timeout or an immediate connect error.
-        let cert_key =
-            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).expect("generate self-signed cert");
-        let dir = tempfile::tempdir().expect("temp dir");
-        let cert_path = dir.path().join("client.crt");
-        let key_path = dir.path().join("client.key");
-        let ca_path = dir.path().join("ca.crt");
-        std::fs::write(&cert_path, cert_key.cert.pem()).expect("write client cert");
-        std::fs::write(&key_path, cert_key.key_pair.serialize_pem()).expect("write client key");
-        std::fs::write(&ca_path, cert_key.cert.pem()).expect("write ca cert");
+        // Bind a local UDP socket and never read/answer it: the port is definitely ours (no flaky
+        // assumption about a fixed port being free) and it silently black-holes the probe packets,
+        // so the probe never gets a reply and must time out.
+        let blackhole = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("bind blackhole socket");
+        let blackhole_addr = blackhole.local_addr().expect("blackhole addr");
 
         let mut conf = tunnel_conf_template();
-        // 127.0.0.1:1 is reserved and unbound; the QUIC handshake cannot complete.
-        conf.gateway_endpoint = "127.0.0.1:1".to_owned();
-        conf.client_cert_path = Utf8PathBuf::from_path_buf(cert_path).expect("utf8 cert path");
-        conf.client_key_path = Utf8PathBuf::from_path_buf(key_path).expect("utf8 key path");
-        conf.gateway_ca_cert_path = Utf8PathBuf::from_path_buf(ca_path).expect("utf8 ca path");
+        conf.gateway_endpoint = blackhole_addr.to_string();
 
         let started = std::time::Instant::now();
-        let result = probe_connectivity(&conf, Duration::from_secs(2)).await;
+        let result = probe_connectivity(&conf, Duration::from_millis(300)).await;
 
         assert!(result.is_err(), "probe must fail when the gateway is unreachable");
-        assert!(started.elapsed() < Duration::from_secs(15), "probe must fail fast");
+        // The real runtime is ~300ms; the 5s ceiling only has to stay well under quinn's ~120s idle
+        // so it catches a "probe hangs instead of timing out" regression without flaking on a loaded
+        // runner where the timer fires late.
+        assert!(started.elapsed() < Duration::from_secs(5), "probe must fail fast");
     }
 }

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -138,7 +138,7 @@ impl Task for TunnelTask {
                     return Ok(());
                 }
                 Ok(ConnectionOutcome::CertRenewed) => {
-                    // Renewal is a completion, not a failure.
+                    // Renewal is a successful outcome, not a failure, we release the backpressure (backoff.reset()).
                     info!("Certificate renewed; reconnecting with new cert immediately");
                     backoff.reset();
                     continue;
@@ -345,6 +345,7 @@ async fn connect_to_gateway(
 ) -> anyhow::Result<(quinn::Endpoint, quinn::Connection)> {
     // Ensure rustls crypto provider is installed (ring).
     let _ = rustls::crypto::ring::default_provider().install_default();
+
     // -- Build rustls ClientConfig --
 
     let certs: Vec<rustls_pki_types::CertificateDer<'static>> = rustls_pemfile::certs(&mut std::io::BufReader::new(

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -138,8 +138,7 @@ impl Task for TunnelTask {
                     return Ok(());
                 }
                 Ok(ConnectionOutcome::CertRenewed) => {
-                    // Renewal is a successful "completion", not a failure — skip
-                    // the backoff and reconnect immediately with the new cert.
+                    // Renewal is a completion, not a failure.
                     info!("Certificate renewed; reconnecting with new cert immediately");
                     backoff.reset();
                     continue;
@@ -190,25 +189,10 @@ enum ConnectionOutcome {
     CertRenewed,
 }
 
-/// Run a single QUIC tunnel connection lifetime: config → connect → event loop.
-///
-/// - `Ok(Shutdown)`: graceful shutdown, exit the task.
-/// - `Ok(CertRenewed)`: certificate renewed; caller should reconnect immediately.
-/// - `Err(...)`: connection lost or handshake failed — caller should retry with backoff.
-async fn run_single_connection(
-    conf_handle: &ConfHandle,
-    shutdown_signal: &mut ShutdownSignal,
-) -> anyhow::Result<ConnectionOutcome> {
-    // Ensure rustls crypto provider is installed (ring).
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    let agent_conf = conf_handle.get_conf();
-    let tunnel_conf = &agent_conf.tunnel;
-
-    let cert_path = &tunnel_conf.client_cert_path;
-    let key_path = &tunnel_conf.client_key_path;
-    let ca_path = &tunnel_conf.gateway_ca_cert_path;
-
+/// Build the route advertisement payload from the current tunnel configuration.
+fn route_advertisements(
+    tunnel_conf: &crate::config::TunnelConf,
+) -> anyhow::Result<(Vec<Ipv4Network>, Vec<agent_tunnel_proto::DomainAdvertisement>)> {
     let advertise_subnets: Vec<Ipv4Network> = tunnel_conf
         .advertise_subnets
         .iter()
@@ -260,23 +244,33 @@ async fn run_single_connection(
         "Advertising subnets and domains"
     );
 
+    Ok((advertise_subnets, advertise_domains))
+}
+
+/// Build the mTLS client config, resolve the gateway endpoint, and perform the
+/// QUIC handshake, returning the live endpoint and connection.
+async fn connect_to_gateway(
+    tunnel_conf: &crate::config::TunnelConf,
+) -> anyhow::Result<(quinn::Endpoint, quinn::Connection)> {
+    // Ensure rustls crypto provider is installed (ring).
+    let _ = rustls::crypto::ring::default_provider().install_default();
     // -- Build rustls ClientConfig --
 
     let certs: Vec<rustls_pki_types::CertificateDer<'static>> = rustls_pemfile::certs(&mut std::io::BufReader::new(
-        std::fs::File::open(cert_path.as_str()).context("open client cert file")?,
+        std::fs::File::open(tunnel_conf.client_cert_path.as_str()).context("open client cert file")?,
     ))
     .collect::<Result<Vec<_>, _>>()
     .context("parse client certificates")?;
 
     let key = rustls_pemfile::private_key(&mut std::io::BufReader::new(
-        std::fs::File::open(key_path.as_str()).context("open client key file")?,
+        std::fs::File::open(tunnel_conf.client_key_path.as_str()).context("open client key file")?,
     ))
     .context("parse private key file")?
     .context("no private key found in file")?;
 
     let mut roots = rustls::RootCertStore::empty();
     let ca_certs: Vec<rustls_pki_types::CertificateDer<'static>> = rustls_pemfile::certs(&mut std::io::BufReader::new(
-        std::fs::File::open(ca_path.as_str()).context("open CA cert file")?,
+        std::fs::File::open(tunnel_conf.gateway_ca_cert_path.as_str()).context("open CA cert file")?,
     ))
     .collect::<Result<Vec<_>, _>>()
     .context("parse CA certificates")?;
@@ -362,6 +356,47 @@ async fn run_single_connection(
         .context("QUIC handshake")?;
 
     info!("QUIC connection established");
+
+    Ok((endpoint, connection))
+}
+
+/// Confirm the QUIC/UDP path to the gateway is open by completing one mTLS+QUIC handshake, then
+/// draining the connection, bounded by `timeout`.
+pub async fn probe_connectivity(tunnel_conf: &crate::config::TunnelConf, timeout: Duration) -> anyhow::Result<()> {
+    if !tunnel_conf.enabled {
+        bail!("agent tunnel is not enabled");
+    }
+
+    let (endpoint, connection) = tokio::time::timeout(timeout, connect_to_gateway(tunnel_conf))
+        .await
+        .context("tunnel connectivity probe timed out")??;
+
+    // Flush the CONNECTION_CLOSE so the gateway unregisters this probe's connection promptly
+    // (keyed by agent_id) rather than after its idle timeout.
+    connection.close(0u32.into(), b"probe-complete");
+    let _ = tokio::time::timeout(Duration::from_secs(3), endpoint.wait_idle()).await;
+
+    Ok(())
+}
+
+/// Run a single QUIC tunnel connection lifetime: config → connect → event loop.
+///
+/// - `Ok(Shutdown)`: graceful shutdown, exit the task.
+/// - `Ok(CertRenewed)`: certificate renewed; caller should reconnect immediately.
+/// - `Err(_)`: connection lost or handshake failed — caller should retry with backoff.
+async fn run_single_connection(
+    conf_handle: &ConfHandle,
+    shutdown_signal: &mut ShutdownSignal,
+) -> anyhow::Result<ConnectionOutcome> {
+    let agent_conf = conf_handle.get_conf();
+    let tunnel_conf = &agent_conf.tunnel;
+
+    let cert_path = &tunnel_conf.client_cert_path;
+    let key_path = &tunnel_conf.client_key_path;
+    let ca_path = &tunnel_conf.gateway_ca_cert_path;
+
+    let (advertise_subnets, advertise_domains) = route_advertisements(tunnel_conf)?;
+    let (_endpoint, connection) = connect_to_gateway(tunnel_conf).await?;
 
     // -- Open control stream --
 
@@ -637,4 +672,68 @@ async fn run_session_proxy(advertise_subnets: Vec<Ipv4Network>, send: quinn::Sen
     }
     .await
     .inspect_err(|e| error!(%e, "Session proxy failed"));
+}
+
+#[cfg(test)]
+mod tests {
+    use camino::Utf8PathBuf;
+
+    use super::*;
+    use crate::config::TunnelConf;
+
+    fn tunnel_conf_template() -> TunnelConf {
+        TunnelConf {
+            enabled: true,
+            gateway_endpoint: String::new(),
+            client_cert_path: Utf8PathBuf::new(),
+            client_key_path: Utf8PathBuf::new(),
+            gateway_ca_cert_path: Utf8PathBuf::new(),
+            advertise_subnets: Vec::new(),
+            advertise_domains: Vec::new(),
+            auto_detect_domain: false,
+            heartbeat_interval_secs: 15,
+            route_advertise_interval_secs: 60,
+            server_spki_sha256: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_fails_fast_when_tunnel_disabled() {
+        let mut conf = tunnel_conf_template();
+        conf.enabled = false;
+
+        let error = probe_connectivity(&conf, Duration::from_secs(5))
+            .await
+            .expect_err("probe must fail when the tunnel is disabled");
+
+        assert!(format!("{error:#}").contains("not enabled"), "unexpected error: {error:#}");
+    }
+
+    #[tokio::test]
+    async fn probe_times_out_when_gateway_unreachable() {
+        // Throwaway PEMs so the pre-connect file reads succeed; nothing listens on the target
+        // port, so the handshake never completes and the probe must hit its own timeout.
+        let cert_key =
+            rcgen::generate_simple_self_signed(vec!["localhost".to_owned()]).expect("generate self-signed cert");
+        let dir = tempfile::tempdir().expect("temp dir");
+        let cert_path = dir.path().join("client.crt");
+        let key_path = dir.path().join("client.key");
+        let ca_path = dir.path().join("ca.crt");
+        std::fs::write(&cert_path, cert_key.cert.pem()).expect("write client cert");
+        std::fs::write(&key_path, cert_key.key_pair.serialize_pem()).expect("write client key");
+        std::fs::write(&ca_path, cert_key.cert.pem()).expect("write ca cert");
+
+        let mut conf = tunnel_conf_template();
+        // 127.0.0.1:1 is reserved and unbound; the QUIC handshake cannot complete.
+        conf.gateway_endpoint = "127.0.0.1:1".to_owned();
+        conf.client_cert_path = Utf8PathBuf::from_path_buf(cert_path).expect("utf8 cert path");
+        conf.client_key_path = Utf8PathBuf::from_path_buf(key_path).expect("utf8 key path");
+        conf.gateway_ca_cert_path = Utf8PathBuf::from_path_buf(ca_path).expect("utf8 ca path");
+
+        let started = std::time::Instant::now();
+        let result = probe_connectivity(&conf, Duration::from_secs(2)).await;
+
+        assert!(result.is_err(), "probe must fail when the gateway is unreachable");
+        assert!(started.elapsed() < Duration::from_secs(15), "probe must fail fast");
+    }
 }

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -509,7 +509,7 @@ namespace DevolutionsAgent.Actions
                     // A hard Kill() bypasses the agent's own rollback and no marker exists yet, so a hang
                     // after `up` persisted its enrollment would orphan it; undo it (guarded so an early
                     // hang that wrote nothing can't delete the prior install's certs).
-                    RollBackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
+                    RollbackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
 
                     return Fail("Agent tunnel enrollment timed out. Verify your Devolutions Gateway is reachable from this machine.");
                 }
@@ -536,7 +536,7 @@ namespace DevolutionsAgent.Actions
 
                     // `up` enrolls then probes, so a non-zero exit can leave a freshly-persisted
                     // enrollment on disk with no marker yet; undo it (guarded against early failures).
-                    RollBackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
+                    RollbackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
 
                     return Fail($"Agent tunnel enrollment failed: {detail}");
                 }
@@ -925,7 +925,7 @@ namespace DevolutionsAgent.Actions
         /// </summary>
         // Only undo when `up` actually persisted a NEW enrollment (client cert path changed from the
         // pre-`up` snapshot); else an early failure would delete the prior install's still-referenced certs.
-        private static void RollBackFailedEnrollment(Session session, string agentJsonPath, JToken originalTunnel, string originalGatewayCaB64, bool originalStateCaptured)
+        private static void RollbackFailedEnrollment(Session session, string agentJsonPath, JToken originalTunnel, string originalGatewayCaB64, bool originalStateCaptured)
         {
             if (!originalStateCaptured)
             {

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -506,17 +506,10 @@ namespace DevolutionsAgent.Actions
                         // Observed.
                     }
 
-                    // A hard Kill() bypasses BOTH recovery layers: the agent's transactional
-                    // rollback never runs (we killed it, it didn't gracefully error), and no marker
-                    // has been written yet (the marker write happens after the exit-code-0 check
-                    // below). So if `up` wrote agent.json + cert files but then hung, those would be
-                    // orphaned. Mirror the marker-failure path: best-effort read whatever cert paths
-                    // landed in agent.json and clean them up + restore the pre-snapshot state. The
-                    // snapshot locals (originalTunnel/originalGatewayCaB64/originalStateCaptured) were
-                    // captured before `up` started, so they're valid here. ReadTunnelCertPaths can't
-                    // throw, so this can't escape the timeout path.
-                    List<string> timeoutCertPaths = ReadTunnelCertPaths(agentJsonPath);
-                    CleanUpEnrollmentArtifacts(session, timeoutCertPaths, originalTunnel, originalGatewayCaB64, originalStateCaptured);
+                    // A hard Kill() bypasses the agent's own rollback and no marker exists yet, so a hang
+                    // after `up` persisted its enrollment would orphan it; undo it (guarded so an early
+                    // hang that wrote nothing can't delete the prior install's certs).
+                    RollBackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
 
                     return Fail("Agent tunnel enrollment timed out. Verify your Devolutions Gateway is reachable from this machine.");
                 }
@@ -540,6 +533,11 @@ namespace DevolutionsAgent.Actions
                 if (process.ExitCode != 0)
                 {
                     string detail = !string.IsNullOrWhiteSpace(stderr) ? Redact(stderr).Trim() : $"exit code {process.ExitCode}";
+
+                    // `up` enrolls then probes, so a non-zero exit can leave a freshly-persisted
+                    // enrollment on disk with no marker yet; undo it (guarded against early failures).
+                    RollBackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
+
                     return Fail($"Agent tunnel enrollment failed: {detail}");
                 }
 
@@ -925,6 +923,32 @@ namespace DevolutionsAgent.Actions
         /// cleanup when it cannot record the rollback marker. Best-effort: logs and continues past
         /// individual failures so it never aborts a rollback.
         /// </summary>
+        // Only undo when `up` actually persisted a NEW enrollment (client cert path changed from the
+        // pre-`up` snapshot); else an early failure would delete the prior install's still-referenced certs.
+        private static void RollBackFailedEnrollment(Session session, string agentJsonPath, JToken originalTunnel, string originalGatewayCaB64, bool originalStateCaptured)
+        {
+            if (!originalStateCaptured)
+            {
+                // Snapshot failed, so we can't tell new artifacts from the prior install's — skip
+                // rather than risk deleting cert/key we never observed (a harmless orphan beats deletion).
+                session.Log("skipping enrollment cleanup: pre-enrollment state was not captured");
+                return;
+            }
+
+            List<string> certPaths = ReadTunnelCertPaths(agentJsonPath);
+            string originalClientCert = originalTunnel?["ClientCertPath"]?.Value<string>();
+            string currentClientCert = certPaths.FirstOrDefault(p => p.EndsWith("-cert.pem", StringComparison.OrdinalIgnoreCase));
+
+            if (currentClientCert != null && !string.Equals(currentClientCert, originalClientCert, StringComparison.OrdinalIgnoreCase))
+            {
+                CleanUpEnrollmentArtifacts(session, certPaths, originalTunnel, originalGatewayCaB64, originalStateCaptured);
+            }
+            else
+            {
+                session.Log("skipping enrollment cleanup: `up` did not persist a new enrollment (client cert unchanged)");
+            }
+        }
+
         private static void CleanUpEnrollmentArtifacts(Session session, List<string> newCertPaths, JToken originalTunnel, string originalGatewayCaB64, bool originalStateCaptured)
         {
             // The client cert/key are uniquely named per enrollment, so they're always deleted —

--- a/package/AgentWindowsManaged/Actions/CustomActions.cs
+++ b/package/AgentWindowsManaged/Actions/CustomActions.cs
@@ -456,56 +456,13 @@ namespace DevolutionsAgent.Actions
                 string Redact(string s) => s.Replace(enrollmentString, "***");
                 session.Log($"Running enrollment: {exePath} {Redact(arguments)}");
 
-                ProcessStartInfo startInfo = new(exePath, arguments)
+                // The JWT goes to the child via stdin (sentinel `-` in the args), never the command
+                // line — the bearer token would otherwise be visible to any local process via
+                // WMI / Process Explorer / ETW.
+                AgentRunResult enrollResult = RunAgentCommand(exePath, arguments, enrollmentString, ProgramDataDirectory, 60_000);
+
+                if (enrollResult.TimedOut)
                 {
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    RedirectStandardInput = true,
-                    CreateNoWindow = true,
-                    WorkingDirectory = ProgramDataDirectory,
-                };
-
-                using Process process = Process.Start(startInfo);
-
-                // Write the JWT to stdin and close it so the child sees EOF. Passing it via stdin
-                // (sentinel `-` in the args) instead of the command line keeps the bearer token out
-                // of the process cmdline. The JWT is small and stdin is closed immediately, so this
-                // write can't block before we start draining stdout/stderr below.
-                process.StandardInput.Write(enrollmentString);
-                process.StandardInput.Close();
-
-                // Drain stdout/stderr concurrently with the wait. The Windows anonymous-pipe
-                // buffer is ~4 KB; if the child writes more than that (verbose logs, cert dumps)
-                // while we block in WaitForExit before reading, the child blocks on write(), the
-                // wait never returns, and we'd Kill() a healthy process — a spurious install
-                // failure. Starting the async readers up front keeps the pipes drained.
-                Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
-                Task<string> stderrTask = process.StandardError.ReadToEndAsync();
-
-                if (!process.WaitForExit(60_000))
-                {
-                    try
-                    {
-                        process.Kill();
-                    }
-                    catch
-                    {
-                        // Already exited between WaitForExit timing out and Kill firing.
-                    }
-
-                    // The async readers may still be running against the (now disposing) streams.
-                    // Observe them with a bounded wait so their exceptions don't surface later as
-                    // unobserved task exceptions; swallow whatever they throw — we're already failing.
-                    try
-                    {
-                        Task.WaitAll(new Task[] { stdoutTask, stderrTask }, 5000);
-                    }
-                    catch
-                    {
-                        // Observed.
-                    }
-
                     // A hard Kill() bypasses the agent's own rollback and no marker exists yet, so a hang
                     // after `up` persisted its enrollment would orphan it; undo it (guarded so an early
                     // hang that wrote nothing can't delete the prior install's certs).
@@ -514,28 +471,21 @@ namespace DevolutionsAgent.Actions
                     return Fail("Agent tunnel enrollment timed out. Verify your Devolutions Gateway is reachable from this machine.");
                 }
 
-                // Parameterless WaitForExit ensures the async stdout/stderr readers have fully
-                // flushed before we read their results. GetAwaiter().GetResult() unwraps IO errors
-                // instead of wrapping them in an AggregateException ("One or more errors occurred.").
-                process.WaitForExit();
-                string stdout = stdoutTask.GetAwaiter().GetResult();
-                string stderr = stderrTask.GetAwaiter().GetResult();
-
-                if (!string.IsNullOrEmpty(stdout))
+                if (!string.IsNullOrEmpty(enrollResult.Stdout))
                 {
-                    session.Log($"enrollment stdout: {Redact(stdout)}");
+                    session.Log($"enrollment stdout: {Redact(enrollResult.Stdout)}");
                 }
-                if (!string.IsNullOrEmpty(stderr))
+                if (!string.IsNullOrEmpty(enrollResult.Stderr))
                 {
-                    session.Log($"enrollment stderr: {Redact(stderr)}");
+                    session.Log($"enrollment stderr: {Redact(enrollResult.Stderr)}");
                 }
 
-                if (process.ExitCode != 0)
+                if (enrollResult.ExitCode != 0)
                 {
-                    string detail = !string.IsNullOrWhiteSpace(stderr) ? Redact(stderr).Trim() : $"exit code {process.ExitCode}";
+                    string detail = !string.IsNullOrWhiteSpace(enrollResult.Stderr) ? Redact(enrollResult.Stderr).Trim() : $"exit code {enrollResult.ExitCode}";
 
-                    // `up` enrolls then probes, so a non-zero exit can leave a freshly-persisted
-                    // enrollment on disk with no marker yet; undo it (guarded against early failures).
+                    // `up` only enrolls, so a non-zero exit can leave a freshly-persisted enrollment
+                    // on disk with no marker yet; undo it (guarded against early failures).
                     RollbackFailedEnrollment(session, agentJsonPath, originalTunnel, originalGatewayCaB64, originalStateCaptured);
 
                     return Fail($"Agent tunnel enrollment failed: {detail}");
@@ -618,6 +568,33 @@ namespace DevolutionsAgent.Actions
                     WriteTunnelAdvertisementsToConfig(session, subnetsArg, domainsArg);
                 }
 
+                // Enrollment only proved the HTTPS/TCP path, but the tunnel runs over QUIC/UDP
+                // (4433). Probe that path as a distinct step so a blocked UDP port fails the install
+                // while the operator is still here to fix the firewall. The rollback marker is
+                // already on disk, so a probe failure is undone by the marker-driven rollback.
+                session.Log($"Running connectivity probe: {exePath} probe");
+                AgentRunResult probeResult = RunAgentCommand(exePath, "probe", null, ProgramDataDirectory, 60_000);
+
+                if (!string.IsNullOrEmpty(probeResult.Stdout))
+                {
+                    session.Log($"probe stdout: {probeResult.Stdout}");
+                }
+                if (!string.IsNullOrEmpty(probeResult.Stderr))
+                {
+                    session.Log($"probe stderr: {probeResult.Stderr}");
+                }
+
+                if (probeResult.TimedOut)
+                {
+                    return Fail("Agent tunnel connectivity probe timed out. The agent can't reach the Devolutions Gateway over UDP/QUIC (port 4433); check that the firewall allows it.");
+                }
+
+                if (probeResult.ExitCode != 0)
+                {
+                    string detail = !string.IsNullOrWhiteSpace(probeResult.Stderr) ? probeResult.Stderr.Trim() : $"exit code {probeResult.ExitCode}";
+                    return Fail($"Agent tunnel connectivity probe failed: the agent could not establish the QUIC/UDP tunnel to the Devolutions Gateway (port 4433). If UDP is blocked, open it on the firewall. {detail}");
+                }
+
                 session.Log("Agent tunnel enrollment completed successfully");
                 return ActionResult.Success;
             }
@@ -625,6 +602,92 @@ namespace DevolutionsAgent.Actions
             {
                 return Fail($"Agent tunnel enrollment failed: {e.Message}");
             }
+        }
+
+        // When TimedOut is true the child was killed, so ExitCode/Stdout/Stderr carry no meaning —
+        // callers must check TimedOut first.
+        private sealed class AgentRunResult
+        {
+            public bool TimedOut;
+            public int ExitCode;
+            public string Stdout;
+            public string Stderr;
+        }
+
+        /// <summary>
+        /// Runs an <c>agent.exe</c> subcommand to completion, feeding <paramref name="stdin"/> (if
+        /// any) and capturing stdout/stderr. Kills the child and reports <see cref="AgentRunResult.TimedOut"/>
+        /// if it doesn't exit within <paramref name="timeoutMs"/>.
+        /// </summary>
+        private static AgentRunResult RunAgentCommand(string exePath, string arguments, string stdin, string workingDirectory, int timeoutMs)
+        {
+            ProcessStartInfo startInfo = new(exePath, arguments)
+            {
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = true,
+                CreateNoWindow = true,
+                WorkingDirectory = workingDirectory,
+            };
+
+            using Process process = Process.Start(startInfo);
+
+            // Write stdin (if any) and close it so the child sees EOF. The payload is small and
+            // stdin is closed immediately, so this can't block before we start draining the output
+            // pipes below.
+            if (stdin != null)
+            {
+                process.StandardInput.Write(stdin);
+            }
+            process.StandardInput.Close();
+
+            // Drain stdout/stderr concurrently with the wait. The Windows anonymous-pipe buffer is
+            // ~4 KB; if the child writes more than that (verbose logs, cert dumps) while we block in
+            // WaitForExit before reading, the child blocks on write(), the wait never returns, and
+            // we'd Kill() a healthy process — a spurious install failure. Starting the async readers
+            // up front keeps the pipes drained.
+            Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+            Task<string> stderrTask = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit(timeoutMs))
+            {
+                try
+                {
+                    process.Kill();
+                }
+                catch
+                {
+                    // Already exited between WaitForExit timing out and Kill firing.
+                }
+
+                // The async readers may still be running against the (now disposing) streams.
+                // Observe them with a bounded wait so their exceptions don't surface later as
+                // unobserved task exceptions; swallow whatever they throw — we're already failing.
+                try
+                {
+                    Task.WaitAll(new Task[] { stdoutTask, stderrTask }, 5000);
+                }
+                catch
+                {
+                    // Observed.
+                }
+
+                return new AgentRunResult { TimedOut = true };
+            }
+
+            // Parameterless WaitForExit ensures the async stdout/stderr readers have fully flushed
+            // before we read their results. GetAwaiter().GetResult() unwraps IO errors instead of
+            // wrapping them in an AggregateException ("One or more errors occurred.").
+            process.WaitForExit();
+
+            return new AgentRunResult
+            {
+                TimedOut = false,
+                ExitCode = process.ExitCode,
+                Stdout = stdoutTask.GetAwaiter().GetResult(),
+                Stderr = stderrTask.GetAwaiter().GetResult(),
+            };
         }
 
         /// <summary>

--- a/testsuite/tests/cli/agent/up.rs
+++ b/testsuite/tests/cli/agent/up.rs
@@ -45,7 +45,7 @@ fn up_enrollment_string_from_stdin() {
         "argument parsing should succeed; stderr was: {stderr}"
     );
     assert!(
-        stderr.contains("Bootstrap failed"),
+        stderr.contains("Enrollment failed"),
         "should fail at enrollment, not parsing; stderr was: {stderr}"
     );
 }
@@ -118,7 +118,7 @@ async fn up_enrollment_against_real_gateway() {
 
     let stderr = std::str::from_utf8(&output.get_output().stderr).unwrap();
     assert!(
-        !stderr.contains("Bootstrap failed"),
+        !stderr.contains("Enrollment failed"),
         "enrollment should succeed; stderr was: {stderr}"
     );
 


### PR DESCRIPTION
Enrollment only proves the HTTPS/TCP path, but the tunnel runs over QUIC/UDP (4433). When UDP is blocked, enrollment still succeeds, so the installer reported success while the agent never connected.

**Fix:** after enrolling, `agent up` performs a one-shot QUIC + mTLS handshake to the gateway and exits non-zero on failure — which `EnrollAgentTunnel` already turns into a failed, rolled-back install. The standalone `probe-tunnel` subcommand and the heartbeat round-trip are gone. The installer-side cleanup rolls back only a freshly-persisted enrollment, never a prior install's certs (guarded, fails safe).

Verified on a lab agent VM: UDP 4433 open → install succeeds; blocked → install fails and rolls back, no orphaned artifacts.

Out-of-scope follow-ups: the kill-mid-enroll window (pre-existing) and a gateway-side connection-identity check on `unregister`.
