### PR TITLE
feat(agent): add npm package broker support

### DIFF
--- a/devolutions-agent/src/broker/command_builder/mod.rs
+++ b/devolutions-agent/src/broker/command_builder/mod.rs
@@ -6,6 +6,7 @@
 pub mod cargo;
 pub mod chocolatey;
 pub mod dotnet;
+pub mod npm;
 pub mod pip;
 pub mod powershell;
 pub mod scoop;
@@ -23,6 +24,7 @@ pub fn build_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
     match request.manager {
         ManagerName::Cargo => cargo::build_cargo_command(request),
         ManagerName::Dotnet => dotnet::build_dotnet_command(request),
+        ManagerName::Npm => npm::build_npm_command(request),
         ManagerName::Winget => Ok(winget::build_winget_command(request)),
         ManagerName::PowerShell => powershell::build_powershell5_command(request),
         ManagerName::PowerShell7 => powershell::build_powershell7_command(request),

--- a/devolutions-agent/src/broker/command_builder/npm.rs
+++ b/devolutions-agent/src/broker/command_builder/npm.rs
@@ -8,7 +8,7 @@
 //! and a `npm.cmd` shim.
 
 use anyhow::bail;
-use now_policy_api::{Elevation, Operation, PackageRequest, Scope};
+use now_policy_api::{Architecture, Elevation, Operation, PackageRequest, Scope};
 
 /// Build an npm command from a validated request.
 pub fn build_npm_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
@@ -20,16 +20,13 @@ pub fn build_npm_command(request: &PackageRequest) -> anyhow::Result<Vec<String>
         Operation::Install | Operation::Update => {
             append_raw(&mut script, "install");
             append_value(&mut script, &install_spec(request)?);
+            append_raw(&mut script, "--global");
         }
         Operation::Uninstall => {
             append_raw(&mut script, "uninstall");
             append_value(&mut script, &local_package_name(&request.package.id.0));
+            append_raw(&mut script, "--global");
         }
-    }
-
-    if request.options.pre_release {
-        append_raw(&mut script, "--include");
-        append_raw(&mut script, "dev");
     }
 
     Ok(vec![
@@ -53,8 +50,14 @@ fn validate_npm_request(request: &PackageRequest) -> anyhow::Result<()> {
     if !request.source.name.eq_ignore_ascii_case("npm") {
         bail!("npm package source must be 'npm'");
     }
-    if request.package.architecture.is_some() {
-        bail!("npm package architecture selection is not supported by the broker");
+    match request.package.architecture {
+        Some(Architecture::X86 | Architecture::X64 | Architecture::Arm64) => {
+            bail!("npm package architecture selection is not supported by the broker");
+        }
+        Some(Architecture::Neutral) | None => {}
+    }
+    if request.options.pre_release {
+        bail!("npm prerelease selection is not supported by the broker");
     }
     if request.package.channel.is_some() {
         bail!("npm package channels are not supported by the broker");
@@ -215,7 +218,7 @@ mod tests {
 
         let cmd = build_npm_command(&request).expect("build command");
 
-        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@1.2.3'");
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@1.2.3' --global");
     }
 
     #[test]
@@ -226,7 +229,7 @@ mod tests {
 
         let cmd = build_npm_command(&request).expect("build command");
 
-        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@2.0.0'");
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@2.0.0' --global");
     }
 
     #[test]
@@ -236,7 +239,7 @@ mod tests {
 
         let cmd = build_npm_command(&request).expect("build command");
 
-        assert_eq!(script_of(&cmd), "npm install 'contoso-tool'");
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool' --global");
     }
 
     #[test]
@@ -250,7 +253,7 @@ mod tests {
 
         assert_eq!(
             script_of(&cmd),
-            "npm install 'babel-core-legacy@npm:@babel/core@7.28.0'"
+            "npm install 'babel-core-legacy@npm:@babel/core@7.28.0' --global"
         );
     }
 
@@ -262,17 +265,37 @@ mod tests {
 
         let cmd = build_npm_command(&request).expect("build command");
 
-        assert_eq!(script_of(&cmd), "npm uninstall 'eslint-v9'");
+        assert_eq!(script_of(&cmd), "npm uninstall 'eslint-v9' --global");
     }
 
     #[test]
-    fn pre_release_matches_unigetui_include_dev_flag() {
+    fn neutral_architecture_is_accepted() {
         let mut request = make_request();
-        request.options.pre_release = true;
+        request.package.architecture = Some(Architecture::Neutral);
 
         let cmd = build_npm_command(&request).expect("build command");
 
-        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@1.2.3' --include dev");
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@1.2.3' --global");
+    }
+
+    #[test]
+    fn concrete_architecture_is_rejected() {
+        let mut request = make_request();
+        request.package.architecture = Some(Architecture::X64);
+
+        let error = build_npm_command(&request).expect_err("concrete architecture should fail");
+
+        assert!(error.to_string().contains("architecture"));
+    }
+
+    #[test]
+    fn pre_release_is_rejected() {
+        let mut request = make_request();
+        request.options.pre_release = true;
+
+        let error = build_npm_command(&request).expect_err("prerelease should fail");
+
+        assert!(error.to_string().contains("prerelease"));
     }
 
     #[test]

--- a/devolutions-agent/src/broker/command_builder/npm.rs
+++ b/devolutions-agent/src/broker/command_builder/npm.rs
@@ -1,0 +1,327 @@
+//! npm command-line builder.
+//!
+//! UniGetUI runs npm through Windows PowerShell on Windows.
+//! The broker follows the same shape so the Windows executor can materialize the
+//! script through its protected PowerShell wrapper.
+//!
+//! Elevated npm operations are rejected because npm resolves through user PATH
+//! and a `npm.cmd` shim.
+
+use anyhow::bail;
+use now_policy_api::{Elevation, Operation, PackageRequest, Scope};
+
+/// Build an npm command from a validated request.
+pub fn build_npm_command(request: &PackageRequest) -> anyhow::Result<Vec<String>> {
+    validate_npm_request(request)?;
+
+    let mut script = String::from("npm");
+
+    match request.operation {
+        Operation::Install | Operation::Update => {
+            append_raw(&mut script, "install");
+            append_value(&mut script, &install_spec(request)?);
+        }
+        Operation::Uninstall => {
+            append_raw(&mut script, "uninstall");
+            append_value(&mut script, &local_package_name(&request.package.id.0));
+        }
+    }
+
+    if request.options.pre_release {
+        append_raw(&mut script, "--include");
+        append_raw(&mut script, "dev");
+    }
+
+    Ok(vec![
+        "powershell.exe".to_owned(),
+        "-NoProfile".to_owned(),
+        "-Command".to_owned(),
+        script,
+    ])
+}
+
+fn validate_npm_request(request: &PackageRequest) -> anyhow::Result<()> {
+    if request.client.requested_elevation == Elevation::Elevated {
+        bail!("npm elevated operations are not supported by the broker");
+    }
+    if request.options.scope == Some(Scope::Machine) {
+        bail!("npm machine-scope operations are not supported by the broker");
+    }
+    if request.source.url.is_some() {
+        bail!("npm package sources with URLs are not supported by the broker");
+    }
+    if !request.source.name.eq_ignore_ascii_case("npm") {
+        bail!("npm package source must be 'npm'");
+    }
+    if request.package.architecture.is_some() {
+        bail!("npm package architecture selection is not supported by the broker");
+    }
+    if request.package.channel.is_some() {
+        bail!("npm package channels are not supported by the broker");
+    }
+    if request.options.interactive {
+        bail!("npm interactive operations are not supported by the broker");
+    }
+    if request.options.skip_hash_check {
+        bail!("npm skip-hash-check operations are not supported by the broker");
+    }
+    if request.options.custom_install_location.is_some() {
+        bail!("npm custom install locations are not supported by the broker");
+    }
+    if let Some(param) = request.options.custom_parameters.iter().find(|param| !param.is_empty()) {
+        bail!("npm custom parameters are not supported by the broker: {}", param.0);
+    }
+    if request.options.uninstall_previous {
+        bail!("npm uninstall-previous operations are not supported by the broker");
+    }
+    if request.options.no_upgrade {
+        bail!("npm no-upgrade operations are not supported by the broker");
+    }
+
+    validate_script_value("package id", &request.package.id.0)?;
+    if let Some(version) = request.package.version.as_deref() {
+        validate_script_value("package version", version)?;
+    }
+
+    Ok(())
+}
+
+fn install_spec(request: &PackageRequest) -> anyhow::Result<String> {
+    let id = &request.package.id.0;
+    let version = request.package.version.as_deref();
+    let spec = if let Some((local_name, target_name)) = alias_parts(id) {
+        match version {
+            Some(version) => format!("{local_name}@npm:{target_name}@{version}"),
+            None => format!("{local_name}@npm:{target_name}"),
+        }
+    } else {
+        match version {
+            Some(version) => format!("{id}@{version}"),
+            None => id.clone(),
+        }
+    };
+
+    validate_script_value("package specifier", &spec)?;
+    Ok(spec)
+}
+
+fn local_package_name(id: &str) -> String {
+    alias_parts(id).map_or_else(|| id.to_owned(), |(local_name, _)| local_name)
+}
+
+fn alias_parts(id: &str) -> Option<(String, String)> {
+    let colon_index = id.find(':')?;
+    if colon_index == 0 {
+        return None;
+    }
+
+    let local_name = id[..colon_index].to_owned();
+    let target_spec = &id[colon_index + 1..];
+    let target_name = target_spec
+        .rfind('@')
+        .filter(|at_index| *at_index > 0)
+        .map_or(target_spec, |at_index| &target_spec[..at_index])
+        .to_owned();
+
+    Some((local_name, target_name))
+}
+
+fn append_raw(script: &mut String, value: &str) {
+    script.push(' ');
+    script.push_str(value);
+}
+
+fn append_value(script: &mut String, value: &str) {
+    append_raw(script, &quote_ps(value));
+}
+
+fn quote_ps(value: &str) -> String {
+    let escaped = value.replace('\'', "''");
+    format!("'{escaped}'")
+}
+
+fn validate_script_value(name: &str, value: &str) -> anyhow::Result<()> {
+    if value.is_empty() {
+        bail!("npm {name} cannot be empty");
+    }
+    if value.contains(['\0', '\r', '\n']) {
+        bail!("npm {name} cannot contain control line separators");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use now_policy_api::*;
+
+    use super::*;
+
+    fn make_request() -> PackageRequest {
+        PackageRequest {
+            request_kind: PackageRequestKind,
+            request_version: API_VERSION_STR.into(),
+            request_id: ResourceId::from("req-npm-1"),
+            created_at: Utc::now(),
+            operation: Operation::Install,
+            manager: ManagerName::Npm,
+            source: RequestSource {
+                name: "npm".to_owned(),
+                url: None,
+            },
+            package: RequestPackage {
+                id: PackageIdentifier::from("contoso-tool".to_owned()),
+                version: Some(VersionString("1.2.3".to_owned())),
+                architecture: None,
+                channel: None,
+            },
+            options: RequestOptions {
+                scope: Some(Scope::User),
+                interactive: false,
+                skip_hash_check: false,
+                pre_release: false,
+                custom_install_location: None,
+                custom_parameters: Vec::new(),
+                pre_operation_command: None,
+                post_operation_command: None,
+                kill_before_operation: Vec::new(),
+                uninstall_previous: false,
+                no_upgrade: false,
+            },
+            client: ClientContext {
+                transport: Transport::HttpNamedPipe,
+                requested_elevation: Elevation::Standard,
+                effective_user: "DOMAIN\\user".to_owned(),
+                client_executable_path: "C:\\Program Files\\Devolutions\\Package Broker\\PackageBrokerClient.exe"
+                    .to_owned(),
+                client_version: "1.0.0".to_owned(),
+            },
+            include_command_preview: false,
+            capture_output: false,
+        }
+    }
+
+    fn script_of(cmd: &[String]) -> &str {
+        assert_eq!(cmd[0], "powershell.exe");
+        assert_eq!(cmd[1], "-NoProfile");
+        assert_eq!(cmd[2], "-Command");
+        &cmd[3]
+    }
+
+    #[test]
+    fn install_uses_npm_install_with_versioned_specifier() {
+        let request = make_request();
+
+        let cmd = build_npm_command(&request).expect("build command");
+
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@1.2.3'");
+    }
+
+    #[test]
+    fn update_uses_install_verb_with_requested_version() {
+        let mut request = make_request();
+        request.operation = Operation::Update;
+        request.package.version = Some(VersionString("2.0.0".to_owned()));
+
+        let cmd = build_npm_command(&request).expect("build command");
+
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@2.0.0'");
+    }
+
+    #[test]
+    fn install_without_version_omits_version_suffix() {
+        let mut request = make_request();
+        request.package.version = None;
+
+        let cmd = build_npm_command(&request).expect("build command");
+
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool'");
+    }
+
+    #[test]
+    fn update_reconstructs_alias_specifier() {
+        let mut request = make_request();
+        request.operation = Operation::Update;
+        request.package.id = PackageIdentifier::from("babel-core-legacy:@babel/core@^7.20.0".to_owned());
+        request.package.version = Some(VersionString("7.28.0".to_owned()));
+
+        let cmd = build_npm_command(&request).expect("build command");
+
+        assert_eq!(
+            script_of(&cmd),
+            "npm install 'babel-core-legacy@npm:@babel/core@7.28.0'"
+        );
+    }
+
+    #[test]
+    fn uninstall_uses_alias_local_name_and_omits_version() {
+        let mut request = make_request();
+        request.operation = Operation::Uninstall;
+        request.package.id = PackageIdentifier::from("eslint-v9:eslint@^9.39.4".to_owned());
+
+        let cmd = build_npm_command(&request).expect("build command");
+
+        assert_eq!(script_of(&cmd), "npm uninstall 'eslint-v9'");
+    }
+
+    #[test]
+    fn pre_release_matches_unigetui_include_dev_flag() {
+        let mut request = make_request();
+        request.options.pre_release = true;
+
+        let cmd = build_npm_command(&request).expect("build command");
+
+        assert_eq!(script_of(&cmd), "npm install 'contoso-tool@1.2.3' --include dev");
+    }
+
+    #[test]
+    fn elevated_requests_are_rejected() {
+        let mut request = make_request();
+        request.client.requested_elevation = Elevation::Elevated;
+
+        let error = build_npm_command(&request).expect_err("elevated npm should fail");
+
+        assert!(error.to_string().contains("elevated"));
+    }
+
+    #[test]
+    fn machine_scope_requests_are_rejected() {
+        let mut request = make_request();
+        request.options.scope = Some(Scope::Machine);
+
+        let error = build_npm_command(&request).expect_err("machine-scope npm should fail");
+
+        assert!(error.to_string().contains("machine-scope"));
+    }
+
+    #[test]
+    fn custom_parameters_are_rejected() {
+        let mut request = make_request();
+        request.options.custom_parameters = vec![CustomParameterString("--ignore-scripts".to_owned())];
+
+        let error = build_npm_command(&request).expect_err("custom parameters should fail");
+
+        assert!(error.to_string().contains("custom parameters"));
+    }
+
+    #[test]
+    fn source_urls_are_rejected() {
+        let mut request = make_request();
+        request.source.url = Some("https://registry.npmjs.org/".parse().expect("URL"));
+
+        let error = build_npm_command(&request).expect_err("source URL should fail");
+
+        assert!(error.to_string().contains("sources with URLs"));
+    }
+
+    #[test]
+    fn script_line_separators_are_rejected() {
+        let mut request = make_request();
+        request.package.id = PackageIdentifier::from("contoso\r\nnpm run unsafe".to_owned());
+
+        let error = build_npm_command(&request).expect_err("line separator should fail");
+
+        assert!(error.to_string().contains("control line separators"));
+    }
+}

--- a/devolutions-agent/src/broker/server/responses.rs
+++ b/devolutions-agent/src/broker/server/responses.rs
@@ -89,6 +89,17 @@ pub(super) fn default_manager_capabilities() -> Vec<ManagerCapability> {
             max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
         },
         ManagerCapability {
+            manager: ManagerName::Npm,
+            operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
+            scopes: vec![Scope::User],
+            architectures: vec![Architecture::Neutral],
+            supports_custom_parameters: false,
+            supports_custom_install_location: false,
+            supports_capture_output: true,
+            supports_details: false,
+            max_operation_timeout_seconds: Some(OperationTracker::operation_timeout().as_secs()),
+        },
+        ManagerCapability {
             manager: ManagerName::PowerShell,
             operations: vec![Operation::Install, Operation::Update, Operation::Uninstall],
             scopes: vec![Scope::User, Scope::Machine],


### PR DESCRIPTION
Adds npm package manager support to the Devolutions Agent package broker for standard-user operations. Users can broker npm install, update, and uninstall requests while unsupported or elevated npm operations are rejected with clear validation errors.

The broker now advertises npm capabilities and uses the released v0.2 NOW policy protocol crates that include the npm manager enum.

Issue: DGW-430