### PR TITLE
fix(agent): recover DVC initialization after session readiness

### DIFF
--- a/devolutions-agent/src/main.rs
+++ b/devolutions-agent/src/main.rs
@@ -106,7 +106,8 @@ fn agent_service_main(
                 | AgentServiceEvent::SessionRemoteConnect(_)
                 | AgentServiceEvent::SessionRemoteDisconnect(_)
                 | AgentServiceEvent::SessionLogon(_)
-                | AgentServiceEvent::SessionLogoff(_) => {
+                | AgentServiceEvent::SessionLogoff(_)
+                | AgentServiceEvent::SessionUnlock(_) => {
                     if let Some(tx) = service_event_tx.as_mut() {
                         match tx.blocking_send(control_code) {
                             Ok(()) => {}

--- a/devolutions-agent/src/session_manager.rs
+++ b/devolutions-agent/src/session_manager.rs
@@ -32,10 +32,36 @@ enum SessionKind {
     Remote,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionReadiness {
+    WaitingForLogon,
+    WaitingForUnlock,
+    Ready,
+}
+
+impl SessionReadiness {
+    fn is_satisfied_by(self, event: SessionReadinessEvent) -> bool {
+        matches!(
+            (self, event),
+            (Self::WaitingForLogon, SessionReadinessEvent::Logon)
+                | (
+                    Self::WaitingForUnlock,
+                    SessionReadinessEvent::Logon | SessionReadinessEvent::Unlock
+                )
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SessionReadinessEvent {
+    Logon,
+    Unlock,
+}
+
 struct GatewaySession {
     session: Session,
     kind: SessionKind,
-    is_session_ready: bool,
+    readiness: SessionReadiness,
 }
 
 // NOTE: `ceviche::controller::Session` do not implement `Debug` for session.
@@ -44,17 +70,17 @@ impl Debug for GatewaySession {
         f.debug_struct("GatewaySession")
             .field("session", &self.session.id)
             .field("kind", &self.kind)
-            .field("is_session_ready", &self.is_session_ready)
+            .field("readiness", &self.readiness)
             .finish()
     }
 }
 
 impl GatewaySession {
-    fn new(session: Session, kind: SessionKind) -> Self {
+    fn new(session: Session, kind: SessionKind, readiness: SessionReadiness) -> Self {
         Self {
             session,
             kind,
-            is_session_ready: false,
+            readiness,
         }
     }
 
@@ -68,13 +94,16 @@ impl GatewaySession {
         &self.session
     }
 
-    #[allow(dead_code)]
-    fn is_session_ready(&self) -> bool {
-        self.is_session_ready
+    fn is_ready_to_start(&self, event: SessionReadinessEvent) -> bool {
+        self.readiness.is_satisfied_by(event)
     }
 
-    fn set_session_ready(&mut self, is_ready: bool) {
-        self.is_session_ready = is_ready;
+    fn set_session_ready(&mut self) {
+        self.readiness = SessionReadiness::Ready;
+    }
+
+    fn wait_for_logon(&mut self) {
+        self.readiness = SessionReadiness::WaitingForLogon;
     }
 }
 
@@ -84,9 +113,11 @@ struct SessionManagerCtx {
 }
 
 impl SessionManagerCtx {
-    fn register_session(&mut self, session: &Session, kind: SessionKind) {
-        self.sessions
-            .insert(session.to_string(), GatewaySession::new(Session::new(session.id), kind));
+    fn register_session(&mut self, session: &Session, kind: SessionKind, readiness: SessionReadiness) {
+        self.sessions.insert(
+            session.to_string(),
+            GatewaySession::new(Session::new(session.id), kind, readiness),
+        );
     }
 
     fn unregister_session(&mut self, session: &Session) {
@@ -95,6 +126,12 @@ impl SessionManagerCtx {
 
     fn get_session_mut(&mut self, session: &Session) -> Option<&mut GatewaySession> {
         self.sessions.get_mut(&session.to_string())
+    }
+
+    fn should_start_session(&self, session: &Session, event: SessionReadinessEvent) -> bool {
+        self.sessions
+            .get(&session.to_string())
+            .is_some_and(|session| session.is_ready_to_start(event))
     }
 }
 
@@ -154,7 +191,7 @@ impl Task for SessionManager {
                         AgentServiceEvent::SessionConnect(id) => {
                             info!(%id, "Session connected");
                             let mut ctx = ctx.write().await;
-                            ctx.register_session(&id, SessionKind::Console);
+                            ctx.register_session(&id, SessionKind::Console, SessionReadiness::WaitingForLogon);
                             // We only start the session process for remote sessions (initiated
                             // via RDP), as session process with DVC handler is only needed for remote
                             // sessions.
@@ -169,10 +206,15 @@ impl Task for SessionManager {
                             // Terminate old session process if it is already running.
                             terminate_session_process(&id);
 
+                            let readiness = if session_has_logged_in_user(id.id)? {
+                                SessionReadiness::WaitingForUnlock
+                            } else {
+                                SessionReadiness::WaitingForLogon
+                            };
+
                             {
                                 let mut ctx = ctx.write().await;
-                                ctx.register_session(&id, SessionKind::Remote);
-                                start_session_process_if_not_running(&mut ctx, &id)?;
+                                ctx.register_session(&id, SessionKind::Remote, readiness);
                             }
                         }
                         AgentServiceEvent::SessionRemoteDisconnect(id) => {
@@ -186,15 +228,21 @@ impl Task for SessionManager {
                         AgentServiceEvent::SessionLogon(id) => {
                             info!(%id, "Session logged on");
 
-                            // Terminate old session process if it is already running.
-                            terminate_session_process(&id);
-
-
                             // NOTE: In some cases, SessionRemoteConnect is fired before
                             // an actual user is logged in, therefore we need to try start the
                             // session app on logon, if not yet started.
                             let mut ctx = ctx.write().await;
-                            start_session_process_if_not_running(&mut ctx, &id)?;
+                            if ctx.should_start_session(&id, SessionReadinessEvent::Logon) {
+                                start_session_process_if_not_running(&mut ctx, &id)?;
+                            }
+                        }
+                        AgentServiceEvent::SessionUnlock(id) => {
+                            info!(%id, "Session unlocked");
+
+                            let mut ctx = ctx.write().await;
+                            if ctx.should_start_session(&id, SessionReadinessEvent::Unlock) {
+                                start_session_process_if_not_running(&mut ctx, &id)?;
+                            }
                         }
                         AgentServiceEvent::SessionLogoff(id) => {
                             info!(%id, "Session logged off");
@@ -203,7 +251,7 @@ impl Task for SessionManager {
                                 // Console sessions could be reused for different users, therefore
                                 // we should not remove the session from the list, but mark it as
                                 // not yet ready (session will be started as soon as new user logs in).
-                                session.set_session_ready(false);
+                                session.wait_for_logon();
                             }
                         }
                         _ => {
@@ -227,7 +275,7 @@ fn start_session_process_if_not_running(ctx: &mut SessionManagerCtx, session: &S
     match ctx.get_session_mut(session) {
         Some(gw_session) => {
             if is_session_running_in_session(session)? {
-                gw_session.set_session_ready(true);
+                gw_session.set_session_ready();
                 return Ok(());
             }
 
@@ -236,7 +284,7 @@ fn start_session_process_if_not_running(ctx: &mut SessionManagerCtx, session: &S
             match start_session_process(session) {
                 Ok(()) => {
                     info!(%session, "Session process started");
-                    gw_session.set_session_ready(true);
+                    gw_session.set_session_ready();
                 }
                 Err(error) => {
                     error!(%error, %session, "Failed to start session process");
@@ -325,4 +373,27 @@ fn session_app_path() -> Utf8PathBuf {
     current_dir.push(SESSION_BINARY);
 
     current_dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SessionReadiness, SessionReadinessEvent};
+
+    #[test]
+    fn new_user_session_waits_for_logon() {
+        assert!(SessionReadiness::WaitingForLogon.is_satisfied_by(SessionReadinessEvent::Logon));
+        assert!(!SessionReadiness::WaitingForLogon.is_satisfied_by(SessionReadinessEvent::Unlock));
+    }
+
+    #[test]
+    fn existing_user_session_waits_for_unlock() {
+        assert!(SessionReadiness::WaitingForUnlock.is_satisfied_by(SessionReadinessEvent::Unlock));
+        assert!(SessionReadiness::WaitingForUnlock.is_satisfied_by(SessionReadinessEvent::Logon));
+    }
+
+    #[test]
+    fn ready_session_ignores_later_readiness_events() {
+        assert!(!SessionReadiness::Ready.is_satisfied_by(SessionReadinessEvent::Logon));
+        assert!(!SessionReadiness::Ready.is_satisfied_by(SessionReadinessEvent::Unlock));
+    }
 }

--- a/devolutions-agent/src/session_manager.rs
+++ b/devolutions-agent/src/session_manager.rs
@@ -36,6 +36,7 @@ enum SessionKind {
 enum SessionReadiness {
     WaitingForLogon,
     WaitingForUnlock,
+    WaitingForLogonOrUnlock,
     Ready,
 }
 
@@ -46,6 +47,10 @@ impl SessionReadiness {
             (Self::WaitingForLogon, SessionReadinessEvent::Logon)
                 | (
                     Self::WaitingForUnlock,
+                    SessionReadinessEvent::Logon | SessionReadinessEvent::Unlock
+                )
+                | (
+                    Self::WaitingForLogonOrUnlock,
                     SessionReadinessEvent::Logon | SessionReadinessEvent::Unlock
                 )
         )
@@ -102,7 +107,7 @@ impl GatewaySession {
         self.readiness = SessionReadiness::Ready;
     }
 
-    fn wait_for_logon(&mut self) {
+    fn set_waiting_for_logon(&mut self) {
         self.readiness = SessionReadiness::WaitingForLogon;
     }
 }
@@ -206,10 +211,17 @@ impl Task for SessionManager {
                             // Terminate old session process if it is already running.
                             terminate_session_process(&id);
 
-                            let readiness = if session_has_logged_in_user(id.id)? {
-                                SessionReadiness::WaitingForUnlock
-                            } else {
-                                SessionReadiness::WaitingForLogon
+                            let readiness = match session_has_logged_in_user(id.id) {
+                                Ok(true) => SessionReadiness::WaitingForUnlock,
+                                Ok(false) => SessionReadiness::WaitingForLogon,
+                                Err(error) => {
+                                    error!(
+                                        %error,
+                                        %id,
+                                        "Failed to determine whether the remote session has a logged in user"
+                                    );
+                                    SessionReadiness::WaitingForLogonOrUnlock
+                                }
                             };
 
                             {
@@ -251,7 +263,7 @@ impl Task for SessionManager {
                                 // Console sessions could be reused for different users, therefore
                                 // we should not remove the session from the list, but mark it as
                                 // not yet ready (session will be started as soon as new user logs in).
-                                session.wait_for_logon();
+                                session.set_waiting_for_logon();
                             }
                         }
                         _ => {
@@ -395,5 +407,11 @@ mod tests {
     fn ready_session_ignores_later_readiness_events() {
         assert!(!SessionReadiness::Ready.is_satisfied_by(SessionReadinessEvent::Logon));
         assert!(!SessionReadiness::Ready.is_satisfied_by(SessionReadinessEvent::Unlock));
+    }
+
+    #[test]
+    fn unknown_session_user_state_accepts_logon_or_unlock() {
+        assert!(SessionReadiness::WaitingForLogonOrUnlock.is_satisfied_by(SessionReadinessEvent::Logon));
+        assert!(SessionReadiness::WaitingForLogonOrUnlock.is_satisfied_by(SessionReadinessEvent::Unlock));
     }
 }

--- a/devolutions-session/src/dvc/io.rs
+++ b/devolutions-session/src/dvc/io.rs
@@ -9,7 +9,7 @@ use win_api_wrappers::event::Event;
 use win_api_wrappers::utils::Pipe;
 use win_api_wrappers::wts::WtsVirtualChannel;
 use windows::Win32::Foundation::{
-    ERROR_GEN_FAILURE, ERROR_IO_PENDING, GetLastError, HANDLE, WAIT_EVENT, WAIT_OBJECT_0,
+    ERROR_GEN_FAILURE, ERROR_IO_PENDING, GetLastError, HANDLE, WAIT_EVENT, WAIT_OBJECT_0, WAIT_TIMEOUT,
 };
 use windows::Win32::Storage::FileSystem::{ReadFile, WriteFile};
 use windows::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
@@ -28,7 +28,6 @@ const DVC_RETRY_DELAYS: [Duration; 5] = [
     Duration::from_secs(2),
     Duration::from_secs(4),
 ];
-const WAIT_TIMEOUT: WAIT_EVENT = WAIT_EVENT(258);
 
 #[derive(Debug, Clone, Copy)]
 enum DvcInitializationStage {
@@ -83,22 +82,13 @@ pub fn run_dvc_io(
     read_tx: Sender<NowMessage<'static>>,
     stop_event: Event,
 ) -> Result<(), anyhow::Error> {
-    let Some(DvcIoContext {
-        _wts,
-        channel_file,
-        mut pdu_chunk_buffer,
-        mut overlapped,
-        mut bytes_read,
-        mut message_dissector,
-        read_event,
-    }) = initialize_dvc_with_retry(&stop_event)?
-    else {
+    let Some(mut context) = initialize_dvc_with_retry(&stop_event)? else {
         info!("DVC IO thread stopped during initialization");
         return Ok(());
     };
 
     loop {
-        let events = [read_event.raw(), write_rx.raw_wait_handle(), stop_event.raw()];
+        let events = [context.read_event.raw(), write_rx.raw_wait_handle(), stop_event.raw()];
 
         const WAIT_OBJECT_READ_DVC: WAIT_EVENT = WAIT_OBJECT_0;
         const WAIT_OBJECT_WRITE_DVC: WAIT_EVENT = WAIT_EVENT(WAIT_OBJECT_0.0 + 1);
@@ -113,9 +103,16 @@ pub fn run_dvc_io(
                 trace!("DVC channel read event is signaled");
 
                 // SAFETY: No preconditions.
-                unsafe { GetOverlappedResult(*channel_file, &overlapped, &mut bytes_read, false) }?;
+                unsafe {
+                    GetOverlappedResult(
+                        *context.channel_file,
+                        &context.overlapped,
+                        &mut context.bytes_read,
+                        false,
+                    )
+                }?;
 
-                if bytes_read
+                if context.bytes_read
                     < u32::try_from(size_of::<CHANNEL_PDU_HEADER>())
                         .expect("CHANNEL_PDU_HEADER size always fits into u32")
                 {
@@ -123,15 +120,16 @@ pub fn run_dvc_io(
                     return Ok(());
                 }
 
-                let chunk_data_size = usize::try_from(bytes_read)
+                let chunk_data_size = usize::try_from(context.bytes_read)
                     .expect("read size can't be breater than CHANNEL_CHUNK_LENGTH, therefore it should fit into usize")
                     .checked_sub(size_of::<CHANNEL_PDU_HEADER>())
                     .expect("read size is less than header size; Correctness of this should be ensured by the OS");
 
                 const HEADER_SIZE: usize = size_of::<CHANNEL_PDU_HEADER>();
 
-                let messages = message_dissector
-                    .dissect(&pdu_chunk_buffer[HEADER_SIZE..HEADER_SIZE + chunk_data_size])
+                let messages = context
+                    .message_dissector
+                    .dissect(&context.pdu_chunk_buffer[HEADER_SIZE..HEADER_SIZE + chunk_data_size])
                     .context("failed to dissect DVC messages");
 
                 let messages = match messages {
@@ -160,8 +158,14 @@ pub fn run_dvc_io(
                 }
                 // Prepare async read file operation one more time.
                 // SAFETY: No preconditions.
-                let result =
-                    unsafe { ReadFile(*channel_file, Some(&mut pdu_chunk_buffer), None, Some(&mut overlapped)) };
+                let result = unsafe {
+                    ReadFile(
+                        *context.channel_file,
+                        Some(&mut context.pdu_chunk_buffer),
+                        None,
+                        Some(&mut context.overlapped),
+                    )
+                };
 
                 ensure_overlapped_io_result(result)?;
             }
@@ -175,7 +179,7 @@ pub fn run_dvc_io(
                 let mut dw_written: u32 = 0;
 
                 // SAFETY: No preconditions.
-                unsafe { WriteFile(*channel_file, Some(&message_bytes), Some(&mut dw_written), None)? }
+                unsafe { WriteFile(*context.channel_file, Some(&message_bytes), Some(&mut dw_written), None)? }
             }
             WAIT_OBJECT_STOP => {
                 info!("DVC IO thread is stopped");
@@ -189,16 +193,26 @@ pub fn run_dvc_io(
     }
 }
 
-fn initialize_dvc_with_retry(stop_event: &Event) -> anyhow::Result<Option<DvcIoContext>> {
+fn initialize_dvc_with_retry(stop_event: &Event) -> anyhow::Result<Option<Box<DvcIoContext>>> {
     let mut attempt = 1usize;
 
     loop {
-        match initialize_dvc() {
-            Ok(context) => {
-                info!(attempt, "DVC IO thread is running");
-                return Ok(Some(context));
-            }
-            Err(error) if error.is_retryable() => {
+        let error = match initialize_dvc() {
+            Ok(mut context) => match start_initial_read(&mut context) {
+                Ok(()) => {
+                    info!(attempt, "DVC IO thread is running");
+                    return Ok(Some(context));
+                }
+                Err(error) => DvcInitializationError {
+                    stage: DvcInitializationStage::StartRead,
+                    error: error.into(),
+                },
+            },
+            Err(error) => error,
+        };
+
+        match error {
+            error if error.is_retryable() => {
                 let Some(delay) = dvc_retry_delay(attempt - 1) else {
                     return Err(error.into_anyhow());
                 };
@@ -217,12 +231,12 @@ fn initialize_dvc_with_retry(stop_event: &Event) -> anyhow::Result<Option<DvcIoC
 
                 attempt += 1;
             }
-            Err(error) => return Err(error.into_anyhow()),
+            error => return Err(error.into_anyhow()),
         }
     }
 }
 
-fn initialize_dvc() -> Result<DvcIoContext, DvcInitializationError> {
+fn initialize_dvc() -> Result<Box<DvcIoContext>, DvcInitializationError> {
     trace!("Opening DVC channel");
     let wts = WtsVirtualChannel::open_dvc(DVC_CHANNEL_NAME).map_err(|error| DvcInitializationError {
         stage: DvcInitializationStage::Open,
@@ -237,29 +251,17 @@ fn initialize_dvc() -> Result<DvcIoContext, DvcInitializationError> {
 
     // All DVC messages should be under CHANNEL_CHUNK_LENGTH size, but sometimes RDP stack
     // sends a few messages together; 128Kb buffer should be enough to hold a few dozen messages.
-    let mut pdu_chunk_buffer = vec![0u8; 128 * 1024].into_boxed_slice();
+    let pdu_chunk_buffer = vec![0u8; 128 * 1024].into_boxed_slice();
     let read_event = Event::new_unnamed().map_err(|error| DvcInitializationError {
         stage: DvcInitializationStage::StartRead,
         error,
     })?;
-    let mut overlapped = OVERLAPPED {
+    let overlapped = OVERLAPPED {
         hEvent: read_event.raw(),
         ..Default::default()
     };
 
-    // Prepare async read operation.
-    // SAFETY: Both `channel_file` and event passed to `overlapped` are valid during this call,
-    // therefore it is safe to call.
-    let read_result: Result<(), windows::core::Error> =
-        unsafe { ReadFile(*channel_file, Some(&mut pdu_chunk_buffer), None, Some(&mut overlapped)) };
-    ensure_overlapped_io_result(read_result).map_err(|error| DvcInitializationError {
-        stage: DvcInitializationStage::StartRead,
-        error: error.into(),
-    })?;
-
-    trace!("DVC channel opened");
-
-    Ok(DvcIoContext {
+    Ok(Box::new(DvcIoContext {
         _wts: wts,
         channel_file,
         pdu_chunk_buffer,
@@ -267,7 +269,26 @@ fn initialize_dvc() -> Result<DvcIoContext, DvcInitializationError> {
         bytes_read: 0,
         message_dissector: NowMessageDissector::default(),
         read_event,
-    })
+    }))
+}
+
+fn start_initial_read(context: &mut DvcIoContext) -> Result<(), windows::core::Error> {
+    // Prepare async read operation.
+    // SAFETY: Both `channel_file` and event passed to `overlapped` are valid during this call,
+    // therefore it is safe to call.
+    let read_result: Result<(), windows::core::Error> = unsafe {
+        ReadFile(
+            *context.channel_file,
+            Some(&mut context.pdu_chunk_buffer),
+            None,
+            Some(&mut context.overlapped),
+        )
+    };
+    ensure_overlapped_io_result(read_result)?;
+
+    trace!("DVC channel opened");
+
+    Ok(())
 }
 
 fn dvc_retry_delay(retry: usize) -> Option<Duration> {

--- a/devolutions-session/src/dvc/io.rs
+++ b/devolutions-session/src/dvc/io.rs
@@ -1,21 +1,81 @@
+use std::time::Duration;
+
 use anyhow::Context;
 use now_proto_pdu::NowMessage;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::mpsc::error::TrySendError;
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 use win_api_wrappers::event::Event;
 use win_api_wrappers::utils::Pipe;
 use win_api_wrappers::wts::WtsVirtualChannel;
-use windows::Win32::Foundation::{ERROR_IO_PENDING, GetLastError, WAIT_EVENT, WAIT_OBJECT_0};
+use windows::Win32::Foundation::{
+    ERROR_GEN_FAILURE, ERROR_IO_PENDING, GetLastError, HANDLE, WAIT_EVENT, WAIT_OBJECT_0,
+};
 use windows::Win32::Storage::FileSystem::{ReadFile, WriteFile};
 use windows::Win32::System::IO::{GetOverlappedResult, OVERLAPPED};
 use windows::Win32::System::RemoteDesktop::CHANNEL_PDU_HEADER;
-use windows::Win32::System::Threading::{INFINITE, WaitForMultipleObjects};
+use windows::Win32::System::Threading::{INFINITE, WaitForMultipleObjects, WaitForSingleObject};
+use windows::core::Owned;
 
 use crate::dvc::channel::WinapiSignaledReceiver;
 use crate::dvc::now_message_dissector::NowMessageDissector;
 
 const DVC_CHANNEL_NAME: &str = "Devolutions::Now::Agent";
+const DVC_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(250),
+    Duration::from_millis(500),
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(4),
+];
+const WAIT_TIMEOUT: WAIT_EVENT = WAIT_EVENT(258);
+
+#[derive(Debug, Clone, Copy)]
+enum DvcInitializationStage {
+    Open,
+    QueryFileHandle,
+    StartRead,
+}
+
+impl std::fmt::Display for DvcInitializationStage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Open => f.write_str("opening the DVC channel"),
+            Self::QueryFileHandle => f.write_str("querying the DVC file handle"),
+            Self::StartRead => f.write_str("starting the initial DVC read"),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DvcInitializationError {
+    stage: DvcInitializationStage,
+    error: anyhow::Error,
+}
+
+impl DvcInitializationError {
+    fn is_retryable(&self) -> bool {
+        self.error.chain().any(|source| {
+            source
+                .downcast_ref::<windows::core::Error>()
+                .is_some_and(|error| error.code() == ERROR_GEN_FAILURE.to_hresult())
+        })
+    }
+
+    fn into_anyhow(self) -> anyhow::Error {
+        self.error.context(self.stage.to_string())
+    }
+}
+
+struct DvcIoContext {
+    _wts: WtsVirtualChannel,
+    channel_file: Owned<HANDLE>,
+    pdu_chunk_buffer: Box<[u8]>,
+    overlapped: OVERLAPPED,
+    bytes_read: u32,
+    message_dissector: NowMessageDissector,
+    read_event: Event,
+}
 
 /// Run main DVC IO loop for `Devolutions::Now::Agent` channel.
 pub fn run_dvc_io(
@@ -23,34 +83,19 @@ pub fn run_dvc_io(
     read_tx: Sender<NowMessage<'static>>,
     stop_event: Event,
 ) -> Result<(), anyhow::Error> {
-    trace!("Opening DVC channel");
-    let wts = WtsVirtualChannel::open_dvc(DVC_CHANNEL_NAME)?;
-
-    trace!("Querying DVC channel");
-    let channel_file = wts.query_file_handle()?;
-
-    trace!("DVC channel opened");
-
-    // All DVC messages should be under CHANNEL_CHUNK_LENGTH size, but sometimes RDP stack
-    // sends a few messages together; 128Kb buffer should be enough to hold a few dozen messages.
-    let mut pdu_chunk_buffer = [0u8; 128 * 1024];
-    let mut overlapped = OVERLAPPED::default();
-    let mut bytes_read: u32 = 0;
-
-    let mut message_dissector = NowMessageDissector::default();
-
-    let read_event = Event::new_unnamed()?;
-    overlapped.hEvent = read_event.raw();
-
-    info!("DVC IO thread is running");
-
-    // Prepare async read operation.
-    // SAFETY: Both `channel_file` and event passed to `overlapped` are valid during this call,
-    // therefore it is safe to call.
-    let read_result: Result<(), windows::core::Error> =
-        unsafe { ReadFile(*channel_file, Some(&mut pdu_chunk_buffer), None, Some(&mut overlapped)) };
-
-    ensure_overlapped_io_result(read_result)?;
+    let Some(DvcIoContext {
+        _wts,
+        channel_file,
+        mut pdu_chunk_buffer,
+        mut overlapped,
+        mut bytes_read,
+        mut message_dissector,
+        read_event,
+    }) = initialize_dvc_with_retry(&stop_event)?
+    else {
+        info!("DVC IO thread stopped during initialization");
+        return Ok(());
+    };
 
     loop {
         let events = [read_event.raw(), write_rx.raw_wait_handle(), stop_event.raw()];
@@ -144,6 +189,104 @@ pub fn run_dvc_io(
     }
 }
 
+fn initialize_dvc_with_retry(stop_event: &Event) -> anyhow::Result<Option<DvcIoContext>> {
+    let mut attempt = 1usize;
+
+    loop {
+        match initialize_dvc() {
+            Ok(context) => {
+                info!(attempt, "DVC IO thread is running");
+                return Ok(Some(context));
+            }
+            Err(error) if error.is_retryable() => {
+                let Some(delay) = dvc_retry_delay(attempt - 1) else {
+                    return Err(error.into_anyhow());
+                };
+
+                warn!(
+                    attempt,
+                    stage = %error.stage,
+                    error = %error.error,
+                    retry_delay_ms = delay.as_millis(),
+                    "Transient DVC initialization failure; retrying"
+                );
+
+                if !wait_for_retry_delay(stop_event, delay)? {
+                    return Ok(None);
+                }
+
+                attempt += 1;
+            }
+            Err(error) => return Err(error.into_anyhow()),
+        }
+    }
+}
+
+fn initialize_dvc() -> Result<DvcIoContext, DvcInitializationError> {
+    trace!("Opening DVC channel");
+    let wts = WtsVirtualChannel::open_dvc(DVC_CHANNEL_NAME).map_err(|error| DvcInitializationError {
+        stage: DvcInitializationStage::Open,
+        error,
+    })?;
+
+    trace!("Querying DVC channel");
+    let channel_file = wts.query_file_handle().map_err(|error| DvcInitializationError {
+        stage: DvcInitializationStage::QueryFileHandle,
+        error,
+    })?;
+
+    // All DVC messages should be under CHANNEL_CHUNK_LENGTH size, but sometimes RDP stack
+    // sends a few messages together; 128Kb buffer should be enough to hold a few dozen messages.
+    let mut pdu_chunk_buffer = vec![0u8; 128 * 1024].into_boxed_slice();
+    let read_event = Event::new_unnamed().map_err(|error| DvcInitializationError {
+        stage: DvcInitializationStage::StartRead,
+        error,
+    })?;
+    let mut overlapped = OVERLAPPED {
+        hEvent: read_event.raw(),
+        ..Default::default()
+    };
+
+    // Prepare async read operation.
+    // SAFETY: Both `channel_file` and event passed to `overlapped` are valid during this call,
+    // therefore it is safe to call.
+    let read_result: Result<(), windows::core::Error> =
+        unsafe { ReadFile(*channel_file, Some(&mut pdu_chunk_buffer), None, Some(&mut overlapped)) };
+    ensure_overlapped_io_result(read_result).map_err(|error| DvcInitializationError {
+        stage: DvcInitializationStage::StartRead,
+        error: error.into(),
+    })?;
+
+    trace!("DVC channel opened");
+
+    Ok(DvcIoContext {
+        _wts: wts,
+        channel_file,
+        pdu_chunk_buffer,
+        overlapped,
+        bytes_read: 0,
+        message_dissector: NowMessageDissector::default(),
+        read_event,
+    })
+}
+
+fn dvc_retry_delay(retry: usize) -> Option<Duration> {
+    DVC_RETRY_DELAYS.get(retry).copied()
+}
+
+fn wait_for_retry_delay(stop_event: &Event, delay: Duration) -> anyhow::Result<bool> {
+    let timeout = u32::try_from(delay.as_millis()).unwrap_or(u32::MAX);
+
+    // SAFETY: stop_event is a valid event handle for the lifetime of this call.
+    let status = unsafe { WaitForSingleObject(stop_event.raw(), timeout) };
+
+    match status {
+        WAIT_OBJECT_0 => Ok(false),
+        WAIT_TIMEOUT => Ok(true),
+        _ => anyhow::bail!("waiting for DVC retry delay failed with status {}", status.0),
+    }
+}
+
 pub fn ensure_overlapped_io_result(result: windows::core::Result<()>) -> Result<(), windows::core::Error> {
     if let Err(error) = result {
         // SAFETY: GetLastError is alwayі safe to call
@@ -180,5 +323,19 @@ impl IoRedirectionPipes {
             stdin_read_pipe,
             stdin_write_pipe,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::dvc_retry_delay;
+
+    #[test]
+    fn dvc_retry_delays_are_bounded() {
+        assert_eq!(dvc_retry_delay(0), Some(Duration::from_millis(250)));
+        assert_eq!(dvc_retry_delay(4), Some(Duration::from_secs(4)));
+        assert_eq!(dvc_retry_delay(5), None);
     }
 }


### PR DESCRIPTION
Improves Devolutions Agent reliability for RDP connections that use multi-step authentication or reconnect an existing session. The session host now waits for the appropriate Windows logon or unlock event before starting, and transient virtual-channel initialization failures recover automatically instead of ending the session immediately.

Issue: N/A