### PR TITLE
feat(agent): add vcpkg package broker support

### DIFF
--- a/devolutions-agent/src/broker/command_builder/mod.rs
+++ b/devolutions-agent/src/broker/command_builder/mod.rs
@@ -6,6 +6,7 @@
 pub mod chocolatey;
 pub mod powershell;
 pub mod scoop;
+pub mod vcpkg;
 pub mod winget;
 
 use anyhow::bail;
@@ -22,6 +23,7 @@ pub fn build_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
         ManagerName::PowerShell7 => powershell::build_powershell7_command(request),
         ManagerName::Chocolatey => chocolatey::build_chocolatey_command(request),
         ManagerName::Scoop => scoop::build_scoop_command(request),
+        ManagerName::Vcpkg => vcpkg::build_vcpkg_command(request),
         unsupported => bail!("package manager is not supported by the broker: {unsupported}"),
     }
 }

--- a/devolutions-agent/src/broker/command_builder/vcpkg.rs
+++ b/devolutions-agent/src/broker/command_builder/vcpkg.rs
@@ -1,0 +1,255 @@
+//! vcpkg command-line builder.
+//!
+//! UniGetUI runs vcpkg package operations as:
+//! - `vcpkg install <package[:triplet]>`
+//! - `vcpkg upgrade <package[:triplet]> --no-dry-run`
+//! - `vcpkg remove <package[:triplet]> --recurse`
+//!
+//! The broker maps the request source name to the vcpkg triplet and does not
+//! accept command-line extensions that can redirect vcpkg to an arbitrary root,
+//! overlay, registry, or script path.
+
+use anyhow::bail;
+use now_policy_api::{Elevation, Operation, PackageRequest, Scope};
+
+/// Build the vcpkg command line from a validated request.
+pub fn build_vcpkg_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
+    validate_vcpkg_request(request)?;
+
+    let operation = match request.operation {
+        Operation::Install => "install",
+        Operation::Update => "upgrade",
+        Operation::Uninstall => "remove",
+    };
+
+    let mut command = vec!["vcpkg.exe".to_owned(), operation.to_owned(), package_spec(request)?];
+
+    match request.operation {
+        Operation::Install => {}
+        Operation::Update => command.push("--no-dry-run".to_owned()),
+        Operation::Uninstall => command.push("--recurse".to_owned()),
+    }
+
+    Ok(command)
+}
+
+fn validate_vcpkg_request(request: &PackageRequest) -> anyhow::Result<()> {
+    if request.client.requested_elevation == Elevation::Elevated {
+        bail!("vcpkg elevated operations are not supported by the broker");
+    }
+    if request.options.scope == Some(Scope::Machine) {
+        bail!("vcpkg machine-scope operations are not supported by the broker");
+    }
+    if request.source.url.is_some() {
+        bail!("vcpkg package sources with URLs are not supported by the broker");
+    }
+    if !is_valid_triplet(&request.source.name) {
+        bail!("vcpkg package source name must be a triplet");
+    }
+    if request.package.version.is_some() {
+        bail!("vcpkg package versions are not supported by the broker");
+    }
+    if request.package.architecture.is_some() {
+        bail!("vcpkg package architecture is encoded by the triplet source");
+    }
+    if request.package.channel.is_some() {
+        bail!("vcpkg package channels are not supported by the broker");
+    }
+    if request.options.interactive {
+        bail!("vcpkg interactive operations are not supported by the broker");
+    }
+    if request.options.skip_hash_check {
+        bail!("vcpkg skip-hash-check operations are not supported by the broker");
+    }
+    if request.options.pre_release {
+        bail!("vcpkg prerelease operations are not supported by the broker");
+    }
+    if request.options.custom_install_location.is_some() {
+        bail!("vcpkg custom install locations are not supported by the broker");
+    }
+    if let Some(param) = request.options.custom_parameters.iter().find(|param| !param.is_empty()) {
+        bail!("vcpkg custom parameters are not supported by the broker: {}", param.0);
+    }
+    if request.options.uninstall_previous {
+        bail!("vcpkg uninstall-previous operations are not supported by the broker");
+    }
+    if request.options.no_upgrade {
+        bail!("vcpkg no-upgrade operations are not supported by the broker");
+    }
+
+    Ok(())
+}
+
+fn package_spec(request: &PackageRequest) -> anyhow::Result<String> {
+    let triplet = request.source.name.trim();
+    let package_id = request.package.id.0.trim();
+
+    if package_id.is_empty() {
+        bail!("vcpkg package id is required");
+    }
+
+    if let Some((port, package_triplet)) = package_id.split_once(':') {
+        if port.is_empty() || package_triplet.is_empty() || package_triplet.contains(':') {
+            bail!("vcpkg package id must be in the form '<port>[:<triplet>]'");
+        }
+        if package_triplet != triplet {
+            bail!("vcpkg package triplet must match the request source");
+        }
+        Ok(package_id.to_owned())
+    } else {
+        Ok(format!("{package_id}:{triplet}"))
+    }
+}
+
+fn is_valid_triplet(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use now_policy_api::*;
+
+    use super::*;
+
+    fn make_request() -> PackageRequest {
+        PackageRequest {
+            request_kind: PackageRequestKind,
+            request_version: API_VERSION_STR.into(),
+            request_id: ResourceId::from("req-vcpkg-1"),
+            created_at: Utc::now(),
+            operation: Operation::Install,
+            manager: ManagerName::Vcpkg,
+            source: RequestSource {
+                name: "x64-windows".to_owned(),
+                url: None,
+            },
+            package: RequestPackage {
+                id: PackageIdentifier::from("zlib".to_owned()),
+                version: None,
+                architecture: None,
+                channel: None,
+            },
+            options: RequestOptions {
+                scope: Some(Scope::User),
+                interactive: false,
+                skip_hash_check: false,
+                pre_release: false,
+                custom_install_location: None,
+                custom_parameters: Vec::new(),
+                pre_operation_command: None,
+                post_operation_command: None,
+                kill_before_operation: Vec::new(),
+                uninstall_previous: false,
+                no_upgrade: false,
+            },
+            client: ClientContext {
+                transport: Transport::HttpNamedPipe,
+                requested_elevation: Elevation::Standard,
+                effective_user: "DOMAIN\\user".to_owned(),
+                client_executable_path: "C:\\Program Files\\Devolutions\\Package Broker\\PackageBrokerClient.exe"
+                    .to_owned(),
+                client_version: "1.0.0".to_owned(),
+            },
+            include_command_preview: false,
+            capture_output: false,
+        }
+    }
+
+    #[test]
+    fn install_appends_source_triplet() {
+        let request = make_request();
+        let cmd = build_vcpkg_command(&request).expect("build command");
+
+        assert_eq!(cmd, ["vcpkg.exe", "install", "zlib:x64-windows"]);
+    }
+
+    #[test]
+    fn update_uses_unigetui_no_dry_run_semantics() {
+        let mut request = make_request();
+        request.operation = Operation::Update;
+        request.package.id = PackageIdentifier::from("curl:x64-windows".to_owned());
+
+        let cmd = build_vcpkg_command(&request).expect("build command");
+
+        assert_eq!(cmd, ["vcpkg.exe", "upgrade", "curl:x64-windows", "--no-dry-run"]);
+    }
+
+    #[test]
+    fn uninstall_uses_unigetui_recurse_semantics() {
+        let mut request = make_request();
+        request.operation = Operation::Uninstall;
+        request.package.id = PackageIdentifier::from("openssl:x64-windows".to_owned());
+
+        let cmd = build_vcpkg_command(&request).expect("build command");
+
+        assert_eq!(cmd, ["vcpkg.exe", "remove", "openssl:x64-windows", "--recurse"]);
+    }
+
+    #[test]
+    fn package_triplet_must_match_source() {
+        let mut request = make_request();
+        request.package.id = PackageIdentifier::from("zlib:x86-windows".to_owned());
+
+        let error = build_vcpkg_command(&request).expect_err("triplet mismatch should fail");
+
+        assert!(error.to_string().contains("triplet"));
+    }
+
+    #[test]
+    fn elevated_requests_are_rejected() {
+        let mut request = make_request();
+        request.client.requested_elevation = Elevation::Elevated;
+
+        let error = build_vcpkg_command(&request).expect_err("elevated request should fail");
+
+        assert!(error.to_string().contains("elevated"));
+    }
+
+    #[test]
+    fn machine_scope_requests_are_rejected() {
+        let mut request = make_request();
+        request.options.scope = Some(Scope::Machine);
+
+        let error = build_vcpkg_command(&request).expect_err("machine scope should fail");
+
+        assert!(error.to_string().contains("machine-scope"));
+    }
+
+    #[test]
+    fn custom_parameters_are_rejected() {
+        let mut request = make_request();
+        request.options.custom_parameters = vec![CustomParameterString(
+            "--vcpkg-root=C:\\Users\\user\\checkout".to_owned(),
+        )];
+
+        let error = build_vcpkg_command(&request).expect_err("custom parameter should fail");
+
+        assert!(error.to_string().contains("custom parameters"));
+    }
+
+    #[test]
+    fn unsupported_options_are_rejected() {
+        let mut request = make_request();
+        request.options.custom_install_location = Some("C:\\libs".to_owned());
+        assert!(
+            build_vcpkg_command(&request)
+                .expect_err("custom install location should fail")
+                .to_string()
+                .contains("custom install")
+        );
+
+        request = make_request();
+        request.package.version = Some(VersionString("1.2.3".to_owned()));
+        assert!(
+            build_vcpkg_command(&request)
+                .expect_err("version should fail")
+                .to_string()
+                .contains("versions")
+        );
+    }
+}

--- a/devolutions-agent/src/broker/command_builder/vcpkg.rs
+++ b/devolutions-agent/src/broker/command_builder/vcpkg.rs
@@ -87,6 +87,10 @@ fn package_spec(request: &PackageRequest) -> anyhow::Result<String> {
     if package_id.is_empty() {
         bail!("vcpkg package id is required");
     }
+    if package_id != request.package.id.0 {
+        bail!("vcpkg package id must not contain leading or trailing whitespace");
+    }
+    validate_port_spec(package_id)?;
 
     if let Some((port, package_triplet)) = package_id.split_once(':') {
         if port.is_empty() || package_triplet.is_empty() || package_triplet.contains(':') {
@@ -99,6 +103,57 @@ fn package_spec(request: &PackageRequest) -> anyhow::Result<String> {
     } else {
         Ok(format!("{package_id}:{triplet}"))
     }
+}
+
+fn validate_port_spec(value: &str) -> anyhow::Result<()> {
+    let (port_with_features, triplet) = value
+        .split_once(':')
+        .map_or((value, None), |(port_with_features, triplet)| {
+            (port_with_features, Some(triplet))
+        });
+
+    if let Some(triplet) = triplet
+        && !is_valid_triplet(triplet)
+    {
+        bail!("vcpkg package triplet is invalid");
+    }
+
+    let (port, features) = port_with_features
+        .split_once('[')
+        .map_or((port_with_features, None), |(port, features)| (port, Some(features)));
+
+    if !is_valid_port_name(port) {
+        bail!("vcpkg package port name is invalid");
+    }
+
+    let Some(features) = features else {
+        return Ok(());
+    };
+
+    if !features.ends_with(']') || features[..features.len() - 1].contains(['[', ']']) {
+        bail!("vcpkg package features are invalid");
+    }
+
+    let features = &features[..features.len() - 1];
+    if features.is_empty() {
+        bail!("vcpkg package features are invalid");
+    }
+
+    for feature in features.split(',') {
+        if !is_valid_port_name(feature) {
+            bail!("vcpkg package features are invalid");
+        }
+    }
+
+    Ok(())
+}
+
+fn is_valid_port_name(value: &str) -> bool {
+    !value.is_empty()
+        && !value.starts_with('-')
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
 }
 
 fn is_valid_triplet(value: &str) -> bool {
@@ -191,6 +246,16 @@ mod tests {
     }
 
     #[test]
+    fn package_features_are_preserved() {
+        let mut request = make_request();
+        request.package.id = PackageIdentifier::from("curl[non-http,ssl]".to_owned());
+
+        let cmd = build_vcpkg_command(&request).expect("build command");
+
+        assert_eq!(cmd, ["vcpkg.exe", "install", "curl[non-http,ssl]:x64-windows"]);
+    }
+
+    #[test]
     fn package_triplet_must_match_source() {
         let mut request = make_request();
         request.package.id = PackageIdentifier::from("zlib:x86-windows".to_owned());
@@ -230,6 +295,29 @@ mod tests {
         let error = build_vcpkg_command(&request).expect_err("custom parameter should fail");
 
         assert!(error.to_string().contains("custom parameters"));
+    }
+
+    #[test]
+    fn invalid_package_specs_are_rejected() {
+        for package_id in [
+            "--vcpkg-root=C:\\checkout",
+            "zlib\" & calc & rem \"",
+            "zlib & calc",
+            "zlib[]",
+            "zlib[bad feature]",
+            "Zlib",
+            "zlib:x64-windows:extra",
+        ] {
+            let mut request = make_request();
+            request.package.id = PackageIdentifier::from(package_id.to_owned());
+
+            let error = build_vcpkg_command(&request).expect_err("invalid package spec should fail");
+
+            assert!(
+                error.to_string().contains("vcpkg package"),
+                "unexpected error for {package_id}: {error}"
+            );
+        }
     }
 
     #[test]

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -59,6 +59,7 @@ impl CommandExecutor for WindowsExecutor {
         process_started: Option<ProcessStartedCallback>,
     ) -> anyhow::Result<ExecutionOutput> {
         let requires_elevation = ctx.elevation == Elevation::Elevated || ctx.scope == Some(Scope::Machine);
+        reject_unsupported_vcpkg_elevation(ctx)?;
 
         if !self.is_system && requires_elevation {
             bail!(
@@ -272,7 +273,21 @@ fn prepare_main_command_in(
         return prepare_chocolatey_script(command, temp_dir, user_env);
     }
 
+    if executable_is(command, "vcpkg.exe") {
+        return prepare_vcpkg_script(command, temp_dir, user_env);
+    }
+
     Ok(PreparedCommand::raw(command))
+}
+
+fn reject_unsupported_vcpkg_elevation(ctx: &ExecutionContext) -> anyhow::Result<()> {
+    if executable_is(&ctx.command, "vcpkg.exe")
+        && (ctx.elevation == Elevation::Elevated || ctx.scope == Some(Scope::Machine))
+    {
+        bail!("vcpkg elevated or machine-scope operations are not supported by the broker");
+    }
+
+    Ok(())
 }
 
 fn prepare_shell_command(_token: &Token, payload: &str) -> anyhow::Result<PreparedCommand> {
@@ -431,6 +446,48 @@ fn prepare_chocolatey_script_in_with_default_install_root(
     script.push_str("\r\nif \"%CHOCO_EXIT_CODE%\"==\"1641\" exit /b 0");
     script.push_str("\r\nif \"%CHOCO_EXIT_CODE%\"==\"3010\" exit /b 0");
     script.push_str("\r\nexit /b %CHOCO_EXIT_CODE%\r\n");
+
+    let temp_script = broker_temp_script("bat", temp_dir)?;
+    temp_script.write_content(&script).with_context(|| {
+        format!(
+            "failed to write broker temporary script at {}",
+            temp_script.path().display()
+        )
+    })?;
+
+    let prepared = vec![
+        trusted_system32_executable("cmd.exe"),
+        "/D".to_owned(),
+        "/V:OFF".to_owned(),
+        "/Q".to_owned(),
+        "/C".to_owned(),
+        temp_script.path_string(),
+    ];
+
+    Ok(PreparedCommand::with_script(prepared, temp_script))
+}
+
+fn prepare_vcpkg_script(
+    command: &[String],
+    temp_dir: Option<&Path>,
+    user_env: Option<&HashMap<String, String>>,
+) -> anyhow::Result<PreparedCommand> {
+    let mut script = String::new();
+    script.push_str("@echo off\r\n");
+    script.push_str(BATCH_UTF8_PREAMBLE);
+    script.push_str("\r\nset \"NO_COLOR=1\"\r\n");
+
+    let (executable, args) = command.split_first().context("empty vcpkg command")?;
+    let executable = user_env.map_or_else(
+        || Ok(executable.clone()),
+        |env| resolve_vcpkg_executable(env).map(|path| path.display().to_string()),
+    )?;
+    append_batch_argument(&mut script, &executable)?;
+    for arg in args {
+        script.push(' ');
+        append_batch_argument(&mut script, arg)?;
+    }
+    script.push_str("\r\nexit /b %ERRORLEVEL%\r\n");
 
     let temp_script = broker_temp_script("bat", temp_dir)?;
     temp_script.write_content(&script).with_context(|| {
@@ -692,6 +749,32 @@ fn resolve_winget_executable(env: &HashMap<String, String>) -> anyhow::Result<Pa
     bail!("trusted winget.exe not found in target user PATH");
 }
 
+fn resolve_vcpkg_executable(env: &HashMap<String, String>) -> anyhow::Result<PathBuf> {
+    if let Some(root) = env_value_ignore_case(env, "VCPKG_ROOT")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let candidate = PathBuf::from(root).join("vcpkg.exe");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    let path_var = env_value_ignore_case(env, "PATH").unwrap_or_default();
+    for dir in path_var.split(';') {
+        let dir = dir.trim();
+        if dir.is_empty() {
+            continue;
+        }
+        let candidate = PathBuf::from(dir).join("vcpkg.exe");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    bail!("vcpkg.exe not found in target user VCPKG_ROOT or PATH");
+}
+
 fn is_trusted_winget_path(candidate: &Path, env: &HashMap<String, String>) -> bool {
     let candidate = candidate.as_os_str().to_string_lossy().to_lowercase();
     let program_files = env
@@ -795,10 +878,14 @@ impl PreparedCommand {
 mod tests {
     use std::collections::HashMap;
 
+    use now_policy_api::{Elevation, Scope};
+    use win_api_wrappers::identity::sid::Sid;
+
     use super::{
         POWERSHELL_UTF8_ENCODING_PREAMBLE, prepare_chocolatey_script_in_with_default_install_root,
-        prepare_main_command_in, prepare_shell_command_in,
+        prepare_main_command_in, prepare_shell_command_in, reject_unsupported_vcpkg_elevation,
     };
+    use crate::broker::executor::ExecutionContext;
 
     #[test]
     fn shell_command_uses_utf8_temp_batch_file() {
@@ -1130,5 +1217,62 @@ mod tests {
             Err(error) => error,
         };
         assert!(error.to_string().contains("trusted system Chocolatey folder"));
+    }
+
+    #[test]
+    fn vcpkg_command_uses_batch_wrapper_with_user_resolved_executable() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let vcpkg_root = temp_dir.path().join("vcpkg-root");
+        std::fs::create_dir(&vcpkg_root).expect("create vcpkg root");
+        std::fs::write(vcpkg_root.join("vcpkg.exe"), []).expect("create vcpkg exe");
+
+        let command = vec![
+            "vcpkg.exe".to_owned(),
+            "install".to_owned(),
+            "zlib:x64-windows".to_owned(),
+        ];
+        let user_env = HashMap::from([("VCPKG_ROOT".to_owned(), vcpkg_root.display().to_string())]);
+        let command =
+            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env)).expect("prepare vcpkg command");
+
+        assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
+        assert_eq!(command.args()[1], "/D");
+        assert_eq!(command.args()[2], "/V:OFF");
+        assert_eq!(command.args()[3], "/Q");
+        assert_eq!(command.args()[4], "/C");
+
+        let script = std::fs::read_to_string(&command.args()[5]).expect("read temp script");
+        assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\nset \"NO_COLOR=1\""));
+        assert!(script.contains("\"install\" \"zlib:x64-windows\""));
+        assert!(script.contains("vcpkg.exe"));
+        assert!(script.contains("exit /b %ERRORLEVEL%"));
+    }
+
+    #[test]
+    fn vcpkg_elevated_execution_is_rejected() {
+        let mut ctx = ExecutionContext {
+            kill_processes: Vec::new(),
+            pre_command: None,
+            command: vec![
+                "vcpkg.exe".to_owned(),
+                "install".to_owned(),
+                "zlib:x64-windows".to_owned(),
+            ],
+            post_command: None,
+            effective_user: "DOMAIN\\user".to_owned(),
+            user_sid: Sid::from_well_known(windows::Win32::Security::WinWorldSid, None)
+                .expect("well-known Everyone SID"),
+            elevation: Elevation::Elevated,
+            scope: Some(Scope::User),
+            capture_output: false,
+        };
+
+        let error = reject_unsupported_vcpkg_elevation(&ctx).expect_err("elevated vcpkg should fail");
+        assert!(error.to_string().contains("elevated"));
+
+        ctx.elevation = Elevation::Standard;
+        ctx.scope = Some(Scope::Machine);
+        let error = reject_unsupported_vcpkg_elevation(&ctx).expect_err("machine-scope vcpkg should fail");
+        assert!(error.to_string().contains("machine-scope"));
     }
 }

--- a/devolutions-agent/src/broker/server/responses.rs
+++ b/devolutions-agent/src/broker/server/responses.rs
@@ -83,6 +83,17 @@ pub(super) fn default_manager_capabilities() -> Vec<ManagerCapability> {
             supports_details: false,
             max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
         },
+        ManagerCapability {
+            manager: ManagerName::Vcpkg,
+            operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
+            scopes: vec![Scope::User],
+            architectures: vec![Architecture::Neutral],
+            supports_custom_parameters: false,
+            supports_custom_install_location: false,
+            supports_capture_output: true,
+            supports_details: false,
+            max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
+        },
     ]
 }
 


### PR DESCRIPTION
Adds vcpkg as a supported Devolutions Agent package broker manager for user-scope package operations. Users can now broker vcpkg install, update, and uninstall requests through the same policy-controlled package broker flow as other supported managers.

The broker uses UniGetUI-compatible vcpkg command semantics and rejects unsupported options that could redirect operations to unsafe package roots, overlays, registries, or scripts.

Issue: DGW-426