### PR TITLE
feat(dgw): add Session Recording Log artifacts

### DIFF
--- a/devolutions-gateway/src/api/jrec.rs
+++ b/devolutions-gateway/src/api/jrec.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use anyhow::Context as _;
 use axum::extract::ws::{CloseFrame, WebSocket};
 use axum::extract::{self, ConnectInfo, Query, State, WebSocketUpgrade};
+use axum::http::header::{CONTENT_TYPE, HeaderValue};
 use axum::response::Response;
 use axum::routing::{delete, get};
 use axum::{Json, Router};
@@ -511,10 +512,21 @@ where
         return Err(HttpError::not_found().msg("requested file does not exist"));
     }
 
-    let response = tower_http::services::ServeFile::new(path)
+    let mut response = tower_http::services::ServeFile::new(&path)
         .oneshot(request)
         .await
         .map_err(HttpError::internal().err())?;
+
+    let content_type = path
+        .extension()
+        .and_then(RecordingFileType::from_extension)
+        .and_then(RecordingFileType::content_type);
+
+    if let Some(content_type) = content_type {
+        response
+            .headers_mut()
+            .insert(CONTENT_TYPE, HeaderValue::from_static(content_type));
+    }
 
     Ok(response)
 }

--- a/devolutions-gateway/src/token.rs
+++ b/devolutions-gateway/src/token.rs
@@ -280,14 +280,20 @@ pub enum RecordingFileType {
     TRP,
     /// asciinema cast for terminal playback
     Asciicast,
+    /// Session Recording Log NDJSON stream
+    #[serde(rename = "slog")]
+    SessionRecordingLog,
 }
 
 impl RecordingFileType {
+    pub const SLOG_CONTENT_TYPE: &'static str = "application/x-ndjson";
+
     pub const fn format_name(self) -> &'static str {
         match self {
             RecordingFileType::WebM => "WebM",
             RecordingFileType::TRP => "TRP",
             RecordingFileType::Asciicast => "asciicast",
+            RecordingFileType::SessionRecordingLog => "slog",
         }
     }
 
@@ -296,6 +302,24 @@ impl RecordingFileType {
             RecordingFileType::WebM => "webm",
             RecordingFileType::TRP => "trp",
             RecordingFileType::Asciicast => "cast",
+            RecordingFileType::SessionRecordingLog => "slog",
+        }
+    }
+
+    pub fn from_extension(extension: &str) -> Option<Self> {
+        match extension {
+            "webm" => Some(RecordingFileType::WebM),
+            "trp" => Some(RecordingFileType::TRP),
+            "cast" => Some(RecordingFileType::Asciicast),
+            "slog" => Some(RecordingFileType::SessionRecordingLog),
+            _ => None,
+        }
+    }
+
+    pub const fn content_type(self) -> Option<&'static str> {
+        match self {
+            RecordingFileType::SessionRecordingLog => Some(Self::SLOG_CONTENT_TYPE),
+            RecordingFileType::WebM | RecordingFileType::TRP | RecordingFileType::Asciicast => None,
         }
     }
 }


### PR DESCRIPTION
Adds server-side support for Session Recording Log recording artifacts.

Gateway can now accept JREC recording pushes with `fileType=slog`, persist the raw UTF-8 NDJSON stream as `.slog`, and serve `.slog` downloads with the `application/x-ndjson` content type. This establishes the Gateway storage contract needed by AD Session Recording Log producers and future viewers. Consumers derive the artifact type from the file extension in `recording.json`.

This PR only adds the Gateway recording storage contract. Token generation remains provided by the host system, such as DVLS. Gateway standalone webapp sandbox wiring will follow separately on top of this server contract.

Issue: DGW-403