### PR TITLE
fix(dgw): target Gateway hostname when using the credential-injection fake KDC proxy

### DIFF
--- a/devolutions-gateway/src/credential_injection_kdc.rs
+++ b/devolutions-gateway/src/credential_injection_kdc.rs
@@ -55,12 +55,6 @@ pub(crate) enum CredentialInjectionKdcResolveError {
     ExpiredCredential { jti: Uuid },
     #[error("credential-injection state is not available for {jti}")]
     NonInjectionCredential { jti: Uuid },
-    #[error("association token for {jti} is not valid for credential injection")]
-    InvalidAssociationToken {
-        jti: Uuid,
-        #[source]
-        source: anyhow::Error,
-    },
     #[error("credential-injection KDC config could not be initialized for {jti}")]
     BuildKdcConfig {
         jti: Uuid,
@@ -444,19 +438,15 @@ fn random_32_bytes() -> Vec<u8> {
 /// through this service, so callers see one handle instead of coordinating a store and a registry.
 #[derive(Debug, Clone)]
 pub struct CredentialService {
+    hostname: String,
     credentials: CredentialStoreHandle,
     sessions: Arc<Mutex<HashMap<Uuid, Arc<CredentialInjectionKdcSession>>>>,
 }
 
-impl Default for CredentialService {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl CredentialService {
-    pub fn new() -> Self {
+    pub fn new(hostname: String) -> Self {
         Self {
+            hostname,
             credentials: CredentialStoreHandle::new(),
             sessions: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -524,16 +514,6 @@ impl CredentialService {
             CredentialInjectionKdcResolveError::NonInjectionCredential { jti }
         })?;
 
-        let target_hostname = crate::token::extract_credential_injection_target_hostname(&credential_entry.token)
-            .map_err(|source| {
-                warn!(
-                    %jti,
-                    error = format!("{source:#}"),
-                    "KDC token references invalid credential-injection association token"
-                );
-                CredentialInjectionKdcResolveError::InvalidAssociationToken { jti, source }
-            })?;
-
         let proxy_username = app_credential_username(&mapping.proxy).to_owned();
         // Atomic get-or-insert: holds the lock long enough to guarantee a single Arc<Session>
         // wins for this JTI even under concurrent `kdc_for` calls. The derivation is fast (a few
@@ -546,7 +526,7 @@ impl CredentialService {
             Arc::clone(session)
         };
 
-        CredentialInjectionKdc::from_parts(jti, credential_entry, target_hostname, session)
+        CredentialInjectionKdc::from_parts(jti, credential_entry, self.hostname.clone(), session)
             .map_err(|source| CredentialInjectionKdcResolveError::BuildKdcConfig { jti, source })
     }
 
@@ -701,7 +681,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_rejects_expired_credential_entry() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
         let jti = Uuid::new_v4();
 
         // Negative TTL: entry is born already expired. `CredentialStoreHandle::get` does not
@@ -726,7 +706,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_returns_same_session_under_concurrent_calls() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
         let jti = Uuid::new_v4();
 
         service
@@ -753,7 +733,7 @@ mod tests {
 
     #[test]
     fn service_insert_drops_stale_session_even_without_credential_replacement() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
         let jti = Uuid::new_v4();
 
         // Simulate the race called out by Codex: a previous provisioning's session is still
@@ -782,7 +762,7 @@ mod tests {
 
     #[test]
     fn service_insert_replacement_drops_cached_kerberos_material() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
         let jti = Uuid::new_v4();
 
         service
@@ -818,7 +798,7 @@ mod tests {
 
     #[test]
     fn service_sweep_orphans_drops_sessions_with_no_credential_entry() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
         let jti = Uuid::new_v4();
 
         service
@@ -837,6 +817,7 @@ mod tests {
         // drive `credential::cleanup_task` to expire the entry, but it sleeps for 15 minutes
         // between ticks. Swapping the inner store is the deterministic equivalent.
         let orphaned_service = CredentialService {
+            hostname: "dgateway.localhost.com".to_owned(),
             credentials: CredentialStoreHandle::new(),
             sessions: Arc::clone(&service.sessions),
         };
@@ -901,7 +882,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_rejects_unknown_jti() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
 
         assert!(
             matches!(
@@ -914,7 +895,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_rejects_non_injection_entry() {
-        let service = CredentialService::new();
+        let service = CredentialService::new("dgateway.localhost.com".to_owned());
         let jti = Uuid::new_v4();
 
         service
@@ -928,24 +909,6 @@ mod tests {
             ),
             "KDC tokens with jet_cred_id must require provision-credentials state"
         );
-    }
-
-    #[test]
-    fn service_kdc_for_lazily_extracts_target_hostname_from_entry_token() {
-        let service = CredentialService::new();
-        let jti = Uuid::new_v4();
-
-        service
-            .insert(
-                association_token(jti),
-                Some(cleartext_mapping_with_target_username("target")),
-                time::Duration::minutes(5),
-            )
-            .expect("credential entry inserts");
-
-        let kdc = service.kdc_for(jti).expect("credential-injection KDC resolves");
-
-        assert_eq!(kdc.target_hostname, "target.example");
     }
 
     #[test]

--- a/devolutions-gateway/src/credential_injection_kdc.rs
+++ b/devolutions-gateway/src/credential_injection_kdc.rs
@@ -41,6 +41,8 @@ pub(crate) struct CredentialInjectionKdc {
     jti: Uuid,
     raw_token: String,
     credential_mapping: AppCredentialMapping,
+    // Client target hostname. It is not a hostname of the end machine, but a DGW hostname the client
+    // uses when connecting.
     target_hostname: String,
     session: Arc<CredentialInjectionKdcSession>,
     // The KDC crate models users with plaintext passwords, so this object owns those secrets
@@ -187,7 +189,8 @@ impl CredentialInjectionKdc {
 
         // The SPN that the client puts on its AP-REQ ticket is the one for the target RDP
         // server (`TERMSRV/<target>`). Gateway-as-CredSSP-server is impersonating that target,
-        // so ServerProperties must claim the same SPN or sspi-rs rejects the ticket.
+        // so `ServerProperties` must claim the same SPN as the gateway listener or sspi-rs
+        // rejects the ticket.
         Ok(sspi::KerberosServerConfig {
             kerberos_config: sspi::KerberosConfig {
                 kdc_url: Some(kdc_url),

--- a/devolutions-gateway/src/credential_injection_kdc.rs
+++ b/devolutions-gateway/src/credential_injection_kdc.rs
@@ -26,6 +26,7 @@ use thiserror::Error;
 use url::Url;
 use uuid::Uuid;
 
+use crate::config::ConfHandle;
 use crate::credential::{AppCredential, AppCredentialMapping, ArcCredentialEntry, CredentialStoreHandle};
 
 // The reserved `.invalid` TLD (RFC 6761) lets sspi-rs CredSSP server emit "KDC requests" that
@@ -436,17 +437,30 @@ fn random_32_bytes() -> Vec<u8> {
 ///
 /// All credential reads/writes — provision-credentials, RDP mode detection, KDC dispatch — go
 /// through this service, so callers see one handle instead of coordinating a store and a registry.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CredentialService {
-    hostname: String,
+    // The `ConfHandle` is needed to resolve the hostname for the KDC config, which is used to
+    // build the SPN for the CredSSP acceptor. The hostname cannot not be a plain `String`, because
+    // the config can be reloaded at runtime.
+    conf_handle: ConfHandle,
     credentials: CredentialStoreHandle,
     sessions: Arc<Mutex<HashMap<Uuid, Arc<CredentialInjectionKdcSession>>>>,
 }
 
+impl fmt::Debug for CredentialService {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CredentialService")
+            .field("conf_handle", &"<ConfHandle>")
+            .field("credentials", &self.credentials)
+            .field("sessions", &self.sessions)
+            .finish()
+    }
+}
+
 impl CredentialService {
-    pub fn new(hostname: String) -> Self {
+    pub fn new(conf_handle: ConfHandle) -> Self {
         Self {
-            hostname,
+            conf_handle,
             credentials: CredentialStoreHandle::new(),
             sessions: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -526,7 +540,9 @@ impl CredentialService {
             Arc::clone(session)
         };
 
-        CredentialInjectionKdc::from_parts(jti, credential_entry, self.hostname.clone(), session)
+        let hostname = self.conf_handle.get_conf().hostname.clone();
+
+        CredentialInjectionKdc::from_parts(jti, credential_entry, hostname, session)
             .map_err(|source| CredentialInjectionKdcResolveError::BuildKdcConfig { jti, source })
     }
 
@@ -596,7 +612,23 @@ mod tests {
     use secrecy::SecretString;
 
     use super::*;
+    use crate::config::ConfHandle;
     use crate::credential::{CleartextAppCredential, CleartextAppCredentialMapping};
+
+    const TEST_CONFIG: &str = r#"{
+        "Hostname": "dgateway.localhost.com",
+        "ProvisionerPublicKeyData": {
+            "Value": "mMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4vuqLOkl1pWobt6su1XO9VskgCAwevEGs6kkNjJQBwkGnPKYLmNF1E/af1yCocfVn/OnPf9e4x+lXVyZ6LMDJxFxu+axdgOq3Ld392J1iAEbfvwlyRFnEXFOJNyylqg3bY6LvnWHL/XZczVdMD9xYfq2sO9bg3xjRW4s7r9EEYOFjqVT3VFznH9iWJVtcSEKukmS/3uKoO6lGhacvu0HhjXXdgq0R8zvR4XRJ9Fcnf0f9Ypoc+i6L80NVjrRCeVOH+Ld/2fA9bocpfLarcVqG3RjS+qgOtpyCc0jWVFF4zaGQ7LUDFkEIYILkICeMMn2ll29hmZNzsJzZJ9s6NocgQIDAQAB"
+        },
+        "Listeners": [
+            { "InternalUrl": "http://*:7171", "ExternalUrl": "https://*:7171" }
+        ],
+        "__debug__": { "disable_token_validation": true }
+    }"#;
+
+    fn mock_conf_handle() -> ConfHandle {
+        ConfHandle::mock(TEST_CONFIG).expect("test config is valid")
+    }
 
     fn cleartext_mapping_with_target_username(target_username: &str) -> CleartextAppCredentialMapping {
         CleartextAppCredentialMapping {
@@ -681,7 +713,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_rejects_expired_credential_entry() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
         let jti = Uuid::new_v4();
 
         // Negative TTL: entry is born already expired. `CredentialStoreHandle::get` does not
@@ -706,7 +738,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_returns_same_session_under_concurrent_calls() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
         let jti = Uuid::new_v4();
 
         service
@@ -733,7 +765,7 @@ mod tests {
 
     #[test]
     fn service_insert_drops_stale_session_even_without_credential_replacement() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
         let jti = Uuid::new_v4();
 
         // Simulate the race called out by Codex: a previous provisioning's session is still
@@ -762,7 +794,7 @@ mod tests {
 
     #[test]
     fn service_insert_replacement_drops_cached_kerberos_material() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
         let jti = Uuid::new_v4();
 
         service
@@ -798,7 +830,7 @@ mod tests {
 
     #[test]
     fn service_sweep_orphans_drops_sessions_with_no_credential_entry() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
         let jti = Uuid::new_v4();
 
         service
@@ -817,7 +849,7 @@ mod tests {
         // drive `credential::cleanup_task` to expire the entry, but it sleeps for 15 minutes
         // between ticks. Swapping the inner store is the deterministic equivalent.
         let orphaned_service = CredentialService {
-            hostname: "dgateway.localhost.com".to_owned(),
+            conf_handle: mock_conf_handle(),
             credentials: CredentialStoreHandle::new(),
             sessions: Arc::clone(&service.sessions),
         };
@@ -882,7 +914,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_rejects_unknown_jti() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
 
         assert!(
             matches!(
@@ -895,7 +927,7 @@ mod tests {
 
     #[test]
     fn service_kdc_for_rejects_non_injection_entry() {
-        let service = CredentialService::new("dgateway.localhost.com".to_owned());
+        let service = CredentialService::new(mock_conf_handle());
         let jti = Uuid::new_v4();
 
         service

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -89,7 +89,7 @@ impl DgwState {
         let (shutdown_handle, shutdown_signal) = devolutions_gateway_task::ShutdownHandle::new();
         let (job_queue_handle, job_queue_rx) = job_queue::JobQueueHandle::new();
         let (traffic_audit_handle, traffic_audit_rx) = traffic_audit::TrafficAuditHandle::new();
-        let credentials = credential_injection_kdc::CredentialService::new();
+        let credentials = credential_injection_kdc::CredentialService::new(conf_handle.get_conf().hostname.clone());
         let monitoring_state = Arc::new(network_monitor::State::new(Arc::new(MockMonitorsCache))?);
 
         let state = Self {

--- a/devolutions-gateway/src/lib.rs
+++ b/devolutions-gateway/src/lib.rs
@@ -89,7 +89,7 @@ impl DgwState {
         let (shutdown_handle, shutdown_signal) = devolutions_gateway_task::ShutdownHandle::new();
         let (job_queue_handle, job_queue_rx) = job_queue::JobQueueHandle::new();
         let (traffic_audit_handle, traffic_audit_rx) = traffic_audit::TrafficAuditHandle::new();
-        let credentials = credential_injection_kdc::CredentialService::new(conf_handle.get_conf().hostname.clone());
+        let credentials = credential_injection_kdc::CredentialService::new(conf_handle.clone());
         let monitoring_state = Arc::new(network_monitor::State::new(Arc::new(MockMonitorsCache))?);
 
         let state = Self {

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -267,7 +267,7 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<Tasks> {
             .await
             .context("failed to initialize traffic audit manager")?;
 
-    let credentials = devolutions_gateway::credential_injection_kdc::CredentialService::new();
+    let credentials = devolutions_gateway::credential_injection_kdc::CredentialService::new(conf.hostname.clone());
 
     let filesystem_monitor_config_cache = devolutions_gateway::api::monitoring::FilesystemConfigCache::new(
         config::get_data_dir().join("monitors_cache.json"),

--- a/devolutions-gateway/src/service.rs
+++ b/devolutions-gateway/src/service.rs
@@ -267,7 +267,7 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<Tasks> {
             .await
             .context("failed to initialize traffic audit manager")?;
 
-    let credentials = devolutions_gateway::credential_injection_kdc::CredentialService::new(conf.hostname.clone());
+    let credentials = devolutions_gateway::credential_injection_kdc::CredentialService::new(conf_handle.clone());
 
     let filesystem_monitor_config_cache = devolutions_gateway::api::monitoring::FilesystemConfigCache::new(
         config::get_data_dir().join("monitors_cache.json"),


### PR DESCRIPTION
Hi,

I fixed the target hostname for the fake KDC inside the KDC proxy. I tried to write the minimal possible solution.

The problem: during the credentials injection, the RDP client does the Kerberos authentication via a KDC proxy with a fake KDC. In that case, the target hostname (Kerberos service name for the TGS) must be a proxy hostname. But prior to this PR, the KDC proxy always configured the internal KDC to the real target machine hostname. This problem was introduced in #1768.

For example, my local configuration:

* Devolutions-Gateway hostname: `dgateway.tbt.com`.
* Target machine behind the proxy: `WIN-956CQOSSJTF.tbt.com`.

When I connect to the target machine using credentials injection, my FreeRDP command looks like this:

```ps1
.\sdl-freerdp.exe /v:dgateway.tbt.com:8181 /u:fake_user /d:603077ae-b66b-4256-ae48-a458db5b90b0.jet /p:fake_password /sec:nla /log-level:TRACE /sspi-module:"<sspi.dll path>" /pcb:<token>
```

During the FreeRDP's NLA stage, it should perform Kerberos auth against `dgateway.tbt.com` (instead of `WIN-956CQOSSJTF.tbt.com`).

I hope I explained the problem well 😄.