### PR TITLE
chore(openapi): type UpdateProductInfo.version as a string in the OpenAPI spec

### DIFF
--- a/devolutions-gateway/openapi/gateway-api.yaml
+++ b/devolutions-gateway/openapi/gateway-api.yaml
@@ -7,7 +7,7 @@ info:
     email: infos@devolutions.net
   license:
     name: MIT/Apache-2.0
-  version: 2026.1.2
+  version: 2026.2.4
 paths:
   /jet/config:
     patch:
@@ -2179,7 +2179,8 @@ components:
       - Version
       properties:
         Version:
-          $ref: '#/components/schemas/VersionSpecification'
+          type: string
+          description: 'Requested or installed version: `"latest"` or `"YYYY.M.D"` / `"YYYY.M.D.R"`.'
     UpdateRequestSchema:
       type: object
       description: |-

--- a/devolutions-gateway/src/api/update.rs
+++ b/devolutions-gateway/src/api/update.rs
@@ -98,6 +98,9 @@ async fn write_manifest(mut manifest: UpdateManifestV2) -> Result<(), HttpError>
 #[serde(rename_all = "PascalCase")]
 pub(crate) struct UpdateProductInfo {
     /// Requested or installed version: `"latest"` or `"YYYY.M.D"` / `"YYYY.M.D.R"`.
+    // `VersionSpecification` serializes as one of those strings and lives in a crate without utoipa,
+    // so describe it as a string here instead of emitting a `$ref` to a schema that never gets generated.
+    #[cfg_attr(feature = "openapi", schema(value_type = String))]
     pub version: VersionSpecification,
 }
 


### PR DESCRIPTION
## What

`UpdateProductInfo.version` is typed `VersionSpecification`, which lives in `devolutions-agent-shared` — a crate that does not depend on utoipa. The derived OpenAPI schema therefore emitted a `$ref` to a `VersionSpecification` component that is never generated, leaving a dangling reference in `gateway-api.yaml`.

## Why it matters

The dangling `$ref` makes the spec fail strict OpenAPI validation. The client generator (`openapi-generator` 7.9.0, validation on, as `generate_clients.ps1` runs it) refuses **every** gateway target:

```
attribute components.schemas.UpdateProductInfo.VersionSpecification is not of type `schema`
[error] Spec has 1 error.
```

So the C#, TypeScript and doc clients cannot be regenerated at all until this is fixed. The bug is pre-existing on `master` (introduced with the Update API in #1726) and stayed latent because nobody had regenerated the clients since.

## Fix

Mark the field `#[schema(value_type = String)]`. `VersionSpecification` serializes as `"latest"` or a `YYYY.M.D[.R]` string, so a plain `string` schema matches the wire format exactly — the same treatment as the neighbouring `UpdateProduct`. Regenerated `gateway-api.yaml`; validation now passes with 0 errors.

## Stack

Base of the credential-injection stack (bottom to top):
1. **this PR** — make the OpenAPI spec valid again
2. #1862 — decide credential-injection CredSSP protocol once for both legs
3. #1865 — provision the target-side KDC for credential injection
