### PR TITLE
feat(agent): add Bun package broker support

### DIFF
--- a/devolutions-agent/src/broker/command_builder/bun.rs
+++ b/devolutions-agent/src/broker/command_builder/bun.rs
@@ -1,0 +1,282 @@
+//! Bun command-line builder.
+//!
+//! UniGetUI models Bun package operations as direct `bun` invocations:
+//! `bun add <package>@<version>` for install/update and `bun remove <package>`
+//! for uninstall.
+//! The broker only supports standard, per-user global Bun operations because
+//! Bun is discovered from the user's PATH and there is no broker-trusted
+//! elevated Bun executable location.
+
+use anyhow::bail;
+use now_policy_api::{Architecture, Elevation, Operation, PackageRequest, Scope};
+
+const BUN_SOURCE_NAME: &str = "Bun";
+const BUN_SOURCE_URL: &str = "https://www.npmjs.com";
+
+/// Build the Bun command line from a validated request.
+///
+/// Returns the command as a list of arguments (first element is the executable).
+pub fn build_bun_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
+    validate_bun_request(request)?;
+
+    let operation = match request.operation {
+        Operation::Install | Operation::Update => "add",
+        Operation::Uninstall => "remove",
+    };
+
+    let package = match request.operation {
+        Operation::Install | Operation::Update => {
+            package_spec(&request.package.id.0, request.package.version.as_deref())
+        }
+        Operation::Uninstall => request.package.id.0.clone(),
+    };
+
+    Ok(vec![
+        "bun".to_owned(),
+        operation.to_owned(),
+        package,
+        "--global".to_owned(),
+    ])
+}
+
+fn validate_bun_request(request: &PackageRequest) -> anyhow::Result<()> {
+    if request.client.requested_elevation == Elevation::Elevated {
+        bail!("elevated Bun package operations are not supported by the broker");
+    }
+
+    if request.options.scope == Some(Scope::Machine) {
+        bail!("machine-scope Bun package operations are not supported by the broker");
+    }
+
+    if !request.source.name.eq_ignore_ascii_case(BUN_SOURCE_NAME)
+        || request
+            .source
+            .url
+            .as_ref()
+            .is_some_and(|url| !is_default_bun_source_url(url))
+    {
+        bail!("custom Bun package sources are not supported by the broker");
+    }
+
+    if let Some(architecture) = request.package.architecture
+        && architecture != Architecture::Neutral
+    {
+        bail!("Bun package architecture selection is not supported by the broker");
+    }
+
+    if request
+        .package
+        .channel
+        .as_ref()
+        .is_some_and(|channel| !channel.trim().is_empty())
+    {
+        bail!("Bun package channels are not supported by the broker");
+    }
+
+    if request.options.interactive {
+        bail!("interactive Bun package operations are not supported by the broker");
+    }
+
+    if request.options.skip_hash_check {
+        bail!("Bun hash-check bypass is not supported by the broker");
+    }
+
+    if request.options.pre_release {
+        bail!("Bun pre-release selection is not supported by the broker");
+    }
+
+    if request
+        .options
+        .custom_install_location
+        .as_ref()
+        .is_some_and(|path| !path.trim().is_empty())
+    {
+        bail!("custom Bun install locations are not supported by the broker");
+    }
+
+    if let Some(param) = request.options.custom_parameters.iter().find(|param| !param.is_empty()) {
+        bail!("Bun custom parameters are not supported by the broker: {}", param.0);
+    }
+
+    if request.options.uninstall_previous {
+        bail!("Bun uninstall-previous operations are not supported by the broker");
+    }
+
+    if request.options.no_upgrade {
+        bail!("Bun no-upgrade operations are not supported by the broker");
+    }
+
+    Ok(())
+}
+
+fn package_spec(package_id: &str, version: Option<&str>) -> String {
+    match version.filter(|version| !version.is_empty()) {
+        Some(version) => format!("{package_id}@{version}"),
+        None => package_id.to_owned(),
+    }
+}
+
+fn is_default_bun_source_url(url: &str) -> bool {
+    url.trim_end_matches('/').eq_ignore_ascii_case(BUN_SOURCE_URL)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use now_policy_api::*;
+
+    use super::*;
+
+    fn make_request() -> PackageRequest {
+        PackageRequest {
+            request_kind: PackageRequestKind,
+            request_version: API_VERSION_STR.into(),
+            request_id: ResourceId::from("req-bun-1"),
+            created_at: Utc::now(),
+            operation: Operation::Install,
+            manager: ManagerName::Bun,
+            source: RequestSource {
+                name: "Bun".to_owned(),
+                url: None,
+            },
+            package: RequestPackage {
+                id: PackageIdentifier::from("typescript".to_owned()),
+                version: Some(VersionString("5.7.3".to_owned())),
+                architecture: None,
+                channel: None,
+            },
+            options: RequestOptions {
+                scope: Some(Scope::User),
+                interactive: false,
+                skip_hash_check: false,
+                pre_release: false,
+                custom_install_location: None,
+                custom_parameters: Vec::new(),
+                pre_operation_command: None,
+                post_operation_command: None,
+                kill_before_operation: Vec::new(),
+                uninstall_previous: false,
+                no_upgrade: false,
+            },
+            client: ClientContext {
+                transport: Transport::HttpNamedPipe,
+                requested_elevation: Elevation::Standard,
+                effective_user: "DOMAIN\\user".to_owned(),
+                client_executable_path: "C:\\Program Files\\Devolutions\\Package Broker\\PackageBrokerClient.exe"
+                    .to_owned(),
+                client_version: "1.0.0".to_owned(),
+            },
+            include_command_preview: false,
+            capture_output: false,
+        }
+    }
+
+    #[test]
+    fn bun_install_uses_add_global_with_version() {
+        let request = make_request();
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "add", "typescript@5.7.3", "--global"]);
+    }
+
+    #[test]
+    fn bun_update_uses_add_global_with_requested_version() {
+        let mut request = make_request();
+        request.operation = Operation::Update;
+        request.package.version = Some(VersionString("5.8.0".to_owned()));
+
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "add", "typescript@5.8.0", "--global"]);
+    }
+
+    #[test]
+    fn bun_install_without_version_uses_plain_package_id() {
+        let mut request = make_request();
+        request.package.version = None;
+
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "add", "typescript", "--global"]);
+    }
+
+    #[test]
+    fn bun_accepts_default_source_url() {
+        let mut request = make_request();
+        request.source.url = Some("https://www.npmjs.com/".to_owned());
+
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "add", "typescript@5.7.3", "--global"]);
+    }
+
+    #[test]
+    fn bun_uninstall_uses_remove_and_omits_version() {
+        let mut request = make_request();
+        request.operation = Operation::Uninstall;
+
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "remove", "typescript", "--global"]);
+    }
+
+    #[test]
+    fn bun_rejects_elevated_execution() {
+        let mut request = make_request();
+        request.client.requested_elevation = Elevation::Elevated;
+
+        let error = build_bun_command(&request).expect_err("elevation should fail");
+
+        assert!(error.to_string().contains("elevated Bun"));
+    }
+
+    #[test]
+    fn bun_rejects_machine_scope() {
+        let mut request = make_request();
+        request.options.scope = Some(Scope::Machine);
+
+        let error = build_bun_command(&request).expect_err("machine scope should fail");
+
+        assert!(error.to_string().contains("machine-scope Bun"));
+    }
+
+    #[test]
+    fn bun_rejects_custom_source() {
+        let mut request = make_request();
+        request.source.name = "npmjs".to_owned();
+
+        let error = build_bun_command(&request).expect_err("custom source should fail");
+
+        assert!(error.to_string().contains("custom Bun package sources"));
+    }
+
+    #[test]
+    fn bun_rejects_custom_source_url() {
+        let mut request = make_request();
+        request.source.url = Some("https://registry.npmjs.org".to_owned());
+
+        let error = build_bun_command(&request).expect_err("custom source URL should fail");
+
+        assert!(error.to_string().contains("custom Bun package sources"));
+    }
+
+    #[test]
+    fn bun_rejects_custom_parameters() {
+        let mut request = make_request();
+        request.options.custom_parameters = vec![CustomParameterString("--cwd=C:\\temp".to_owned())];
+
+        let error = build_bun_command(&request).expect_err("custom parameters should fail");
+
+        assert!(error.to_string().contains("custom parameters"));
+    }
+
+    #[test]
+    fn bun_rejects_security_sensitive_unsupported_options() {
+        let mut request = make_request();
+        request.options.skip_hash_check = true;
+
+        let error = build_bun_command(&request).expect_err("skip hash check should fail");
+
+        assert!(error.to_string().contains("hash-check bypass"));
+    }
+}

--- a/devolutions-agent/src/broker/command_builder/bun.rs
+++ b/devolutions-agent/src/broker/command_builder/bun.rs
@@ -106,6 +106,10 @@ fn validate_bun_request(request: &PackageRequest) -> anyhow::Result<()> {
         bail!("Bun no-upgrade operations are not supported by the broker");
     }
 
+    if let Some(version) = request.package.version.as_deref() {
+        validate_bun_package_version(version)?;
+    }
+
     Ok(())
 }
 
@@ -118,6 +122,18 @@ fn package_spec(package_id: &str, version: Option<&str>) -> String {
 
 fn is_default_bun_source_url(url: &str) -> bool {
     url.trim_end_matches('/').eq_ignore_ascii_case(BUN_SOURCE_URL)
+}
+
+fn validate_bun_package_version(version: &str) -> anyhow::Result<()> {
+    if version.is_empty() {
+        bail!("Bun package version must not be empty");
+    }
+
+    if semver::Version::parse(version).is_err() {
+        bail!("Bun package version must be a valid semantic version: {version}");
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -201,6 +217,27 @@ mod tests {
     }
 
     #[test]
+    fn bun_install_accepts_scoped_package_identifiers() {
+        let mut request = make_request();
+        request.package.id = PackageIdentifier::from("@scope/package".to_owned());
+        request.package.version = None;
+
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "add", "@scope/package", "--global"]);
+    }
+
+    #[test]
+    fn bun_accepts_semver_prerelease_and_build_versions() {
+        let mut request = make_request();
+        request.package.version = Some(VersionString("1.2.3-beta.1+build.5".to_owned()));
+
+        let command = build_bun_command(&request).expect("build command");
+
+        assert_eq!(command, ["bun", "add", "typescript@1.2.3-beta.1+build.5", "--global"]);
+    }
+
+    #[test]
     fn bun_accepts_default_source_url() {
         let mut request = make_request();
         request.source.url = Some("https://www.npmjs.com/".to_owned());
@@ -278,5 +315,26 @@ mod tests {
         let error = build_bun_command(&request).expect_err("skip hash check should fail");
 
         assert!(error.to_string().contains("hash-check bypass"));
+    }
+
+    #[test]
+    fn bun_rejects_non_version_package_selectors() {
+        for version in [
+            "npm:unapproved-package",
+            "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+            "git+https://github.com/microsoft/TypeScript.git",
+            "file:../typescript",
+            "^5.7.3",
+        ] {
+            let mut request = make_request();
+            request.package.version = Some(VersionString(version.to_owned()));
+
+            let error = build_bun_command(&request).expect_err("non-version selector should fail");
+
+            assert!(
+                error.to_string().contains("valid semantic version"),
+                "unexpected error for {version}: {error}"
+            );
+        }
     }
 }

--- a/devolutions-agent/src/broker/command_builder/mod.rs
+++ b/devolutions-agent/src/broker/command_builder/mod.rs
@@ -3,6 +3,7 @@
 //! Constructs the commands the broker would execute from validated request fields.
 //! The broker never executes client-supplied commands directly.
 
+pub mod bun;
 pub mod cargo;
 pub mod chocolatey;
 pub mod dotnet;
@@ -22,6 +23,7 @@ use now_policy_api::{ManagerName, PackageRequest};
 /// Returns the command as a list of arguments (first element is the executable).
 pub fn build_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
     match request.manager {
+        ManagerName::Bun => bun::build_bun_command(request),
         ManagerName::Cargo => cargo::build_cargo_command(request),
         ManagerName::Dotnet => dotnet::build_dotnet_command(request),
         ManagerName::Npm => npm::build_npm_command(request),

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -203,6 +203,11 @@ fn run_plan(
     session_id: u32,
     process_started: Option<ProcessStartedCallback>,
 ) -> anyhow::Result<ExecutionOutput> {
+    let requires_elevation = ctx.elevation == Elevation::Elevated || ctx.scope == Some(Scope::Machine);
+    if requires_elevation && command_is_bun(&ctx.command) {
+        bail!("elevated Bun package operations are not supported by the broker");
+    }
+
     // 1. Kill requested processes (best-effort; a missing process is not an error).
     for process_name in &ctx.kill_processes {
         let kill_cmd = vec![
@@ -283,6 +288,10 @@ fn prepare_main_command_in(
 
     if is_pip_python_command(command) {
         return prepare_pip_command(command, temp_dir, user_env);
+    }
+
+    if command_is_bun(command) {
+        return prepare_bun_command(command, temp_dir, user_env);
     }
 
     Ok(PreparedCommand::raw(command))
@@ -588,6 +597,68 @@ fn powershell_inline_script(command: &[String]) -> Option<(&str, usize)> {
     }
 }
 
+fn prepare_bun_command(
+    command: &[String],
+    temp_dir: Option<&Path>,
+    user_env: Option<&HashMap<String, String>>,
+) -> anyhow::Result<PreparedCommand> {
+    let (executable, args) = command.split_first().context("empty Bun command")?;
+    let executable = user_env.map_or_else(
+        || Ok(PathBuf::from(executable)),
+        |env| resolve_bun_executable(executable, env),
+    )?;
+
+    if executable
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("cmd"))
+    {
+        return prepare_bun_cmd_script(&executable.display().to_string(), args, temp_dir);
+    }
+
+    let mut prepared = Vec::with_capacity(command.len());
+    prepared.push(executable.display().to_string());
+    prepared.extend_from_slice(args);
+
+    Ok(PreparedCommand::raw(&prepared))
+}
+
+fn prepare_bun_cmd_script(
+    executable: &str,
+    args: &[String],
+    temp_dir: Option<&Path>,
+) -> anyhow::Result<PreparedCommand> {
+    let mut script = String::new();
+    script.push_str("@echo off\r\n");
+    script.push_str(BATCH_UTF8_PREAMBLE);
+    script.push_str("\r\ncall ");
+    append_batch_argument(&mut script, executable)?;
+    for arg in args {
+        script.push(' ');
+        append_batch_argument(&mut script, arg)?;
+    }
+    script.push_str("\r\nexit /b %ERRORLEVEL%\r\n");
+
+    let temp_script = broker_temp_script("bat", temp_dir)?;
+    temp_script.write_content(&script).with_context(|| {
+        format!(
+            "failed to write broker temporary script at {}",
+            temp_script.path().display()
+        )
+    })?;
+
+    let prepared = vec![
+        trusted_system32_executable("cmd.exe"),
+        "/D".to_owned(),
+        "/V:OFF".to_owned(),
+        "/Q".to_owned(),
+        "/C".to_owned(),
+        temp_script.path_string(),
+    ];
+
+    Ok(PreparedCommand::with_script(prepared, temp_script))
+}
+
 // Owner keeps full control; interactive users only need read access to execute the script.
 // The DACL is protected (`P`) so permissive entries are never inherited from the parent directory.
 const SCRIPT_DACL: &str = "D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;OW)(A;;FR;;;BU)";
@@ -706,6 +777,10 @@ fn is_pip_python_command(command: &[String]) -> bool {
         && executable_is(command, "python.exe")
         && command[1] == "-m"
         && command[2].eq_ignore_ascii_case("pip")
+}
+
+fn command_is_bun(command: &[String]) -> bool {
+    executable_is(command, "bun") || executable_is(command, "bun.exe") || executable_is(command, "bun.cmd")
 }
 
 fn quote_powershell_literal(value: &str) -> String {
@@ -881,6 +956,49 @@ fn resolve_python_executable(exe_name: &str, env: &HashMap<String, String>) -> a
     }
 
     bail!("python.exe not found in target user PATH");
+}
+
+fn resolve_bun_executable(executable: &str, env: &HashMap<String, String>) -> anyhow::Result<PathBuf> {
+    let executable_path = Path::new(executable);
+    if executable_path.is_absolute() {
+        if executable_path.exists() {
+            return Ok(executable_path.to_owned());
+        }
+        bail!(
+            "bun executable not found at absolute path: {}",
+            executable_path.display()
+        );
+    }
+
+    let Some(file_name) = executable_path.file_name().and_then(|name| name.to_str()) else {
+        bail!("invalid Bun executable name: {executable}");
+    };
+
+    let candidate_names: &[&str] = match file_name.to_ascii_lowercase().as_str() {
+        "bun" => &["bun.exe", "bun.cmd"],
+        "bun.exe" => &["bun.exe"],
+        "bun.cmd" => &["bun.cmd"],
+        _ => bail!("invalid Bun executable name: {executable}"),
+    };
+
+    let path_var = env
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("PATH"))
+        .map(|(_, value)| value.as_str())
+        .unwrap_or_default();
+    for dir in path_var.split(';') {
+        let dir = dir.trim();
+        if dir.is_empty() {
+            continue;
+        }
+        for candidate_name in candidate_names {
+            let candidate = PathBuf::from(dir).join(candidate_name);
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+    bail!("bun executable not found in target user PATH");
 }
 
 fn is_trusted_winget_path(candidate: &Path, env: &HashMap<String, String>) -> bool {
@@ -1111,6 +1229,60 @@ mod tests {
         assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\nset \"NO_COLOR=1\""));
         assert!(script.contains("\"winget.exe\" \"install\" \"--id\" \"Vendor.Package&Name\" \"100%%\""));
         assert!(script.contains("exit /b %ERRORLEVEL%"));
+    }
+
+    #[test]
+    fn bun_cmd_command_uses_trusted_cmd_batch_wrapper() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let bun_path = temp_dir.path().join("bun.cmd");
+        std::fs::write(&bun_path, "@echo off\r\n").expect("write bun wrapper");
+        let mut user_env = HashMap::new();
+        user_env.insert("PATH".to_owned(), temp_dir.path().display().to_string());
+        let command = vec![
+            "bun".to_owned(),
+            "add".to_owned(),
+            "typescript@5.7.3".to_owned(),
+            "--global".to_owned(),
+        ];
+
+        let command =
+            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env)).expect("prepare Bun command");
+
+        assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
+        assert_eq!(command.args()[1], "/D");
+        assert_eq!(command.args()[2], "/V:OFF");
+        assert_eq!(command.args()[3], "/Q");
+        assert_eq!(command.args()[4], "/C");
+
+        let script = std::fs::read_to_string(&command.args()[5]).expect("read temp script");
+        assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\ncall "));
+        assert!(script.contains(&format!(
+            "\"{}\" \"add\" \"typescript@5.7.3\" \"--global\"",
+            bun_path.display()
+        )));
+        assert!(script.contains("exit /b %ERRORLEVEL%"));
+    }
+
+    #[test]
+    fn bun_exe_command_resolves_from_user_path_without_script_wrapper() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let bun_path = temp_dir.path().join("bun.exe");
+        std::fs::write(&bun_path, b"").expect("write bun exe placeholder");
+        let mut user_env = HashMap::new();
+        user_env.insert("PATH".to_owned(), temp_dir.path().display().to_string());
+        let command = vec![
+            "bun".to_owned(),
+            "add".to_owned(),
+            "typescript@5.7.3".to_owned(),
+            "--global".to_owned(),
+        ];
+
+        let command = prepare_main_command_in(&command, None, Some(&user_env)).expect("prepare Bun command");
+
+        assert_eq!(command.args()[0], bun_path.display().to_string());
+        assert_eq!(command.args()[1], "add");
+        assert_eq!(command.args()[2], "typescript@5.7.3");
+        assert_eq!(command.args()[3], "--global");
     }
 
     #[test]

--- a/devolutions-agent/src/broker/server/responses.rs
+++ b/devolutions-agent/src/broker/server/responses.rs
@@ -51,6 +51,17 @@ pub(super) fn default_manager_capabilities() -> Vec<ManagerCapability> {
             max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
         },
         ManagerCapability {
+            manager: ManagerName::Bun,
+            operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
+            scopes: vec![Scope::User],
+            architectures: vec![Architecture::Neutral],
+            supports_custom_parameters: false,
+            supports_custom_install_location: false,
+            supports_capture_output: true,
+            supports_details: false,
+            max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
+        },
+        ManagerCapability {
             manager: ManagerName::Cargo,
             operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
             scopes: vec![Scope::User],


### PR DESCRIPTION
Adds Bun as a supported Devolutions Agent package broker manager for standard user-scope package operations. Approved clients can install, update, and uninstall Bun packages through the broker while unsupported or security-sensitive Bun options are rejected with explicit validation errors.

Bun broker operations intentionally remain non-elevated because the broker cannot validate a trusted elevated Bun executable location. Standard execution resolves Bun from the target user's PATH without reintroducing local protocol crate patches.

Issue: DGW-431