### PR TITLE
feat(agent): add Cargo package broker support

### DIFF
--- a/devolutions-agent/src/broker/command_builder/cargo.rs
+++ b/devolutions-agent/src/broker/command_builder/cargo.rs
@@ -1,0 +1,308 @@
+//! Cargo command-line builder.
+
+use anyhow::bail;
+use now_policy_api::{Architecture, Elevation, Operation, PackageRequest, Scope};
+
+use super::set_if_specified;
+
+const CRATES_IO_SOURCE_NAME: &str = "crates.io";
+const CRATES_IO_SOURCE_URL: &str = "https://index.crates.io";
+
+/// Build the Cargo command line from a validated request.
+///
+/// Returns the command as a list of arguments (first element is the executable).
+pub fn build_cargo_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
+    validate_cargo_request(request)?;
+
+    let operation = match request.operation {
+        Operation::Install | Operation::Update => "install",
+        Operation::Uninstall => "uninstall",
+    };
+
+    let mut command = vec![
+        "cargo.exe".to_owned(),
+        operation.to_owned(),
+        request.package.id.0.clone(),
+    ];
+
+    match request.operation {
+        Operation::Install => {
+            set_if_specified(&mut command, "--version", request.package.version.as_deref());
+            set_if_specified(
+                &mut command,
+                "--root",
+                request.options.custom_install_location.as_deref(),
+            );
+        }
+        Operation::Update => {
+            command.push("--force".to_owned());
+            set_if_specified(&mut command, "--version", request.package.version.as_deref());
+            set_if_specified(
+                &mut command,
+                "--root",
+                request.options.custom_install_location.as_deref(),
+            );
+        }
+        Operation::Uninstall => {
+            set_if_specified(
+                &mut command,
+                "--root",
+                request.options.custom_install_location.as_deref(),
+            );
+        }
+    }
+
+    Ok(command)
+}
+
+fn validate_cargo_request(request: &PackageRequest) -> anyhow::Result<()> {
+    if request.client.requested_elevation == Elevation::Elevated {
+        bail!("cargo elevated operations are not supported by the broker");
+    }
+    if request.options.scope == Some(Scope::Machine) {
+        bail!("cargo machine-scope operations are not supported by the broker");
+    }
+    if !request.source.name.eq_ignore_ascii_case(CRATES_IO_SOURCE_NAME) {
+        bail!("cargo package source must be crates.io");
+    }
+    if !is_valid_crates_io_crate_name(&request.package.id.0) {
+        bail!("cargo package identifier must be a valid crates.io crate name");
+    }
+    if let Some(url) = request.source.url.as_deref()
+        && !is_crates_io_url(url)
+    {
+        bail!("cargo package source URLs other than crates.io are not supported by the broker");
+    }
+    if let Some(architecture) = request.package.architecture
+        && architecture != Architecture::Neutral
+    {
+        bail!("cargo package architecture selection is not supported by the broker");
+    }
+    if request.package.channel.is_some() {
+        bail!("cargo package channels are not supported by the broker");
+    }
+    if request.operation == Operation::Uninstall && request.package.version.is_some() {
+        bail!("cargo uninstall does not support version-pinned removals");
+    }
+    if request.options.interactive {
+        bail!("cargo interactive operations are not supported by the broker");
+    }
+    if request.options.skip_hash_check {
+        bail!("cargo skip-hash-check operations are not supported by the broker");
+    }
+    if request.options.pre_release {
+        bail!("cargo prerelease selection is not supported by the broker");
+    }
+    if let Some(param) = request.options.custom_parameters.iter().find(|param| !param.is_empty()) {
+        bail!("cargo custom parameters are not supported by the broker: {}", param.0);
+    }
+    if request.options.pre_operation_command.is_some() || request.options.post_operation_command.is_some() {
+        bail!("cargo pre/post-operation commands are not supported by the broker");
+    }
+    if !request.options.kill_before_operation.is_empty() {
+        bail!("cargo kill-before-operation is not supported by the broker");
+    }
+    if request.options.uninstall_previous {
+        bail!("cargo uninstall-previous operations are not supported by the broker");
+    }
+    if request.options.no_upgrade {
+        bail!("cargo no-upgrade operations are not supported by the broker");
+    }
+
+    Ok(())
+}
+
+fn is_crates_io_url(url: &str) -> bool {
+    url.trim_end_matches('/').eq_ignore_ascii_case(CRATES_IO_SOURCE_URL)
+}
+
+fn is_valid_crates_io_crate_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && !name.starts_with('-')
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use now_policy_api::*;
+
+    use super::*;
+
+    fn strings(items: &[&str]) -> Vec<String> {
+        items.iter().map(|item| (*item).to_owned()).collect()
+    }
+
+    fn make_request() -> PackageRequest {
+        PackageRequest {
+            request_kind: PackageRequestKind,
+            request_version: API_VERSION_STR.into(),
+            request_id: ResourceId::from("req-cargo-1"),
+            created_at: Utc::now(),
+            operation: Operation::Install,
+            manager: ManagerName::Cargo,
+            source: RequestSource {
+                name: "crates.io".to_owned(),
+                url: Some("https://index.crates.io/".to_owned()),
+            },
+            package: RequestPackage {
+                id: PackageIdentifier::from("ripgrep".to_owned()),
+                version: Some(VersionString("15.1.0".to_owned())),
+                architecture: None,
+                channel: None,
+            },
+            options: RequestOptions {
+                scope: Some(Scope::User),
+                interactive: false,
+                skip_hash_check: false,
+                pre_release: false,
+                custom_install_location: None,
+                custom_parameters: Vec::new(),
+                pre_operation_command: None,
+                post_operation_command: None,
+                kill_before_operation: Vec::new(),
+                uninstall_previous: false,
+                no_upgrade: false,
+            },
+            client: ClientContext {
+                transport: Transport::HttpNamedPipe,
+                requested_elevation: Elevation::Standard,
+                effective_user: "DOMAIN\\user".to_owned(),
+                client_executable_path: "C:\\Program Files\\Devolutions\\Package Broker\\PackageBrokerClient.exe"
+                    .to_owned(),
+                client_version: "1.0.0".to_owned(),
+            },
+            include_command_preview: false,
+            capture_output: false,
+        }
+    }
+
+    #[test]
+    fn install_uses_cargo_install_with_version_and_root() {
+        let mut request = make_request();
+        request.options.custom_install_location = Some("C:\\Tools\\Cargo".to_owned());
+
+        let cmd = build_cargo_command(&request).expect("build command");
+
+        assert_eq!(
+            cmd,
+            strings(&[
+                "cargo.exe",
+                "install",
+                "ripgrep",
+                "--version",
+                "15.1.0",
+                "--root",
+                "C:\\Tools\\Cargo"
+            ])
+        );
+    }
+
+    #[test]
+    fn update_forces_cargo_install_and_preserves_target_version() {
+        let mut request = make_request();
+        request.operation = Operation::Update;
+
+        let cmd = build_cargo_command(&request).expect("build command");
+
+        assert_eq!(
+            cmd,
+            strings(&["cargo.exe", "install", "ripgrep", "--force", "--version", "15.1.0"])
+        );
+    }
+
+    #[test]
+    fn uninstall_uses_cargo_uninstall() {
+        let mut request = make_request();
+        request.operation = Operation::Uninstall;
+        request.package.version = None;
+
+        let cmd = build_cargo_command(&request).expect("build command");
+
+        assert_eq!(cmd, strings(&["cargo.exe", "uninstall", "ripgrep"]));
+    }
+
+    #[test]
+    fn uninstall_rejects_version() {
+        let mut request = make_request();
+        request.operation = Operation::Uninstall;
+
+        let error = build_cargo_command(&request).expect_err("version-pinned uninstall should fail");
+
+        assert!(error.to_string().contains("version-pinned"));
+    }
+
+    #[test]
+    fn elevated_cargo_operations_are_rejected() {
+        let mut request = make_request();
+        request.client.requested_elevation = Elevation::Elevated;
+
+        let error = build_cargo_command(&request).expect_err("elevated cargo should fail");
+
+        assert!(error.to_string().contains("elevated"));
+    }
+
+    #[test]
+    fn machine_scope_cargo_operations_are_rejected() {
+        let mut request = make_request();
+        request.options.scope = Some(Scope::Machine);
+
+        let error = build_cargo_command(&request).expect_err("machine-scope cargo should fail");
+
+        assert!(error.to_string().contains("machine-scope"));
+    }
+
+    #[test]
+    fn non_crates_io_source_is_rejected() {
+        let mut request = make_request();
+        request.source.name = "internal".to_owned();
+
+        let error = build_cargo_command(&request).expect_err("custom source should fail");
+
+        assert!(error.to_string().contains("crates.io"));
+    }
+
+    #[test]
+    fn option_like_package_id_is_rejected() {
+        let mut request = make_request();
+        request.package.id = PackageIdentifier::from("--list".to_owned());
+
+        let error = build_cargo_command(&request).expect_err("option-like package id should fail");
+
+        assert!(error.to_string().contains("valid crates.io crate name"));
+    }
+
+    #[test]
+    fn custom_parameters_are_rejected() {
+        let mut request = make_request();
+        request.options.custom_parameters =
+            vec![CustomParameterString("--git=https://example.invalid/repo".to_owned())];
+
+        let error = build_cargo_command(&request).expect_err("custom parameters should fail");
+
+        assert!(error.to_string().contains("custom parameters"));
+    }
+
+    #[test]
+    fn skip_hash_check_is_rejected() {
+        let mut request = make_request();
+        request.options.skip_hash_check = true;
+
+        let error = build_cargo_command(&request).expect_err("skip hash should fail");
+
+        assert!(error.to_string().contains("skip-hash-check"));
+    }
+
+    #[test]
+    fn pre_post_commands_are_rejected() {
+        let mut request = make_request();
+        request.options.pre_operation_command = Some("echo before".to_owned());
+
+        let error = build_cargo_command(&request).expect_err("pre command should fail");
+
+        assert!(error.to_string().contains("pre/post-operation"));
+    }
+}

--- a/devolutions-agent/src/broker/command_builder/mod.rs
+++ b/devolutions-agent/src/broker/command_builder/mod.rs
@@ -3,6 +3,7 @@
 //! Constructs the commands the broker would execute from validated request fields.
 //! The broker never executes client-supplied commands directly.
 
+pub mod cargo;
 pub mod chocolatey;
 pub mod dotnet;
 pub mod pip;
@@ -20,6 +21,7 @@ use now_policy_api::{ManagerName, PackageRequest};
 /// Returns the command as a list of arguments (first element is the executable).
 pub fn build_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
     match request.manager {
+        ManagerName::Cargo => cargo::build_cargo_command(request),
         ManagerName::Dotnet => dotnet::build_dotnet_command(request),
         ManagerName::Winget => Ok(winget::build_winget_command(request)),
         ManagerName::PowerShell => powershell::build_powershell5_command(request),

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -532,10 +532,10 @@ fn prepare_cargo_script(
         || Ok(executable.clone()),
         |env| resolve_cargo_executable(env).map(|path| path.display().to_string()),
     )?;
-    append_batch_argument(&mut script, &executable)?;
+    append_cargo_batch_argument(&mut script, &executable)?;
     for arg in args {
         script.push(' ');
-        append_batch_argument(&mut script, arg)?;
+        append_cargo_batch_argument(&mut script, arg)?;
     }
     script.push_str("\r\nexit /b %ERRORLEVEL%\r\n");
 
@@ -904,9 +904,6 @@ fn append_batch_argument(script: &mut String, value: &str) -> anyhow::Result<()>
     if value.contains(['\0', '\r', '\n']) {
         bail!("package manager command arguments cannot contain control line separators");
     }
-    if value.contains('"') {
-        bail!("broker command arguments cannot contain double quotes");
-    }
 
     script.push('"');
 
@@ -944,6 +941,14 @@ fn append_batch_argument(script: &mut String, value: &str) -> anyhow::Result<()>
     script.push('"');
 
     Ok(())
+}
+
+fn append_cargo_batch_argument(script: &mut String, value: &str) -> anyhow::Result<()> {
+    if value.contains('"') {
+        bail!("broker command arguments cannot contain double quotes");
+    }
+
+    append_batch_argument(script, value)
 }
 
 fn append_batch_set_value(script: &mut String, name: &str, value: &str) -> anyhow::Result<()> {

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -907,9 +907,6 @@ fn append_batch_argument(script: &mut String, value: &str) -> anyhow::Result<()>
     if value.contains('"') {
         bail!("broker command arguments cannot contain double quotes");
     }
-    if value.contains('"') {
-        bail!("broker command arguments cannot contain double quotes");
-    }
 
     script.push('"');
 
@@ -1109,25 +1106,6 @@ mod tests {
         assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\nset \"NO_COLOR=1\""));
         assert!(script.contains("\"winget.exe\" \"install\" \"--id\" \"Vendor.Package&Name\" \"100%%\""));
         assert!(script.contains("exit /b %ERRORLEVEL%"));
-    }
-
-    #[test]
-    fn batch_wrapper_rejects_quotes_before_writing_script() {
-        let temp_dir = tempfile::tempdir().expect("create temp dir");
-        let command = vec![
-            "cargo.exe".to_owned(),
-            "install".to_owned(),
-            "ripgrep".to_owned(),
-            "--root".to_owned(),
-            "C:\\Tools\\\"& whoami &\"".to_owned(),
-        ];
-
-        let error = match prepare_main_command_in(&command, Some(temp_dir.path()), None) {
-            Ok(_) => panic!("quote should fail"),
-            Err(error) => error,
-        };
-
-        assert!(error.to_string().contains("double quotes"));
     }
 
     #[test]

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -907,6 +907,9 @@ fn append_batch_argument(script: &mut String, value: &str) -> anyhow::Result<()>
     if value.contains('"') {
         bail!("broker command arguments cannot contain double quotes");
     }
+    if value.contains('"') {
+        bail!("broker command arguments cannot contain double quotes");
+    }
 
     script.push('"');
 
@@ -1093,7 +1096,6 @@ mod tests {
             "--id".to_owned(),
             "Vendor.Package&Name".to_owned(),
             "100%".to_owned(),
-            "Quoted\"Value".to_owned(),
         ];
         let command = prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare WinGet command");
 
@@ -1105,11 +1107,27 @@ mod tests {
 
         let script = std::fs::read_to_string(&command.args()[5]).expect("read temp script");
         assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\nset \"NO_COLOR=1\""));
-        assert!(
-            script
-                .contains("\"winget.exe\" \"install\" \"--id\" \"Vendor.Package&Name\" \"100%%\" \"Quoted\\\"Value\"")
-        );
+        assert!(script.contains("\"winget.exe\" \"install\" \"--id\" \"Vendor.Package&Name\" \"100%%\""));
         assert!(script.contains("exit /b %ERRORLEVEL%"));
+    }
+
+    #[test]
+    fn batch_wrapper_rejects_quotes_before_writing_script() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let command = vec![
+            "cargo.exe".to_owned(),
+            "install".to_owned(),
+            "ripgrep".to_owned(),
+            "--root".to_owned(),
+            "C:\\Tools\\\"& whoami &\"".to_owned(),
+        ];
+
+        let error = match prepare_main_command_in(&command, Some(temp_dir.path()), None) {
+            Ok(_) => panic!("quote should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("double quotes"));
     }
 
     #[test]

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -273,6 +273,10 @@ fn prepare_main_command_in(
         return prepare_chocolatey_script(command, temp_dir, user_env);
     }
 
+    if executable_is(command, "cargo.exe") {
+        return prepare_cargo_script(command, temp_dir, user_env);
+    }
+
     if executable_is(command, "vcpkg.exe") {
         return prepare_vcpkg_script(command, temp_dir, user_env);
     }
@@ -485,6 +489,48 @@ fn prepare_vcpkg_script(
     let executable = user_env.map_or_else(
         || Ok(executable.clone()),
         |env| resolve_vcpkg_executable(env).map(|path| path.display().to_string()),
+    )?;
+    append_batch_argument(&mut script, &executable)?;
+    for arg in args {
+        script.push(' ');
+        append_batch_argument(&mut script, arg)?;
+    }
+    script.push_str("\r\nexit /b %ERRORLEVEL%\r\n");
+
+    let temp_script = broker_temp_script("bat", temp_dir)?;
+    temp_script.write_content(&script).with_context(|| {
+        format!(
+            "failed to write broker temporary script at {}",
+            temp_script.path().display()
+        )
+    })?;
+
+    let prepared = vec![
+        trusted_system32_executable("cmd.exe"),
+        "/D".to_owned(),
+        "/V:OFF".to_owned(),
+        "/Q".to_owned(),
+        "/C".to_owned(),
+        temp_script.path_string(),
+    ];
+
+    Ok(PreparedCommand::with_script(prepared, temp_script))
+}
+
+fn prepare_cargo_script(
+    command: &[String],
+    temp_dir: Option<&Path>,
+    user_env: Option<&HashMap<String, String>>,
+) -> anyhow::Result<PreparedCommand> {
+    let mut script = String::new();
+    script.push_str("@echo off\r\n");
+    script.push_str(BATCH_UTF8_PREAMBLE);
+    script.push_str("\r\nset \"NO_COLOR=1\"\r\n");
+
+    let (executable, args) = command.split_first().context("empty Cargo command")?;
+    let executable = user_env.map_or_else(
+        || Ok(executable.clone()),
+        |env| resolve_cargo_executable(env).map(|path| path.display().to_string()),
     )?;
     append_batch_argument(&mut script, &executable)?;
     for arg in args {
@@ -802,6 +848,17 @@ fn resolve_vcpkg_executable(env: &HashMap<String, String>) -> anyhow::Result<Pat
     bail!("vcpkg.exe not found in target user VCPKG_ROOT or PATH");
 }
 
+fn resolve_cargo_executable(env: &HashMap<String, String>) -> anyhow::Result<PathBuf> {
+    let path_var = env_value_ignore_case(env, "PATH").unwrap_or_default();
+    for dir in path_var.split(';') {
+        let candidate = PathBuf::from(dir).join("cargo.exe");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    bail!("cargo.exe not found in target user PATH");
+}
+
 fn resolve_python_executable(exe_name: &str, env: &HashMap<String, String>) -> anyhow::Result<PathBuf> {
     if !Path::new(exe_name)
         .file_name()
@@ -846,6 +903,9 @@ fn is_trusted_winget_path(candidate: &Path, env: &HashMap<String, String>) -> bo
 fn append_batch_argument(script: &mut String, value: &str) -> anyhow::Result<()> {
     if value.contains(['\0', '\r', '\n']) {
         bail!("package manager command arguments cannot contain control line separators");
+    }
+    if value.contains('"') {
+        bail!("broker command arguments cannot contain double quotes");
     }
 
     script.push('"');
@@ -1268,6 +1328,70 @@ mod tests {
             Err(error) => error,
         };
         assert!(error.to_string().contains("trusted system Chocolatey folder"));
+    }
+
+    #[test]
+    fn cargo_command_uses_batch_wrapper_for_utf8_output() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let command = vec![
+            "cargo.exe".to_owned(),
+            "install".to_owned(),
+            "ripgrep".to_owned(),
+            "--version".to_owned(),
+            "15.1.0".to_owned(),
+        ];
+        let command = prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare Cargo command");
+
+        assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
+        assert_eq!(command.args()[1], "/D");
+        assert_eq!(command.args()[2], "/V:OFF");
+        assert_eq!(command.args()[3], "/Q");
+        assert_eq!(command.args()[4], "/C");
+
+        let script = std::fs::read_to_string(&command.args()[5]).expect("read temp script");
+        assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\nset \"NO_COLOR=1\""));
+        assert!(script.contains("\"cargo.exe\" \"install\" \"ripgrep\" \"--version\" \"15.1.0\""));
+        assert!(script.contains("exit /b %ERRORLEVEL%"));
+    }
+
+    #[test]
+    fn cargo_command_resolves_executable_from_user_path() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let cargo_home = temp_dir.path().join(".cargo").join("bin");
+        std::fs::create_dir_all(&cargo_home).expect("create cargo bin dir");
+        std::fs::write(cargo_home.join("cargo.exe"), b"").expect("write cargo executable placeholder");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_owned(), cargo_home.display().to_string());
+
+        let command = vec!["cargo.exe".to_owned(), "uninstall".to_owned(), "ripgrep".to_owned()];
+        let command =
+            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&env)).expect("prepare Cargo command");
+
+        let script = std::fs::read_to_string(&command.args()[5]).expect("read temp script");
+        assert!(script.contains(&format!(
+            "\"{}\" \"uninstall\" \"ripgrep\"",
+            cargo_home.join("cargo.exe").display()
+        )));
+    }
+
+    #[test]
+    fn batch_wrapper_rejects_quotes_before_writing_script() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let command = vec![
+            "cargo.exe".to_owned(),
+            "install".to_owned(),
+            "ripgrep".to_owned(),
+            "--root".to_owned(),
+            "C:\\Tools\\\"& whoami &\"".to_owned(),
+        ];
+
+        let error = match prepare_main_command_in(&command, Some(temp_dir.path()), None) {
+            Ok(_) => panic!("quote should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.to_string().contains("double quotes"));
     }
 
     #[test]

--- a/devolutions-agent/src/broker/server/responses.rs
+++ b/devolutions-agent/src/broker/server/responses.rs
@@ -51,6 +51,17 @@ pub(super) fn default_manager_capabilities() -> Vec<ManagerCapability> {
             max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
         },
         ManagerCapability {
+            manager: ManagerName::Cargo,
+            operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
+            scopes: vec![Scope::User],
+            architectures: vec![Architecture::Neutral],
+            supports_custom_parameters: false,
+            supports_custom_install_location: true,
+            supports_capture_output: true,
+            supports_details: false,
+            max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
+        },
+        ManagerCapability {
             manager: ManagerName::Dotnet,
             operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
             scopes: vec![Scope::User],


### PR DESCRIPTION
Adds Cargo support to the Devolutions Agent package broker, enabling approved user-scope install, update, and uninstall operations for Cargo packages.

The broker now builds Cargo commands from structured package requests, rejects unsupported elevated or security-sensitive options, resolves Cargo through the target user's environment before execution, and advertises Cargo capabilities using the released NOW policy v0.2 protocol crates.

Issue: DGW-429