### PR TITLE
fix(agent): connect tunnel targets matched by an advertised domain

### DIFF
--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use agent_tunnel_proto::{
-    ConnectResponse, ControlMessage, ControlStream, FramedRecv, SessionStream, current_time_millis,
+    ConnectResponse, ControlMessage, ControlStream, DomainAdvertisement, FramedRecv, SessionStream, current_time_millis,
 };
 use anyhow::{Context as _, bail};
 use async_trait::async_trait;
@@ -217,10 +217,10 @@ async fn run_single_connection(
     }
 
     // Build domain advertisement list: explicit config + auto-detection.
-    let mut advertise_domains: Vec<agent_tunnel_proto::DomainAdvertisement> = tunnel_conf
+    let mut advertise_domains: Vec<DomainAdvertisement> = tunnel_conf
         .advertise_domains
         .iter()
-        .map(|d| agent_tunnel_proto::DomainAdvertisement {
+        .map(|d| DomainAdvertisement {
             domain: agent_tunnel_proto::DomainName::new(d),
             auto_detected: false,
         })
@@ -233,7 +233,7 @@ async fn run_single_connection(
                 .any(|d| d.domain.as_str().eq_ignore_ascii_case(&detected))
             {
                 info!(domain = %detected, "Auto-detected DNS domain");
-                advertise_domains.push(agent_tunnel_proto::DomainAdvertisement {
+                advertise_domains.push(DomainAdvertisement {
                     domain: agent_tunnel_proto::DomainName::new(detected),
                     auto_detected: true,
                 });
@@ -325,7 +325,8 @@ async fn run_single_connection(
             result = connection.accept_bi() => {
                 let (send, recv) = result.context("accept incoming bidi stream")?;
                 let subnets = advertise_subnets.clone();
-                task_handles.spawn(run_session_proxy(subnets, send, recv));
+                let domains = advertise_domains.clone();
+                task_handles.spawn(run_session_proxy(subnets, domains, send, recv));
             }
 
             // Reap completed session tasks.
@@ -667,7 +668,12 @@ async fn run_control_reader<R: tokio::io::AsyncRead + Unpin>(mut ctrl: FramedRec
 // Session proxy
 // ---------------------------------------------------------------------------
 
-async fn run_session_proxy(advertise_subnets: Vec<Ipv4Network>, send: quinn::SendStream, recv: quinn::RecvStream) {
+async fn run_session_proxy(
+    advertise_subnets: Vec<Ipv4Network>,
+    advertise_domains: Vec<DomainAdvertisement>,
+    send: quinn::SendStream,
+    recv: quinn::RecvStream,
+) {
     let _: anyhow::Result<()> = async {
         let mut session: SessionStream<_, _> = (send, recv).into();
 
@@ -698,7 +704,7 @@ async fn run_session_proxy(advertise_subnets: Vec<Ipv4Network>, send: quinn::Sen
         }
 
         let target = Target::parse(connect_msg.target()).context("parse connect target")?;
-        let candidates = resolve_target(&target, &advertise_subnets).await?;
+        let candidates = resolve_target(&target, &advertise_subnets, &advertise_domains).await?;
         let (tcp_stream, selected_target) = connect_to_target(&candidates).await?;
         info!(target = %selected_target, "TCP connection established");
 

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 use agent_tunnel_proto::{
     ConnectResponse, ControlMessage, ControlStream, DomainAdvertisement, FramedRecv, SessionStream, current_time_millis,
 };
-use anyhow::{Context as _, bail};
+use anyhow::{Context as _, anyhow, bail};
 use async_trait::async_trait;
 use devolutions_gateway_task::{ShutdownSignal, Task};
 use ipnetwork::Ipv4Network;
@@ -668,6 +668,13 @@ async fn run_control_reader<R: tokio::io::AsyncRead + Unpin>(mut ctrl: FramedRec
 // Session proxy
 // ---------------------------------------------------------------------------
 
+/// How long we get to resolve the target and open the TCP connection.
+///
+/// The Gateway stops waiting for the ConnectResponse after 30s
+/// (`crates/agent-tunnel/src/listener.rs`). We have to give up before it does, otherwise a
+/// black-holed target outlives its deadline and it never hears why we failed.
+const CONNECT_DEADLINE: Duration = Duration::from_secs(20);
+
 async fn run_session_proxy(
     advertise_subnets: Vec<Ipv4Network>,
     advertise_domains: Vec<DomainAdvertisement>,
@@ -690,14 +697,20 @@ async fn run_session_proxy(
 
         let protocol_version = connect_msg.protocol_version();
 
-        let connect_result = async {
+        let connect_result = tokio::time::timeout(CONNECT_DEADLINE, async {
             agent_tunnel_proto::validate_protocol_version(protocol_version).context("unsupported protocol version")?;
 
             let target = Target::parse(connect_msg.target()).context("parse connect target")?;
             let candidates = resolve_target(&target, &advertise_subnets, &advertise_domains).await?;
             connect_to_target(&candidates).await
-        }
-        .await;
+        })
+        .await
+        .unwrap_or_else(|_elapsed| {
+            Err(anyhow!(
+                "timed out after {}s resolving or connecting to target",
+                CONNECT_DEADLINE.as_secs()
+            ))
+        });
 
         // Whatever went wrong has to travel back as a ConnectResponse::Error — returning
         // early instead drops the stream and the Gateway just sees an unexplained EOF.

--- a/devolutions-agent/src/tunnel.rs
+++ b/devolutions-agent/src/tunnel.rs
@@ -689,23 +689,37 @@ async fn run_session_proxy(
         );
 
         let protocol_version = connect_msg.protocol_version();
-        if let Err(e) = agent_tunnel_proto::validate_protocol_version(protocol_version) {
-            warn!(
-                %protocol_version,
-                %e,
-                "Rejecting ConnectRequest: unsupported protocol version"
-            );
-            let response = ConnectResponse::error(format!("unsupported protocol version: {e}"));
-            session
-                .send_response(&response)
-                .await
-                .context("send ConnectResponse error for unsupported version")?;
-            bail!("unsupported protocol version in ConnectRequest");
-        }
 
-        let target = Target::parse(connect_msg.target()).context("parse connect target")?;
-        let candidates = resolve_target(&target, &advertise_subnets, &advertise_domains).await?;
-        let (tcp_stream, selected_target) = connect_to_target(&candidates).await?;
+        let connect_result = async {
+            agent_tunnel_proto::validate_protocol_version(protocol_version).context("unsupported protocol version")?;
+
+            let target = Target::parse(connect_msg.target()).context("parse connect target")?;
+            let candidates = resolve_target(&target, &advertise_subnets, &advertise_domains).await?;
+            connect_to_target(&candidates).await
+        }
+        .await;
+
+        // Whatever went wrong has to travel back as a ConnectResponse::Error — returning
+        // early instead drops the stream and the Gateway just sees an unexplained EOF.
+        let (tcp_stream, selected_target) = match connect_result {
+            Ok(connected) => connected,
+            Err(error) => {
+                let reason = format!("{error:#}");
+                warn!(
+                    session_id = %connect_msg.session_id(),
+                    target = %connect_msg.target(),
+                    protocol_version,
+                    error = %reason,
+                    "Rejecting ConnectRequest"
+                );
+                session
+                    .send_response(&ConnectResponse::error(reason))
+                    .await
+                    .context("send ConnectResponse error")?;
+                return Err(error);
+            }
+        };
+
         info!(target = %selected_target, "TCP connection established");
 
         session

--- a/devolutions-agent/src/tunnel_helpers.rs
+++ b/devolutions-agent/src/tunnel_helpers.rs
@@ -1,5 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
 
+use agent_tunnel_proto::DomainAdvertisement;
 use anyhow::{Context as _, bail};
 use ipnetwork::Ipv4Network;
 use tokio::net::TcpStream;
@@ -31,15 +32,18 @@ impl Target {
     }
 }
 
-/// Resolve a target to candidate socket addresses within the advertised subnets.
+/// Resolve a target to candidate socket addresses the agent is willing to reach.
 ///
-/// Only IPv4 subnets are supported right now, matching the wire protocol. IPv6 targets
-/// never match.
+/// A hostname matching an advertised domain is allowed on its own: the Gateway routes
+/// hostnames on the domain advertisement alone, so advertising domains and no subnets has
+/// to work. Anything else has to land in an advertised subnet, and only IPv4 subnets
+/// travel on the wire, so an IPv6 address only ever gets through on a domain match.
 pub(crate) async fn resolve_target(
     target: &Target,
     advertise_subnets: &[Ipv4Network],
+    advertise_domains: &[DomainAdvertisement],
 ) -> anyhow::Result<Vec<SocketAddr>> {
-    fn matches(advertise_subnets: &[Ipv4Network], ip: IpAddr) -> bool {
+    fn in_subnets(advertise_subnets: &[Ipv4Network], ip: IpAddr) -> bool {
         match ip {
             IpAddr::V4(ipv4) => advertise_subnets.iter().any(|subnet| subnet.contains(ipv4)),
             IpAddr::V6(_) => false,
@@ -48,24 +52,30 @@ pub(crate) async fn resolve_target(
 
     match target {
         Target::Ip(ip, port) => {
-            if !matches(advertise_subnets, *ip) {
+            if !in_subnets(advertise_subnets, *ip) {
                 bail!("target {ip}:{port} is not in advertised subnets");
             }
             Ok(vec![SocketAddr::new(*ip, *port)])
         }
         Target::Domain(host, port) => {
             let lookup = format!("{host}:{port}");
-            let resolved: Vec<SocketAddr> = tokio::net::lookup_host(&lookup)
+            let resolved = tokio::net::lookup_host(&lookup)
                 .await
-                .with_context(|| format!("resolve target {lookup}"))?
-                .filter(|addr| matches(advertise_subnets, addr.ip()))
-                .collect();
+                .with_context(|| format!("resolve target {lookup}"))?;
 
-            if resolved.is_empty() {
-                bail!("target {lookup} did not resolve to any address in advertised subnets");
+            let allowed: Vec<SocketAddr> = if advertise_domains.iter().any(|adv| adv.domain.matches_hostname(host)) {
+                resolved.collect()
+            } else {
+                resolved
+                    .filter(|addr| in_subnets(advertise_subnets, addr.ip()))
+                    .collect()
+            };
+
+            if allowed.is_empty() {
+                bail!("target {lookup} resolved to no address this agent advertises");
             }
 
-            Ok(resolved)
+            Ok(allowed)
         }
     }
 }

--- a/devolutions-agent/src/tunnel_helpers.rs
+++ b/devolutions-agent/src/tunnel_helpers.rs
@@ -97,3 +97,61 @@ pub(crate) async fn connect_to_target(candidates: &[SocketAddr]) -> anyhow::Resu
 
     Err(error).with_context(|| format!("TCP connect failed for {candidate}"))
 }
+
+#[cfg(test)]
+mod tests {
+    use agent_tunnel_proto::DomainName;
+
+    use super::*;
+
+    fn subnets(list: &[&str]) -> Vec<Ipv4Network> {
+        list.iter().map(|s| s.parse().expect("valid subnet")).collect()
+    }
+
+    fn domains(list: &[&str]) -> Vec<DomainAdvertisement> {
+        list.iter()
+            .map(|d| DomainAdvertisement {
+                domain: DomainName::new(*d),
+                auto_detected: false,
+            })
+            .collect()
+    }
+
+    // The Gateway routes a hostname on the domain advertisement alone, so an agent
+    // advertising domains and no subnets still has to honour the request.
+    #[tokio::test]
+    async fn domain_target_matching_advertised_domain_needs_no_subnet() {
+        let target = Target::parse("localhost:3389").expect("parse target");
+
+        let resolved = resolve_target(&target, &[], &domains(&["localhost"]))
+            .await
+            .expect("hostname matches an advertised domain");
+
+        assert!(!resolved.is_empty(), "expected at least one resolved address");
+    }
+
+    #[tokio::test]
+    async fn domain_target_falls_back_to_advertised_subnets() {
+        let target = Target::Domain("127.0.0.1".to_owned(), 3389);
+
+        let resolved = resolve_target(&target, &subnets(&["127.0.0.0/8"]), &[])
+            .await
+            .expect("resolved address is inside an advertised subnet");
+
+        assert_eq!(resolved, vec!["127.0.0.1:3389".parse().expect("parse addr")]);
+    }
+
+    #[tokio::test]
+    async fn domain_target_matching_neither_domain_nor_subnet_is_rejected() {
+        let target = Target::Domain("127.0.0.1".to_owned(), 3389);
+
+        let error = resolve_target(&target, &[], &[])
+            .await
+            .expect_err("nothing is advertised");
+
+        assert!(
+            format!("{error:#}").contains("no address this agent advertises"),
+            "unexpected error: {error:#}"
+        );
+    }
+}


### PR DESCRIPTION
Connections through an agent tunnel to a host matched by an advertised DNS domain
were always refused when the agent had no subnets configured. Any RDP or other
tunneled session to such a host failed instantly, and the Gateway log showed only
an unexplained `early eof` with no reason attached, which made it look like a
network or target problem rather than a routing one.

Advertising domains without subnets is now a working configuration, which is what
the Gateway already assumed when it picked the agent. Subnet-based setups are
unaffected.

An agent that refuses a connection also reports why now, so the Gateway log and the
client error name the real cause — an unreachable target, a name that would not
resolve, a refused connect — instead of a generic end-of-stream.
