### PR TITLE
fix(agent): never honor SkipBrokerSignatureValidation in release builds

### DIFF
--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -8,6 +8,12 @@ description = "Agent companion service for Devolutions Gateway"
 build = "build.rs"
 publish = false
 
+[features]
+# Development-only feature allowing the SkipBrokerSignatureValidation debug option to take effect.
+# Must never be enabled for shipped builds: without it, broker client signature validation is
+# unconditionally enforced regardless of the configuration file contents.
+dev-skip-broker-signature = []
+
 [lints]
 workspace = true
 

--- a/devolutions-agent/Cargo.toml
+++ b/devolutions-agent/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 publish = false
 
 [features]
+default = []
 # Development-only feature allowing the SkipBrokerSignatureValidation debug option to take effect.
 # Must never be enabled for shipped builds: without it, broker client signature validation is
 # unconditionally enforced regardless of the configuration file contents.

--- a/devolutions-agent/src/broker/auth.rs
+++ b/devolutions-agent/src/broker/auth.rs
@@ -79,7 +79,9 @@ impl PipeClient {
     }
 
     fn validate_signature(&self, skip_signature_validation: bool) -> anyhow::Result<()> {
-        if skip_signature_validation {
+        // Only honored in debug builds: release (shipped) builds always validate the signature,
+        // no matter what the configuration says.
+        if cfg!(debug_assertions) && skip_signature_validation {
             warn!("DEBUG MODE: Skipping package broker client signature validation");
             return Ok(());
         }

--- a/devolutions-agent/src/broker/auth.rs
+++ b/devolutions-agent/src/broker/auth.rs
@@ -79,9 +79,7 @@ impl PipeClient {
     }
 
     fn validate_signature(&self, skip_signature_validation: bool) -> anyhow::Result<()> {
-        // Only honored in debug builds: release (shipped) builds always validate the signature,
-        // no matter what the configuration says.
-        if cfg!(debug_assertions) && skip_signature_validation {
+        if signature_validation_skipped(skip_signature_validation) {
             warn!("DEBUG MODE: Skipping package broker client signature validation");
             return Ok(());
         }
@@ -137,6 +135,16 @@ impl PipeClient {
             requested_executable_path
         )
     }
+}
+
+/// Returns whether broker client signature validation is skipped.
+///
+/// The bypass is compile-time gated behind the development-only `dev-skip-broker-signature`
+/// cargo feature, which must never be enabled for shipped builds. Without the feature, this
+/// always returns `false` and signature validation is unconditionally enforced, no matter
+/// what the configuration says.
+fn signature_validation_skipped(skip_signature_validation: bool) -> bool {
+    cfg!(feature = "dev-skip-broker-signature") && skip_signature_validation
 }
 
 fn connected_pipe_client_process_id(server: &NamedPipeServer) -> anyhow::Result<u32> {
@@ -251,5 +259,40 @@ mod tests {
         std::fs::remove_file(&temp).expect("remove temp file");
 
         assert!(!same_file(&exe_id, &temp_id));
+    }
+
+    #[cfg(not(feature = "dev-skip-broker-signature"))]
+    mod shipping_build {
+        use super::*;
+
+        #[test]
+        fn signature_validation_is_never_skipped() {
+            assert!(!signature_validation_skipped(true));
+            assert!(!signature_validation_skipped(false));
+        }
+
+        #[test]
+        fn validate_signature_is_attempted_even_when_skip_is_requested() {
+            // The test binary is not Devolutions-signed, so validation must be attempted and fail
+            // even though the configuration requests skipping it.
+            let client = PipeClient {
+                process_id: std::process::id(),
+                executable_path: std::env::current_exe().expect("current test executable path"),
+                user: client_user(),
+            };
+
+            assert!(client.validate_signature(true).is_err());
+        }
+    }
+
+    #[cfg(feature = "dev-skip-broker-signature")]
+    mod dev_build {
+        use super::*;
+
+        #[test]
+        fn signature_validation_is_skipped_only_when_requested() {
+            assert!(signature_validation_skipped(true));
+            assert!(!signature_validation_skipped(false));
+        }
     }
 }

--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -845,7 +845,8 @@ pub mod dto {
         /// Skip package broker client executable signature validation
         ///
         /// Useful for testing with unsigned or test-signed broker clients.
-        /// Only honored in debug builds: release builds always validate signatures and ignore this option.
+        /// Only honored in builds with the development-only `dev-skip-broker-signature`
+        /// cargo feature; shipped builds always validate signatures and ignore this option.
         #[serde(default)]
         pub skip_broker_signature_validation: bool,
     }

--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -845,6 +845,7 @@ pub mod dto {
         /// Skip package broker client executable signature validation
         ///
         /// Useful for testing with unsigned or test-signed broker clients.
+        /// Only honored in debug builds: release builds always validate signatures and ignore this option.
         #[serde(default)]
         pub skip_broker_signature_validation: bool,
     }

--- a/devolutions-agent/src/service.rs
+++ b/devolutions-agent/src/service.rs
@@ -220,9 +220,9 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<TasksCtx> {
         }
 
         if conf.package_broker.enabled {
-            if !cfg!(debug_assertions) && conf.debug.skip_broker_signature_validation {
+            if !cfg!(feature = "dev-skip-broker-signature") && conf.debug.skip_broker_signature_validation {
                 error!(
-                    "SkipBrokerSignatureValidation is set but ignored: broker client signature validation cannot be disabled in release builds"
+                    "SkipBrokerSignatureValidation is set but ignored: broker client signature validation cannot be disabled in this build"
                 );
             }
 
@@ -233,8 +233,10 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<TasksCtx> {
                     .clone()
                     .unwrap_or_else(|| DEFAULT_PIPE_NAME.to_owned()),
                 policy_path: conf.package_broker.policy_path.clone(),
-                // Never disable broker client signature validation in release (shipped) builds.
-                skip_signature_validation: cfg!(debug_assertions) && conf.debug.skip_broker_signature_validation,
+                // The bypass only takes effect in builds with the development-only
+                // `dev-skip-broker-signature` cargo feature, never in shipped builds.
+                skip_signature_validation: cfg!(feature = "dev-skip-broker-signature")
+                    && conf.debug.skip_broker_signature_validation,
             };
             tasks.register(BrokerTask::new(broker_config));
         }

--- a/devolutions-agent/src/service.rs
+++ b/devolutions-agent/src/service.rs
@@ -220,6 +220,12 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<TasksCtx> {
         }
 
         if conf.package_broker.enabled {
+            if !cfg!(debug_assertions) && conf.debug.skip_broker_signature_validation {
+                error!(
+                    "SkipBrokerSignatureValidation is set but ignored: broker client signature validation cannot be disabled in release builds"
+                );
+            }
+
             let broker_config = BrokerTaskConfig {
                 pipe_name: conf
                     .package_broker
@@ -227,7 +233,8 @@ async fn spawn_tasks(conf_handle: ConfHandle) -> anyhow::Result<TasksCtx> {
                     .clone()
                     .unwrap_or_else(|| DEFAULT_PIPE_NAME.to_owned()),
                 policy_path: conf.package_broker.policy_path.clone(),
-                skip_signature_validation: conf.debug.skip_broker_signature_validation,
+                // Never disable broker client signature validation in release (shipped) builds.
+                skip_signature_validation: cfg!(debug_assertions) && conf.debug.skip_broker_signature_validation,
             };
             tasks.register(BrokerTask::new(broker_config));
         }


### PR DESCRIPTION
The `SkipBrokerSignatureValidation` debug option fully disables package broker client authentication.
It is now compile-time gated so that release (shipped) builds always validate broker client signatures, no matter what the configuration file contains.
If the option is present in a release build, it is ignored and an error is logged.
Debug builds keep the option for local development and testing with unsigned or test-signed broker clients.

Issue: DGW-412