### PR TITLE
refactor(agent): remove vestigial hubs from PSU gRPC protocol

### DIFF
--- a/devolutions-agent/Dockerfile.psu-grpc-poc
+++ b/devolutions-agent/Dockerfile.psu-grpc-poc
@@ -22,8 +22,7 @@ ENV DAGENT_CONFIG_PATH=/etc/devolutions-agent \
     POWERSHELL_TELEMETRY_OPTOUT=1 \
     PSU_SERVER_URL=http://host.docker.internal:5006 \
     PSU_AGENT_ID=devo-agent-linux \
-    PSU_DISPLAY_NAME="Devolutions Agent Linux" \
-    PSU_HUBS=default
+    PSU_DISPLAY_NAME="Devolutions Agent Linux"
 
 COPY --from=build /workspace/target/release/devolutions-agent /opt/devolutions/agent/devolutions-agent
 COPY devolutions-agent/docker/psu-grpc-entrypoint.sh /usr/local/bin/psu-grpc-entrypoint.sh

--- a/devolutions-agent/Run-PsuGrpcAgentContainer.ps1
+++ b/devolutions-agent/Run-PsuGrpcAgentContainer.ps1
@@ -8,7 +8,6 @@ param(
     [Parameter(Mandatory = $true)]
     [ValidateNotNullOrEmpty()]
     [string] $AppToken,
-    [string[]] $Hubs = @('default'),
     [switch] $NoBuild
 )
 
@@ -36,8 +35,7 @@ $dockerArgs = @(
     '-e', "PSU_SERVER_URL=$ServerUrl",
     '-e', "PSU_AGENT_ID=$AgentId",
     '-e', "PSU_DISPLAY_NAME=$DisplayName",
-    '-e', "PSU_APP_TOKEN=$AppToken",
-    '-e', "PSU_HUBS=$($Hubs -join ',')"
+    '-e', "PSU_APP_TOKEN=$AppToken"
 )
 
 $dockerArgs += $ImageName

--- a/devolutions-agent/docker/psu-grpc-entrypoint.sh
+++ b/devolutions-agent/docker/psu-grpc-entrypoint.sh
@@ -7,25 +7,6 @@ json_escape() {
     printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
 }
 
-IFS=',' read -r -a hubs <<< "${PSU_HUBS:-default}"
-hubs_json=""
-for hub in "${hubs[@]}"; do
-    hub="${hub#${hub%%[![:space:]]*}}"
-    hub="${hub%${hub##*[![:space:]]}}"
-    if [ -z "${hub}" ]; then
-        continue
-    fi
-
-    if [ -n "${hubs_json}" ]; then
-        hubs_json="${hubs_json}, "
-    fi
-    hubs_json="${hubs_json}\"$(json_escape "${hub}")\""
-done
-
-if [ -z "${hubs_json}" ]; then
-    hubs_json='"default"'
-fi
-
 if [ -z "${PSU_APP_TOKEN:-}" ]; then
     echo "PSU_APP_TOKEN is required" >&2
     exit 1
@@ -46,7 +27,6 @@ cat > "${DAGENT_CONFIG_PATH}/agent.json" <<EOF
     "AgentId": "$(json_escape "${PSU_AGENT_ID:-devo-agent-linux}")",
     "DisplayName": "$(json_escape "${PSU_DISPLAY_NAME:-Devolutions Agent Linux}")",
 ${app_token_property}
-    "Hubs": [ ${hubs_json} ],
     "PowerShell": {
       "ExecutablePath": "$(json_escape "${POWERSHELL_EXECUTABLE:-pwsh}")"
     }

--- a/devolutions-agent/proto/psu_agent.proto
+++ b/devolutions-agent/proto/psu_agent.proto
@@ -51,14 +51,12 @@ message RegisterAgent {
   string architecture = 6;
   string agent_version = 7;
   string protocol_version = 8;
-  repeated string hubs = 9;
   repeated AgentCapability capabilities = 10;
   repeated PowerShellRuntime powershell_runtimes = 11;
 }
 
 message RegisterAccepted {
   string connection_id = 1;
-  repeated string accepted_hubs = 2;
 }
 
 message AgentCapability {

--- a/devolutions-agent/proto/psu_agent.proto
+++ b/devolutions-agent/proto/psu_agent.proto
@@ -51,8 +51,8 @@ message RegisterAgent {
   string architecture = 6;
   string agent_version = 7;
   string protocol_version = 8;
-  repeated AgentCapability capabilities = 10;
-  repeated PowerShellRuntime powershell_runtimes = 11;
+  repeated AgentCapability capabilities = 9;
+  repeated PowerShellRuntime powershell_runtimes = 10;
 }
 
 message RegisterAccepted {

--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -111,7 +111,6 @@ pub struct PsuConf {
     pub agent_id: Option<String>,
     pub display_name: Option<String>,
     pub app_token: String,
-    pub hubs: Vec<String>,
     pub powershell: dto::PsuPowerShellConf,
 }
 
@@ -138,7 +137,6 @@ impl TryFrom<dto::PsuConf> for Option<PsuConf> {
             agent_id: conf.agent_id,
             display_name: conf.display_name,
             app_token,
-            hubs: conf.hubs,
             powershell: conf.powershell,
         }))
     }
@@ -581,10 +579,6 @@ pub mod dto {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub app_token: Option<String>,
 
-        /// Hubs/queues advertised during registration.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub hubs: Vec<String>,
-
         /// PowerShell child process configuration.
         #[serde(
             default,
@@ -928,7 +922,6 @@ mod tests {
                 "AgentId": "agent-01",
                 "DisplayName": "Agent 01",
                 "AppToken": "app-token",
-                "Hubs": ["default"],
                 "PowerShell": {
                     "VersionSelector": "7.5"
                 }

--- a/devolutions-agent/src/psu_agent/mod.rs
+++ b/devolutions-agent/src/psu_agent/mod.rs
@@ -293,7 +293,6 @@ impl PsuAgent {
                 architecture: std::env::consts::ARCH.to_owned(),
                 agent_version: env!("CARGO_PKG_VERSION").to_owned(),
                 protocol_version: PROTOCOL_VERSION.to_owned(),
-                hubs: self.conf.hubs.clone(),
                 capabilities: vec![
                     AgentCapability {
                         name: CAPABILITY_JOB_EXECUTION.to_owned(),
@@ -464,7 +463,6 @@ mod tests {
             agent_id: Some("agent-01".to_owned()),
             display_name: None,
             app_token: "literal-token".to_owned(),
-            hubs: Vec::new(),
             powershell: dto::PsuPowerShellConf {
                 executable_path: Some("missing-pwsh".into()),
                 ..dto::PsuPowerShellConf::default()


### PR DESCRIPTION
The PSU agent gRPC protocol carried a hubs label on registration that the
server echoed back, ported mechanically from the older SignalR PSUEventHub
protocol. It is vestigial: agent identity is defined by AgentId and job
fan-out is handled by computer groups, which superseded hubs.