### PR TITLE
fix(agent): verify DACL and owner of package manager binaries before elevated execution

### DIFF
--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -19,6 +19,7 @@ use win_api_wrappers::utils::WideString;
 use windows::Win32::Security::TOKEN_ALL_ACCESS;
 
 use super::{BROKER_SUPPORTED_MANAGERS, CommandExecutor, ExecutionContext, ExecutionOutput, ProcessStartedCallback};
+use crate::broker::policy_security;
 
 mod privileges;
 mod process;
@@ -353,7 +354,7 @@ fn run_plan(
             "/IM".to_owned(),
             process_name.clone(),
         ];
-        match create_process(token, &kill_cmd, session_id, false, None) {
+        match create_process(token, &kill_cmd, session_id, false, requires_elevation, None) {
             Ok(out) => info!(%process_name, exit_code = out.exit_code, "Kill-before-operation completed"),
             Err(error) => warn!(%process_name, %error, "Kill-before-operation failed (ignored)"),
         }
@@ -363,8 +364,15 @@ fn run_plan(
     if let Some(pre) = &ctx.pre_command {
         info!("Running pre-operation command");
         let command = prepare_shell_command(token, pre)?;
-        let out = create_process(token, command.args(), session_id, ctx.capture_output, None)
-            .context("failed to run pre-operation command")?;
+        let out = create_process(
+            token,
+            command.args(),
+            session_id,
+            ctx.capture_output,
+            requires_elevation,
+            None,
+        )
+        .context("failed to run pre-operation command")?;
         if out.exit_code != 0 {
             bail!(
                 "pre-operation command exited with code {}: {}",
@@ -375,15 +383,22 @@ fn run_plan(
     }
 
     // 3. Main package-manager command.
-    let command = prepare_main_command(token, &ctx.command)?;
-    let output = create_process(token, command.args(), session_id, ctx.capture_output, process_started)?;
+    let command = prepare_main_command(token, &ctx.command, requires_elevation)?;
+    let output = create_process(
+        token,
+        command.args(),
+        session_id,
+        ctx.capture_output,
+        requires_elevation,
+        process_started,
+    )?;
 
     // 4. Post-operation command — runs after the main command; failures are logged only
     //    so a completed main operation is never reported as failed by its post-hook.
     if let Some(post) = &ctx.post_command {
         info!("Running post-operation command");
         match prepare_shell_command(token, post) {
-            Ok(command) => match create_process(token, command.args(), session_id, false, None) {
+            Ok(command) => match create_process(token, command.args(), session_id, false, requires_elevation, None) {
                 Ok(out) if out.exit_code == 0 => {}
                 Ok(out) => warn!(exit_code = out.exit_code, "Post-operation command exited non-zero"),
                 Err(error) => warn!(%error, "Post-operation command failed"),
@@ -395,27 +410,32 @@ fn run_plan(
     Ok(output)
 }
 
-fn prepare_main_command(token: &Token, command: &[String]) -> anyhow::Result<PreparedCommand> {
+fn prepare_main_command(
+    token: &Token,
+    command: &[String],
+    requires_elevation: bool,
+) -> anyhow::Result<PreparedCommand> {
     let user_env = win_api_wrappers::utils::environment_block(Some(token), false)
         .context("failed to load user environment block")?;
-    prepare_main_command_in(command, None, Some(&user_env))
+    prepare_main_command_in(command, None, Some(&user_env), requires_elevation)
 }
 
 fn prepare_main_command_in(
     command: &[String],
     temp_dir: Option<&Path>,
     user_env: Option<&HashMap<String, String>>,
+    requires_elevation: bool,
 ) -> anyhow::Result<PreparedCommand> {
     if let Some((script, command_arg_index)) = powershell_inline_script(command) {
         return prepare_powershell_script(command, command_arg_index, script, temp_dir);
     }
 
     if executable_is(command, "winget.exe") {
-        return prepare_winget_script(command, temp_dir, user_env);
+        return prepare_winget_script(command, temp_dir, user_env, requires_elevation);
     }
 
     if executable_is(command, "choco.exe") {
-        return prepare_chocolatey_script(command, temp_dir, user_env);
+        return prepare_chocolatey_script(command, temp_dir, user_env, requires_elevation);
     }
 
     if executable_is(command, "cargo.exe") {
@@ -522,6 +542,7 @@ fn prepare_winget_script(
     command: &[String],
     temp_dir: Option<&Path>,
     user_env: Option<&HashMap<String, String>>,
+    requires_elevation: bool,
 ) -> anyhow::Result<PreparedCommand> {
     let mut script = String::new();
     script.push_str("@echo off\r\n");
@@ -531,7 +552,7 @@ fn prepare_winget_script(
     let (executable, args) = command.split_first().context("empty WinGet command")?;
     let executable = user_env.map_or_else(
         || Ok(executable.clone()),
-        |env| resolve_winget_executable(env).map(|path| path.display().to_string()),
+        |env| resolve_winget_executable(env, requires_elevation).map(|path| path.display().to_string()),
     )?;
     append_batch_argument(&mut script, &executable)?;
     for arg in args {
@@ -564,17 +585,25 @@ fn prepare_chocolatey_script(
     command: &[String],
     temp_dir: Option<&Path>,
     user_env: Option<&HashMap<String, String>>,
+    requires_elevation: bool,
 ) -> anyhow::Result<PreparedCommand> {
-    prepare_chocolatey_script_in(command, temp_dir, user_env)
+    prepare_chocolatey_script_in(command, temp_dir, user_env, requires_elevation)
 }
 
 fn prepare_chocolatey_script_in(
     command: &[String],
     temp_dir: Option<&Path>,
     user_env: Option<&HashMap<String, String>>,
+    requires_elevation: bool,
 ) -> anyhow::Result<PreparedCommand> {
     let default_install_root = default_chocolatey_install_dir()?;
-    prepare_chocolatey_script_in_with_default_install_root(command, temp_dir, user_env, &default_install_root)
+    prepare_chocolatey_script_in_with_default_install_root(
+        command,
+        temp_dir,
+        user_env,
+        &default_install_root,
+        requires_elevation,
+    )
 }
 
 fn prepare_chocolatey_script_in_with_default_install_root(
@@ -582,6 +611,7 @@ fn prepare_chocolatey_script_in_with_default_install_root(
     temp_dir: Option<&Path>,
     user_env: Option<&HashMap<String, String>>,
     default_install_root: &Path,
+    requires_elevation: bool,
 ) -> anyhow::Result<PreparedCommand> {
     let mut script = String::new();
     script.push_str("@echo off\r\n");
@@ -589,7 +619,8 @@ fn prepare_chocolatey_script_in_with_default_install_root(
     script.push_str("\r\nset \"NO_COLOR=1\"\r\n");
 
     let (_executable, args) = command.split_first().context("empty Chocolatey command")?;
-    let (executable, install_root) = resolve_trusted_chocolatey_executable(user_env, default_install_root)?;
+    let (executable, install_root) =
+        resolve_trusted_chocolatey_executable(user_env, default_install_root, requires_elevation)?;
     append_batch_set_value(&mut script, "ChocolateyInstall", &install_root.display().to_string())?;
     script.push_str("\r\n");
     append_batch_argument(&mut script, &executable.display().to_string())?;
@@ -981,6 +1012,7 @@ fn default_chocolatey_install_dir() -> anyhow::Result<PathBuf> {
 fn resolve_trusted_chocolatey_executable(
     user_env: Option<&HashMap<String, String>>,
     default_install_root: &Path,
+    requires_elevation: bool,
 ) -> anyhow::Result<(PathBuf, PathBuf)> {
     let install_root = user_env
         .and_then(|env| env_value_ignore_case(env, "ChocolateyInstall"))
@@ -1002,6 +1034,8 @@ fn resolve_trusted_chocolatey_executable(
         );
     }
 
+    policy_security::verify_elevated_executable_security(&executable, requires_elevation)?;
+
     Ok((executable, install_root))
 }
 
@@ -1022,7 +1056,7 @@ fn env_value_ignore_case<'a>(env: &'a HashMap<String, String>, key: &str) -> Opt
         .map(|(_, value)| value.as_str())
 }
 
-fn resolve_winget_executable(env: &HashMap<String, String>) -> anyhow::Result<PathBuf> {
+fn resolve_winget_executable(env: &HashMap<String, String>, requires_elevation: bool) -> anyhow::Result<PathBuf> {
     let path_var = env
         .iter()
         .find(|(key, _)| key.eq_ignore_ascii_case("PATH"))
@@ -1031,6 +1065,7 @@ fn resolve_winget_executable(env: &HashMap<String, String>) -> anyhow::Result<Pa
     for dir in path_var.split(';') {
         let candidate = PathBuf::from(dir).join("winget.exe");
         if candidate.exists() && is_trusted_winget_path(&candidate, env) {
+            policy_security::verify_elevated_executable_security(&candidate, requires_elevation)?;
             return Ok(candidate);
         }
     }
@@ -1251,16 +1286,46 @@ impl PreparedCommand {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::path::Path;
 
     use now_policy_api::{Elevation, Scope};
     use win_api_wrappers::identity::sid::Sid;
+    use win_api_wrappers::security::acl::{
+        Acl, ExplicitAccess, InheritableAcl, InheritableAclKind, Trustee, set_named_security_info,
+    };
+    use win_api_wrappers::str::U16CString;
+    use windows::Win32::Foundation::GENERIC_ALL;
+    use windows::Win32::Security::Authorization::{GRANT_ACCESS, SE_FILE_OBJECT};
+    use windows::Win32::Security::{NO_INHERITANCE, WinWorldSid};
 
     use super::{
         POWERSHELL_UTF8_ENCODING_PREAMBLE, WindowsExecutor, execute_as_current_user,
         prepare_chocolatey_script_in_with_default_install_root, prepare_main_command_in, prepare_shell_command_in,
-        reject_unsupported_vcpkg_elevation,
+        reject_unsupported_vcpkg_elevation, resolve_trusted_chocolatey_executable, resolve_winget_executable,
     };
     use crate::broker::executor::{CommandExecutor as _, ExecutionContext};
+
+    fn grant(permissions: u32, sid: Sid) -> ExplicitAccess {
+        ExplicitAccess {
+            access_permissions: permissions,
+            access_mode: GRANT_ACCESS,
+            inheritance: NO_INHERITANCE,
+            trustee: Trustee::Sid(sid),
+        }
+    }
+
+    fn make_everyone_writable(path: &Path) {
+        let everyone = Sid::from_well_known(WinWorldSid, None).expect("well-known Everyone SID");
+        let dacl = InheritableAcl {
+            kind: InheritableAclKind::Protected,
+            acl: Acl::new()
+                .and_then(|acl| acl.set_entries(&[grant(GENERIC_ALL.0, everyone)]))
+                .expect("build ACL with Everyone full-control entry"),
+        };
+        let name = U16CString::from_os_str(path.as_os_str()).expect("no interior NUL in temp path");
+        set_named_security_info(&name, SE_FILE_OBJECT, None, None, Some(&dacl), None)
+            .expect("set everyone-writable DACL");
+    }
 
     #[test]
     fn shell_command_uses_utf8_temp_batch_file() {
@@ -1288,7 +1353,7 @@ mod tests {
             "Write-Output 'héllo'".to_owned(),
         ];
         let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare PowerShell command");
+            prepare_main_command_in(&command, Some(temp_dir.path()), None, false).expect("prepare PowerShell command");
 
         assert!(command.args()[0].ends_with(r"\System32\WindowsPowerShell\v1.0\powershell.exe"));
         assert_eq!(command.args()[1], "-NoProfile");
@@ -1314,7 +1379,7 @@ mod tests {
             "Write-Output 'héllo'".to_owned(),
         ];
         let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare PowerShell command");
+            prepare_main_command_in(&command, Some(temp_dir.path()), None, false).expect("prepare PowerShell command");
 
         assert!(command.args()[0].ends_with(r"\System32\WindowsPowerShell\v1.0\powershell.exe"));
         assert_eq!(command.args()[1], "-NoProfile");
@@ -1334,7 +1399,7 @@ mod tests {
             "Write-Output 'héllo'".to_owned(),
         ];
         let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare PowerShell command");
+            prepare_main_command_in(&command, Some(temp_dir.path()), None, false).expect("prepare PowerShell command");
 
         assert!(command.args()[0].ends_with(r"\PowerShell\7\pwsh.exe"));
         assert_eq!(command.args()[1], "-NoProfile");
@@ -1358,7 +1423,8 @@ mod tests {
             "Vendor.Package&Name".to_owned(),
             "100%".to_owned(),
         ];
-        let command = prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare WinGet command");
+        let command =
+            prepare_main_command_in(&command, Some(temp_dir.path()), None, false).expect("prepare WinGet command");
 
         assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
         assert_eq!(command.args()[1], "/D");
@@ -1370,6 +1436,47 @@ mod tests {
         assert!(script.starts_with("@echo off\r\n@chcp 65001 > nul\r\nset \"NO_COLOR=1\""));
         assert!(script.contains("\"winget.exe\" \"install\" \"--id\" \"Vendor.Package&Name\" \"100%%\""));
         assert!(script.contains("exit /b %ERRORLEVEL%"));
+    }
+
+    #[test]
+    fn winget_elevated_execution_rejects_everyone_writable_executable() {
+        let program_files = tempfile::tempdir().expect("create fake ProgramFiles");
+        let windows_apps = program_files.path().join("WindowsApps");
+        std::fs::create_dir_all(&windows_apps).expect("create fake WindowsApps dir");
+        let winget_path = windows_apps.join("winget.exe");
+        std::fs::write(&winget_path, b"").expect("write winget placeholder");
+        make_everyone_writable(&winget_path);
+
+        let env = HashMap::from([
+            ("PATH".to_owned(), windows_apps.display().to_string()),
+            ("ProgramFiles".to_owned(), program_files.path().display().to_string()),
+        ]);
+
+        let error = resolve_winget_executable(&env, true)
+            .expect_err("an everyone-writable winget.exe must be rejected for elevated execution");
+        assert!(
+            error.to_string().contains("elevated package-manager executable"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn winget_non_elevated_execution_allows_everyone_writable_executable() {
+        let program_files = tempfile::tempdir().expect("create fake ProgramFiles");
+        let windows_apps = program_files.path().join("WindowsApps");
+        std::fs::create_dir_all(&windows_apps).expect("create fake WindowsApps dir");
+        let winget_path = windows_apps.join("winget.exe");
+        std::fs::write(&winget_path, b"").expect("write winget placeholder");
+        make_everyone_writable(&winget_path);
+
+        let env = HashMap::from([
+            ("PATH".to_owned(), windows_apps.display().to_string()),
+            ("ProgramFiles".to_owned(), program_files.path().display().to_string()),
+        ]);
+
+        let resolved =
+            resolve_winget_executable(&env, false).expect("non-elevated resolution is not subject to the ACL check");
+        assert_eq!(resolved, winget_path);
     }
 
     #[test]
@@ -1386,8 +1493,8 @@ mod tests {
             "--global".to_owned(),
         ];
 
-        let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env)).expect("prepare Bun command");
+        let command = prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env), false)
+            .expect("prepare Bun command");
 
         assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
         assert_eq!(command.args()[1], "/D");
@@ -1418,7 +1525,7 @@ mod tests {
             "--global".to_owned(),
         ];
 
-        let command = prepare_main_command_in(&command, None, Some(&user_env)).expect("prepare Bun command");
+        let command = prepare_main_command_in(&command, None, Some(&user_env), false).expect("prepare Bun command");
 
         assert_eq!(command.args()[0], bun_path.display().to_string());
         assert_eq!(command.args()[1], "add");
@@ -1487,7 +1594,7 @@ mod tests {
     }
 
     /// Reads back the DACL of `path` as an SDDL string (`D:...`).
-    fn read_file_dacl_sddl(path: &std::path::Path) -> String {
+    fn read_file_dacl_sddl(path: &Path) -> String {
         use win_api_wrappers::utils::WideString;
         use windows::Win32::Foundation::{ERROR_SUCCESS, HLOCAL, LocalFree};
         use windows::Win32::Security::Authorization::{
@@ -1570,6 +1677,7 @@ mod tests {
             Some(temp_dir.path()),
             Some(&env),
             &install_root,
+            false,
         )
         .expect("prepare Chocolatey command");
 
@@ -1606,6 +1714,7 @@ mod tests {
             Some(temp_dir.path()),
             Some(&env),
             &install_root,
+            false,
         ) {
             Ok(_) => panic!("missing trusted choco should fail"),
             Err(error) => error,
@@ -1637,11 +1746,46 @@ mod tests {
             Some(temp_dir.path()),
             Some(&env),
             &trusted_install_root,
+            false,
         ) {
             Ok(_) => panic!("non-system ChocolateyInstall should fail"),
             Err(error) => error,
         };
         assert!(error.to_string().contains("trusted system Chocolatey folder"));
+    }
+
+    #[test]
+    fn chocolatey_elevated_execution_rejects_everyone_writable_executable() {
+        let program_data = tempfile::tempdir().expect("create fake ProgramData");
+        let install_root = program_data.path().join("chocolatey");
+        let choco_bin = install_root.join("bin");
+        std::fs::create_dir_all(&choco_bin).expect("create fake Chocolatey bin");
+        let choco_path = choco_bin.join("choco.exe");
+        std::fs::write(&choco_path, "").expect("create fake choco");
+        make_everyone_writable(&choco_path);
+
+        let error = resolve_trusted_chocolatey_executable(None, &install_root, true)
+            .expect_err("an everyone-writable choco.exe must be rejected for elevated execution");
+        assert!(
+            error.to_string().contains("elevated package-manager executable"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn chocolatey_non_elevated_execution_allows_everyone_writable_executable() {
+        let program_data = tempfile::tempdir().expect("create fake ProgramData");
+        let install_root = program_data.path().join("chocolatey");
+        let choco_bin = install_root.join("bin");
+        std::fs::create_dir_all(&choco_bin).expect("create fake Chocolatey bin");
+        let choco_path = choco_bin.join("choco.exe");
+        std::fs::write(&choco_path, "").expect("create fake choco");
+        make_everyone_writable(&choco_path);
+
+        let (resolved, resolved_root) = resolve_trusted_chocolatey_executable(None, &install_root, false)
+            .expect("non-elevated resolution is not subject to the ACL check");
+        assert_eq!(resolved, choco_path);
+        assert_eq!(resolved_root, install_root);
     }
 
     #[test]
@@ -1654,7 +1798,8 @@ mod tests {
             "--version".to_owned(),
             "15.1.0".to_owned(),
         ];
-        let command = prepare_main_command_in(&command, Some(temp_dir.path()), None).expect("prepare Cargo command");
+        let command =
+            prepare_main_command_in(&command, Some(temp_dir.path()), None, false).expect("prepare Cargo command");
 
         assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
         assert_eq!(command.args()[1], "/D");
@@ -1680,7 +1825,7 @@ mod tests {
 
         let command = vec!["cargo.exe".to_owned(), "uninstall".to_owned(), "ripgrep".to_owned()];
         let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&env)).expect("prepare Cargo command");
+            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&env), false).expect("prepare Cargo command");
 
         let script = std::fs::read_to_string(&command.args()[5]).expect("read temp script");
         assert!(script.contains(&format!(
@@ -1700,7 +1845,7 @@ mod tests {
             "C:\\Tools\\\"& whoami &\"".to_owned(),
         ];
 
-        let error = match prepare_main_command_in(&command, Some(temp_dir.path()), None) {
+        let error = match prepare_main_command_in(&command, Some(temp_dir.path()), None, false) {
             Ok(_) => panic!("quote should fail"),
             Err(error) => error,
         };
@@ -1721,8 +1866,8 @@ mod tests {
             "zlib:x64-windows".to_owned(),
         ];
         let user_env = HashMap::from([("VCPKG_ROOT".to_owned(), vcpkg_root.display().to_string())]);
-        let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env)).expect("prepare vcpkg command");
+        let command = prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env), false)
+            .expect("prepare vcpkg command");
 
         assert!(command.args()[0].ends_with(r"\System32\cmd.exe"));
         assert_eq!(command.args()[1], "/D");
@@ -1749,8 +1894,7 @@ mod tests {
             ],
             post_command: None,
             effective_user: "DOMAIN\\user".to_owned(),
-            user_sid: Sid::from_well_known(windows::Win32::Security::WinWorldSid, None)
-                .expect("well-known Everyone SID"),
+            user_sid: Sid::from_well_known(WinWorldSid, None).expect("well-known Everyone SID"),
             elevation: Elevation::Elevated,
             scope: Some(Scope::User),
             capture_output: false,
@@ -1827,8 +1971,8 @@ mod tests {
             "requests==2.31.0".to_owned(),
             "--no-input".to_owned(),
         ];
-        let command =
-            prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env)).expect("prepare Pip command");
+        let command = prepare_main_command_in(&command, Some(temp_dir.path()), Some(&user_env), false)
+            .expect("prepare Pip command");
 
         assert_eq!(command.args()[0], python_path.display().to_string());
         assert_eq!(command.args()[1], "-m");

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -151,9 +151,10 @@ fn probe_user_environment(is_system: bool, user_sid: &Sid) -> anyhow::Result<Has
 /// resolution rules the execution path applies for that manager.
 fn manager_is_available(manager: ManagerName, user_env: &HashMap<String, String>) -> bool {
     match manager {
-        ManagerName::Winget => resolve_winget_executable(user_env).is_ok(),
+        // Probing is not an elevated execution, so no executable ACL verification is needed.
+        ManagerName::Winget => resolve_winget_executable(user_env, false).is_ok(),
         ManagerName::Chocolatey => default_chocolatey_install_dir()
-            .and_then(|root| resolve_trusted_chocolatey_executable(Some(user_env), &root))
+            .and_then(|root| resolve_trusted_chocolatey_executable(Some(user_env), &root, false))
             .is_ok(),
         ManagerName::Bun => resolve_bun_executable("bun", user_env).is_ok(),
         ManagerName::Cargo => resolve_cargo_executable(user_env).is_ok(),

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -550,9 +550,11 @@ fn prepare_winget_script(
     script.push_str("\r\nset \"NO_COLOR=1\"\r\n");
 
     let (executable, args) = command.split_first().context("empty WinGet command")?;
-    let executable = user_env.map_or_else(
-        || Ok(executable.clone()),
-        |env| resolve_winget_executable(env, requires_elevation).map(|path| path.display().to_string()),
+    let (executable, exe_guard) = user_env.map_or_else(
+        || Ok((executable.clone(), None)),
+        |env| {
+            resolve_winget_executable(env, requires_elevation).map(|(path, guard)| (path.display().to_string(), guard))
+        },
     )?;
     append_batch_argument(&mut script, &executable)?;
     for arg in args {
@@ -578,7 +580,7 @@ fn prepare_winget_script(
         temp_script.path_string(),
     ];
 
-    Ok(PreparedCommand::with_script(prepared, temp_script))
+    Ok(PreparedCommand::with_script(prepared, temp_script).with_exe_guard(exe_guard))
 }
 
 fn prepare_chocolatey_script(
@@ -619,7 +621,7 @@ fn prepare_chocolatey_script_in_with_default_install_root(
     script.push_str("\r\nset \"NO_COLOR=1\"\r\n");
 
     let (_executable, args) = command.split_first().context("empty Chocolatey command")?;
-    let (executable, install_root) =
+    let (executable, install_root, exe_guard) =
         resolve_trusted_chocolatey_executable(user_env, default_install_root, requires_elevation)?;
     append_batch_set_value(&mut script, "ChocolateyInstall", &install_root.display().to_string())?;
     script.push_str("\r\n");
@@ -652,7 +654,7 @@ fn prepare_chocolatey_script_in_with_default_install_root(
         temp_script.path_string(),
     ];
 
-    Ok(PreparedCommand::with_script(prepared, temp_script))
+    Ok(PreparedCommand::with_script(prepared, temp_script).with_exe_guard(exe_guard))
 }
 
 fn prepare_vcpkg_script(
@@ -1013,7 +1015,7 @@ fn resolve_trusted_chocolatey_executable(
     user_env: Option<&HashMap<String, String>>,
     default_install_root: &Path,
     requires_elevation: bool,
-) -> anyhow::Result<(PathBuf, PathBuf)> {
+) -> anyhow::Result<(PathBuf, PathBuf, Option<policy_security::VerifiedExecutable>)> {
     let install_root = user_env
         .and_then(|env| env_value_ignore_case(env, "ChocolateyInstall"))
         .filter(|value| !value.trim().is_empty())
@@ -1034,9 +1036,10 @@ fn resolve_trusted_chocolatey_executable(
         );
     }
 
-    policy_security::verify_elevated_executable_security(&executable, requires_elevation)?;
+    let guard = policy_security::verify_elevated_executable_security(&executable, requires_elevation)?;
+    let executable = guard.as_ref().map_or(executable, |g| g.path().to_owned());
 
-    Ok((executable, install_root))
+    Ok((executable, install_root, guard))
 }
 
 fn is_trusted_chocolatey_install_dir(install_root: &Path, default_install_root: &Path) -> bool {
@@ -1056,7 +1059,10 @@ fn env_value_ignore_case<'a>(env: &'a HashMap<String, String>, key: &str) -> Opt
         .map(|(_, value)| value.as_str())
 }
 
-fn resolve_winget_executable(env: &HashMap<String, String>, requires_elevation: bool) -> anyhow::Result<PathBuf> {
+fn resolve_winget_executable(
+    env: &HashMap<String, String>,
+    requires_elevation: bool,
+) -> anyhow::Result<(PathBuf, Option<policy_security::VerifiedExecutable>)> {
     let path_var = env
         .iter()
         .find(|(key, _)| key.eq_ignore_ascii_case("PATH"))
@@ -1065,8 +1071,9 @@ fn resolve_winget_executable(env: &HashMap<String, String>, requires_elevation: 
     for dir in path_var.split(';') {
         let candidate = PathBuf::from(dir).join("winget.exe");
         if candidate.exists() && is_trusted_winget_path(&candidate, env) {
-            policy_security::verify_elevated_executable_security(&candidate, requires_elevation)?;
-            return Ok(candidate);
+            let guard = policy_security::verify_elevated_executable_security(&candidate, requires_elevation)?;
+            let candidate = guard.as_ref().map_or(candidate, |g| g.path().to_owned());
+            return Ok((candidate, guard));
         }
     }
     bail!("trusted winget.exe not found in target user PATH");
@@ -1261,6 +1268,9 @@ fn append_batch_set_value(script: &mut String, name: &str, value: &str) -> anyho
 struct PreparedCommand {
     command: Vec<String>,
     _script: Option<TmpFileGuard>,
+    /// Keeps a verified elevated executable embedded in the generated script locked
+    /// against modification and replacement until the command has finished running.
+    _exe_guard: Option<policy_security::VerifiedExecutable>,
 }
 
 impl PreparedCommand {
@@ -1268,6 +1278,7 @@ impl PreparedCommand {
         Self {
             command: command.to_vec(),
             _script: None,
+            _exe_guard: None,
         }
     }
 
@@ -1275,7 +1286,13 @@ impl PreparedCommand {
         Self {
             command,
             _script: Some(script),
+            _exe_guard: None,
         }
+    }
+
+    fn with_exe_guard(mut self, exe_guard: Option<policy_security::VerifiedExecutable>) -> Self {
+        self._exe_guard = exe_guard;
+        self
     }
 
     fn args(&self) -> &[String] {
@@ -1474,9 +1491,10 @@ mod tests {
             ("ProgramFiles".to_owned(), program_files.path().display().to_string()),
         ]);
 
-        let resolved =
+        let (resolved, guard) =
             resolve_winget_executable(&env, false).expect("non-elevated resolution is not subject to the ACL check");
         assert_eq!(resolved, winget_path);
+        assert!(guard.is_none(), "no guard is produced for non-elevated executions");
     }
 
     #[test]
@@ -1782,10 +1800,11 @@ mod tests {
         std::fs::write(&choco_path, "").expect("create fake choco");
         make_everyone_writable(&choco_path);
 
-        let (resolved, resolved_root) = resolve_trusted_chocolatey_executable(None, &install_root, false)
+        let (resolved, resolved_root, guard) = resolve_trusted_chocolatey_executable(None, &install_root, false)
             .expect("non-elevated resolution is not subject to the ACL check");
         assert_eq!(resolved, choco_path);
         assert_eq!(resolved_root, install_root);
+        assert!(guard.is_none(), "no guard is produced for non-elevated executions");
     }
 
     #[test]

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -1936,8 +1936,7 @@ mod tests {
             command: vec!["winget.exe".to_owned(), "install".to_owned()],
             post_command: None,
             effective_user: "DOMAIN\\user".to_owned(),
-            user_sid: Sid::from_well_known(windows::Win32::Security::WinWorldSid, None)
-                .expect("well-known Everyone SID"),
+            user_sid: Sid::from_well_known(WinWorldSid, None).expect("well-known Everyone SID"),
             elevation: Elevation::Elevated,
             scope: Some(Scope::User),
             capture_output: false,
@@ -1964,8 +1963,7 @@ mod tests {
             post_command: None,
             effective_user: "DOMAIN\\other".to_owned(),
             // The Everyone (World) SID never matches the test process user SID.
-            user_sid: Sid::from_well_known(windows::Win32::Security::WinWorldSid, None)
-                .expect("well-known Everyone SID"),
+            user_sid: Sid::from_well_known(WinWorldSid, None).expect("well-known Everyone SID"),
             elevation: Elevation::Standard,
             scope: Some(Scope::User),
             capture_output: false,

--- a/devolutions-agent/src/broker/executor/windows/privileges.rs
+++ b/devolutions-agent/src/broker/executor/windows/privileges.rs
@@ -134,5 +134,10 @@ mod tests {
             let refcounts = guard.as_ref().unwrap();
             assert_eq!(refcounts.get(&name.to_string_lossy()), Some(&0));
         }
+
+        // SeChangeNotify (bypass traverse checking) is enabled by default on every token;
+        // the last drop above disabled it process-wide, which breaks concurrent tests doing
+        // path normalization. Restore the default state.
+        adjust(&[name], true).unwrap();
     }
 }

--- a/devolutions-agent/src/broker/executor/windows/process.rs
+++ b/devolutions-agent/src/broker/executor/windows/process.rs
@@ -50,7 +50,10 @@ pub(super) fn create_process(
     let user_env = utils::environment_block(Some(token), false).context("failed to load user environment block")?;
 
     let exe_name = command.first().context("empty command")?;
-    let resolved_exe = resolve_executable(exe_name, &user_env, requires_elevation)?;
+    // `_exe_guard` (when elevation is required) keeps the verified executable locked
+    // against modification and replacement until this function returns, i.e. after the
+    // spawned process has finished.
+    let (resolved_exe, _exe_guard) = resolve_executable(exe_name, &user_env, requires_elevation)?;
 
     info!(
         exe = %resolved_exe.display(),
@@ -211,22 +214,29 @@ pub(super) fn create_process(
 ///
 /// When `requires_elevation` is true (the command will run with an elevated or
 /// machine-scope token), the resolved executable must additionally be writable only by
-/// SYSTEM or the built-in Administrators group; otherwise a standard user could replace
-/// the binary (e.g. via a weakly-ACL'd `%ProgramData%` install root) and have the broker
-/// launch it with elevated privileges. This check is skipped for non-elevated executions,
-/// since per-user tool installs (pip venvs, `~/.cargo`, etc.) are not admin-owned.
+/// trusted principals (SYSTEM, built-in Administrators, or TrustedInstaller); otherwise
+/// a standard user could replace the binary (e.g. via a weakly-ACL'd `%ProgramData%`
+/// install root) and have the broker launch it with elevated privileges. In that case
+/// the returned path is the final path pinned by the returned
+/// [`policy_security::VerifiedExecutable`] guard, which must be kept alive until the
+/// process has been spawned so the verified binary cannot be swapped in between. This
+/// check is skipped for non-elevated executions, since per-user tool installs (pip
+/// venvs, `~/.cargo`, etc.) are not admin-owned.
 fn resolve_executable(
     exe_name: &str,
     env: &std::collections::HashMap<String, String>,
     requires_elevation: bool,
-) -> anyhow::Result<PathBuf> {
+) -> anyhow::Result<(PathBuf, Option<policy_security::VerifiedExecutable>)> {
     let exe_path = Path::new(exe_name);
 
     // If already an absolute path, just verify it exists.
     if exe_path.is_absolute() {
         if exe_path.exists() {
-            policy_security::verify_elevated_executable_security(exe_path, requires_elevation)?;
-            return Ok(exe_path.to_owned());
+            let guard = policy_security::verify_elevated_executable_security(exe_path, requires_elevation)?;
+            let resolved = guard
+                .as_ref()
+                .map_or_else(|| exe_path.to_owned(), |g| g.path().to_owned());
+            return Ok((resolved, guard));
         }
         bail!("executable not found at absolute path: {}", exe_path.display());
     }
@@ -258,8 +268,9 @@ fn resolve_executable(
             let file_name = format!("{}{}", exe_name, ext);
             candidate.push(&file_name);
             if candidate.exists() && is_trusted_winget_path(&candidate, env) {
-                policy_security::verify_elevated_executable_security(&candidate, requires_elevation)?;
-                return Ok(candidate);
+                let guard = policy_security::verify_elevated_executable_security(&candidate, requires_elevation)?;
+                let resolved = guard.as_ref().map_or(candidate, |g| g.path().to_owned());
+                return Ok((resolved, guard));
             }
         }
     }
@@ -335,11 +346,13 @@ mod tests {
 
     #[test]
     fn elevated_execution_rejects_everyone_writable_absolute_executable() {
-        let temp = tempfile::NamedTempFile::new().expect("create temp file");
-        make_everyone_writable(temp.path());
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let exe = temp_dir.path().join("fake.exe");
+        std::fs::write(&exe, b"").expect("write fake executable");
+        make_everyone_writable(&exe);
 
         let env = HashMap::new();
-        let error = resolve_executable(&temp.path().display().to_string(), &env, true)
+        let error = resolve_executable(&exe.display().to_string(), &env, true)
             .expect_err("an everyone-writable executable must be rejected when it will run with an elevated token");
         assert!(
             error.to_string().contains("elevated package-manager executable"),
@@ -349,12 +362,15 @@ mod tests {
 
     #[test]
     fn non_elevated_execution_allows_everyone_writable_absolute_executable() {
-        let temp = tempfile::NamedTempFile::new().expect("create temp file");
-        make_everyone_writable(temp.path());
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let exe = temp_dir.path().join("fake.exe");
+        std::fs::write(&exe, b"").expect("write fake executable");
+        make_everyone_writable(&exe);
 
         let env = HashMap::new();
-        let resolved = resolve_executable(&temp.path().display().to_string(), &env, false)
+        let (resolved, guard) = resolve_executable(&exe.display().to_string(), &env, false)
             .expect("non-elevated executables are not subject to the admin-only-writable check");
-        assert_eq!(resolved, temp.path());
+        assert_eq!(resolved, exe);
+        assert!(guard.is_none(), "no guard is produced for non-elevated executions");
     }
 }

--- a/devolutions-agent/src/broker/executor/windows/process.rs
+++ b/devolutions-agent/src/broker/executor/windows/process.rs
@@ -18,6 +18,7 @@ use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
 
 use crate::broker::executor::{ExecutionOutput, MAX_CAPTURED_OUTPUT_BYTES, ProcessStartedCallback, tail_utf8};
 use crate::broker::operation_tracker::OperationTracker;
+use crate::broker::policy_security;
 
 /// Create a process under the given token and wait for exit.
 ///
@@ -34,6 +35,7 @@ pub(super) fn create_process(
     command: &[String],
     session_id: u32,
     capture: bool,
+    requires_elevation: bool,
     process_started: Option<ProcessStartedCallback>,
 ) -> anyhow::Result<ExecutionOutput> {
     let cmd_line = CommandLine::new(command.to_vec());
@@ -48,7 +50,7 @@ pub(super) fn create_process(
     let user_env = utils::environment_block(Some(token), false).context("failed to load user environment block")?;
 
     let exe_name = command.first().context("empty command")?;
-    let resolved_exe = resolve_executable(exe_name, &user_env)?;
+    let resolved_exe = resolve_executable(exe_name, &user_env, requires_elevation)?;
 
     info!(
         exe = %resolved_exe.display(),
@@ -206,12 +208,24 @@ pub(super) fn create_process(
 ///
 /// Handles both absolute paths and bare names (e.g., `winget.exe`).
 /// Appends `.exe` if no extension is present and the file is not found as-is.
-fn resolve_executable(exe_name: &str, env: &std::collections::HashMap<String, String>) -> anyhow::Result<PathBuf> {
+///
+/// When `requires_elevation` is true (the command will run with an elevated or
+/// machine-scope token), the resolved executable must additionally be writable only by
+/// SYSTEM or the built-in Administrators group; otherwise a standard user could replace
+/// the binary (e.g. via a weakly-ACL'd `%ProgramData%` install root) and have the broker
+/// launch it with elevated privileges. This check is skipped for non-elevated executions,
+/// since per-user tool installs (pip venvs, `~/.cargo`, etc.) are not admin-owned.
+fn resolve_executable(
+    exe_name: &str,
+    env: &std::collections::HashMap<String, String>,
+    requires_elevation: bool,
+) -> anyhow::Result<PathBuf> {
     let exe_path = Path::new(exe_name);
 
     // If already an absolute path, just verify it exists.
     if exe_path.is_absolute() {
         if exe_path.exists() {
+            policy_security::verify_elevated_executable_security(exe_path, requires_elevation)?;
             return Ok(exe_path.to_owned());
         }
         bail!("executable not found at absolute path: {}", exe_path.display());
@@ -244,6 +258,7 @@ fn resolve_executable(exe_name: &str, env: &std::collections::HashMap<String, St
             let file_name = format!("{}{}", exe_name, ext);
             candidate.push(&file_name);
             if candidate.exists() && is_trusted_winget_path(&candidate, env) {
+                policy_security::verify_elevated_executable_security(&candidate, requires_elevation)?;
                 return Ok(candidate);
             }
         }
@@ -279,4 +294,67 @@ fn is_trusted_winget_path(candidate: &Path, env: &std::collections::HashMap<Stri
 
     candidate.starts_with(&format!("{program_files}\\windowsapps\\"))
         || local_app_data.is_some_and(|path| candidate == format!("{path}\\microsoft\\windowsapps\\winget.exe"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use win_api_wrappers::identity::sid::Sid;
+    use win_api_wrappers::security::acl::{
+        Acl, ExplicitAccess, InheritableAcl, InheritableAclKind, Trustee, set_named_security_info,
+    };
+    use win_api_wrappers::str::U16CString;
+    use windows::Win32::Foundation::GENERIC_ALL;
+    use windows::Win32::Security::Authorization::{GRANT_ACCESS, SE_FILE_OBJECT};
+    use windows::Win32::Security::{NO_INHERITANCE, WinWorldSid};
+
+    use super::*;
+
+    fn grant(permissions: u32, sid: Sid) -> ExplicitAccess {
+        ExplicitAccess {
+            access_permissions: permissions,
+            access_mode: GRANT_ACCESS,
+            inheritance: NO_INHERITANCE,
+            trustee: Trustee::Sid(sid),
+        }
+    }
+
+    fn make_everyone_writable(path: &Path) {
+        let everyone = Sid::from_well_known(WinWorldSid, None).expect("well-known Everyone SID");
+        let dacl = InheritableAcl {
+            kind: InheritableAclKind::Protected,
+            acl: Acl::new()
+                .and_then(|acl| acl.set_entries(&[grant(GENERIC_ALL.0, everyone)]))
+                .expect("build ACL with Everyone full-control entry"),
+        };
+        let name = U16CString::from_os_str(path.as_os_str()).expect("no interior NUL in temp path");
+        set_named_security_info(&name, SE_FILE_OBJECT, None, None, Some(&dacl), None)
+            .expect("set everyone-writable DACL");
+    }
+
+    #[test]
+    fn elevated_execution_rejects_everyone_writable_absolute_executable() {
+        let temp = tempfile::NamedTempFile::new().expect("create temp file");
+        make_everyone_writable(temp.path());
+
+        let env = HashMap::new();
+        let error = resolve_executable(&temp.path().display().to_string(), &env, true)
+            .expect_err("an everyone-writable executable must be rejected when it will run with an elevated token");
+        assert!(
+            error.to_string().contains("elevated package-manager executable"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn non_elevated_execution_allows_everyone_writable_absolute_executable() {
+        let temp = tempfile::NamedTempFile::new().expect("create temp file");
+        make_everyone_writable(temp.path());
+
+        let env = HashMap::new();
+        let resolved = resolve_executable(&temp.path().display().to_string(), &env, false)
+            .expect("non-elevated executables are not subject to the admin-only-writable check");
+        assert_eq!(resolved, temp.path());
+    }
 }

--- a/devolutions-agent/src/broker/mod.rs
+++ b/devolutions-agent/src/broker/mod.rs
@@ -10,7 +10,7 @@ pub mod executor;
 pub mod operation_tracker;
 pub mod pipe;
 pub mod policy_loader;
-mod policy_security;
+pub(crate) mod policy_security;
 pub mod policy_watcher;
 pub mod server;
 pub mod task;

--- a/devolutions-agent/src/broker/policy_security.rs
+++ b/devolutions-agent/src/broker/policy_security.rs
@@ -63,12 +63,24 @@ const WRITE_ACCESS_MASK: u32 = FILE_WRITE_DATA.0 /* modify content */
 /// Access rights on an ancestor directory that allow swapping a path component underneath
 /// a verified executable (renaming or deleting entries, or rewriting the directory's own
 /// security descriptor). Rights that only allow *adding* new entries are deliberately not
-/// included: they cannot redirect an existing path.
+/// included here: they cannot redirect an existing path component. The directory hosting
+/// the executable itself is held to the stricter [`PARENT_DIRECTORY_TAMPER_MASK`].
 const DIRECTORY_TAMPER_MASK: u32 = FILE_DELETE_CHILD.0 /* delete or rename child entries */
     | DELETE.0 /* delete or rename the directory itself */
     | WRITE_DAC.0 /* rewrite the DACL itself */
     | WRITE_OWNER.0 /* take ownership */
     | GENERIC_ALL.0; /* full control */
+
+/// Access rights on the directory hosting a verified executable that allow tampering with
+/// its execution. On top of [`DIRECTORY_TAMPER_MASK`], create rights are rejected: a
+/// principal able to add entries beside the executable can plant a DLL or another
+/// application-loaded resource that the elevated process picks up at start (side-loading),
+/// even though the verified binary itself is pinned. On directories, `FILE_WRITE_DATA` is
+/// `FILE_ADD_FILE` and `FILE_APPEND_DATA` is `FILE_ADD_SUBDIRECTORY`.
+const PARENT_DIRECTORY_TAMPER_MASK: u32 = DIRECTORY_TAMPER_MASK
+    | FILE_WRITE_DATA.0 /* add files (plant DLLs) */
+    | FILE_APPEND_DATA.0 /* add subdirectories */
+    | GENERIC_WRITE.0; /* generic write (maps to add rights) */
 
 /// `NT SERVICE\TrustedInstaller`, the Windows Modules Installer service SID.
 ///
@@ -204,13 +216,20 @@ pub(crate) fn verify_elevated_executable_security(
 }
 
 /// Verify that every ancestor directory of `path` denies untrusted principals the rights
-/// needed to swap a path component (see [`DIRECTORY_TAMPER_MASK`]).
+/// needed to tamper with the executable's resolution or loading.
 ///
-/// Without this, a principal with delete/rename rights on an ancestor could replace a
-/// whole directory subtree so the verified name resolves to a different file when the
-/// image is finally loaded.
+/// The directory hosting the executable is checked against
+/// [`PARENT_DIRECTORY_TAMPER_MASK`], which additionally rejects create rights: a principal
+/// able to add entries beside the binary can plant a DLL or another application-loaded
+/// resource that the elevated process side-loads at start. Higher ancestors are checked
+/// against [`DIRECTORY_TAMPER_MASK`]: without it, a principal with delete/rename rights
+/// could replace a whole directory subtree so the verified name resolves to a different
+/// file when the image is finally loaded. Create rights higher up are harmless (and are
+/// granted to unprivileged users on stock drive roots), since they cannot redirect an
+/// existing path component.
 fn verify_ancestor_directories(path: &Path, subject: &str) -> anyhow::Result<()> {
     let mut current = path.parent();
+    let mut tamper_mask = PARENT_DIRECTORY_TAMPER_MASK;
 
     while let Some(dir) = current {
         let dir_subject = format!("{subject} ancestor directory '{}'", dir.display());
@@ -226,9 +245,10 @@ fn verify_ancestor_directories(path: &Path, subject: &str) -> anyhow::Result<()>
             &handle,
             &dir_subject,
             TrustedWriters::AdminOrTrustedInstaller,
-            DIRECTORY_TAMPER_MASK,
+            tamper_mask,
         )?;
 
+        tamper_mask = DIRECTORY_TAMPER_MASK;
         current = dir.parent();
     }
 
@@ -525,6 +545,10 @@ mod tests {
         }
 
         fn verify_as_executable(&self) -> anyhow::Result<()> {
+            self.verify_with_mask(WRITE_ACCESS_MASK)
+        }
+
+        fn verify_with_mask(&self, mask: u32) -> anyhow::Result<()> {
             // SAFETY: `owner` and `dacl` point into the owned security descriptor, which outlives
             // this call.
             unsafe {
@@ -533,7 +557,7 @@ mod tests {
                     self.owner,
                     self.dacl,
                     TrustedWriters::AdminOrTrustedInstaller,
-                    WRITE_ACCESS_MASK,
+                    mask,
                 )
             }
         }
@@ -632,6 +656,51 @@ mod tests {
         let sd = SddlDescriptor::parse(&sddl);
         let error = sd.verify().unwrap_err();
         assert!(error.to_string().contains("owner"), "unexpected error: {error}");
+    }
+
+    #[test]
+    fn untrusted_add_file_right_is_rejected_on_hosting_directory() {
+        // FILE_WRITE_DATA (0x2) on a directory is FILE_ADD_FILE: enough to plant a DLL
+        // beside the executable for side-loading into the elevated process.
+        let sd = SddlDescriptor::parse("O:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x2;;;BU)");
+        let error = sd.verify_with_mask(PARENT_DIRECTORY_TAMPER_MASK).unwrap_err();
+        assert!(
+            error.to_string().contains("grants write access"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn untrusted_add_subdirectory_right_is_rejected_on_hosting_directory() {
+        // FILE_APPEND_DATA (0x4) on a directory is FILE_ADD_SUBDIRECTORY.
+        let sd = SddlDescriptor::parse("O:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x4;;;AU)");
+        let error = sd.verify_with_mask(PARENT_DIRECTORY_TAMPER_MASK).unwrap_err();
+        assert!(
+            error.to_string().contains("grants write access"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn untrusted_create_rights_are_tolerated_on_higher_ancestors() {
+        // Stock drive roots grant Authenticated Users add-file/add-subdirectory rights;
+        // those cannot redirect an existing path component, so higher ancestors only
+        // reject rename/delete and descriptor rewrites.
+        let sd = SddlDescriptor::parse("O:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x6;;;AU)");
+        sd.verify_with_mask(DIRECTORY_TAMPER_MASK)
+            .expect("create rights on higher ancestors must be tolerated");
+    }
+
+    #[test]
+    fn untrusted_delete_child_right_is_rejected_on_higher_ancestors() {
+        // FILE_DELETE_CHILD (0x40) lets a principal swap path components underneath the
+        // verified executable.
+        let sd = SddlDescriptor::parse("O:SYD:(A;;FA;;;SY)(A;;FA;;;BA)(A;;0x40;;;BU)");
+        let error = sd.verify_with_mask(DIRECTORY_TAMPER_MASK).unwrap_err();
+        assert!(
+            error.to_string().contains("grants write access"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/devolutions-agent/src/broker/policy_security.rs
+++ b/devolutions-agent/src/broker/policy_security.rs
@@ -12,26 +12,44 @@
 //! as SYSTEM/Administrator.
 //!
 //! As defense-in-depth, before trusting such a file, we verify that it is owned by
-//! SYSTEM or the built-in Administrators group and that its DACL does not grant write
-//! access to any other principal. Callers fail closed when this check fails.
+//! a trusted principal and that its DACL does not grant write access to any other
+//! principal. Callers fail closed when this check fails.
+//!
+//! For the policy file, the trusted principals are SYSTEM and the built-in
+//! Administrators group. For executables, `NT SERVICE\TrustedInstaller` is trusted as
+//! well, since Windows-protected binaries (`System32`, `Program Files`, `WindowsApps`)
+//! are owned by and writable by that service.
+//!
+//! For elevated executables the verification additionally defends against
+//! time-of-check/time-of-use races: the file is opened without write or delete sharing
+//! and the returned [`VerifiedExecutable`] guard keeps that handle alive so the verified
+//! object cannot be written, deleted, or renamed until it has been executed. Execution is
+//! bound to the final path resolved from the verified handle (defeating reparse-point
+//! retargeting of the originally supplied name), and every ancestor directory of that
+//! path is checked so untrusted principals cannot swap path components either.
 
-use std::fs::File;
+use std::ffi::OsString;
+use std::fs::{File, OpenOptions};
+use std::os::windows::ffi::OsStringExt as _;
+use std::os::windows::fs::OpenOptionsExt as _;
 use std::os::windows::io::AsRawHandle as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, bail};
 use windows::Win32::Foundation::{ERROR_SUCCESS, GENERIC_ALL, GENERIC_WRITE, HANDLE, HLOCAL, LocalFree};
 use windows::Win32::Security::Authorization::{ConvertSidToStringSidW, GetSecurityInfo, SE_FILE_OBJECT};
 use windows::Win32::Security::{
-    ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, DACL_SECURITY_INFORMATION, GetAce, IsWellKnownSid, OWNER_SECURITY_INFORMATION,
-    PSECURITY_DESCRIPTOR, PSID, WinBuiltinAdministratorsSid, WinLocalSystemSid,
+    ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, DACL_SECURITY_INFORMATION, GetAce, INHERIT_ONLY_ACE, IsWellKnownSid,
+    OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, WinBuiltinAdministratorsSid, WinLocalSystemSid,
 };
 use windows::Win32::Storage::FileSystem::{
-    DELETE, FILE_APPEND_DATA, FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA, FILE_WRITE_EA, WRITE_DAC, WRITE_OWNER,
+    DELETE, FILE_APPEND_DATA, FILE_DELETE_CHILD, FILE_FLAG_BACKUP_SEMANTICS, FILE_NAME_NORMALIZED,
+    FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES, FILE_WRITE_DATA,
+    FILE_WRITE_EA, GetFinalPathNameByHandleW, READ_CONTROL, WRITE_DAC, WRITE_OWNER,
 };
 use windows::core::PWSTR;
 
-/// Access rights that allow modifying the policy file content or its security descriptor.
+/// Access rights that allow modifying the file content or its security descriptor.
 const WRITE_ACCESS_MASK: u32 = FILE_WRITE_DATA.0 /* modify content */
     | FILE_APPEND_DATA.0 /* append content */
     | FILE_WRITE_EA.0 /* write extended attributes */
@@ -41,6 +59,33 @@ const WRITE_ACCESS_MASK: u32 = FILE_WRITE_DATA.0 /* modify content */
     | WRITE_OWNER.0 /* take ownership */
     | GENERIC_WRITE.0 /* generic write */
     | GENERIC_ALL.0; /* full control */
+
+/// Access rights on an ancestor directory that allow swapping a path component underneath
+/// a verified executable (renaming or deleting entries, or rewriting the directory's own
+/// security descriptor). Rights that only allow *adding* new entries are deliberately not
+/// included: they cannot redirect an existing path.
+const DIRECTORY_TAMPER_MASK: u32 = FILE_DELETE_CHILD.0 /* delete or rename child entries */
+    | DELETE.0 /* delete or rename the directory itself */
+    | WRITE_DAC.0 /* rewrite the DACL itself */
+    | WRITE_OWNER.0 /* take ownership */
+    | GENERIC_ALL.0; /* full control */
+
+/// `NT SERVICE\TrustedInstaller`, the Windows Modules Installer service SID.
+///
+/// Windows-protected binaries (under `System32`, `Program Files`, `WindowsApps`, ...) are
+/// owned by this SID and grant it full control, so it must be trusted when verifying
+/// executables. It is deliberately *not* trusted for the policy file, which is never
+/// serviced by the Windows Modules Installer.
+const TRUSTED_INSTALLER_SID: &str = "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464";
+
+/// Principals trusted to hold write access over a verified file.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TrustedWriters {
+    /// SYSTEM and the built-in Administrators group (policy file).
+    AdminOnly,
+    /// Additionally trusts `NT SERVICE\TrustedInstaller` (Windows-protected executables).
+    AdminOrTrustedInstaller,
+}
 
 // ACE type constants from winnt.h (the Win32_System_SystemServices feature is not enabled).
 const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
@@ -67,27 +112,186 @@ impl Drop for OwnedSecurityDescriptor {
 /// descriptor belongs to the very same file that is subsequently read (no TOCTOU window
 /// via file replacement).
 ///
-/// See [`verify_admin_only_writable`] for the exact rules.
+/// Rules (fail-closed):
+/// - The owner must be a trusted principal.
+/// - A DACL must be present (a NULL DACL grants everyone full control).
+/// - Every access-allowed ACE granting write access must have a trusted principal as
+///   the trustee (inherit-only ACEs are skipped, since they do not apply to the object).
+/// - Unsupported (object/callback) access-allowed ACE types are rejected.
 pub(crate) fn verify_policy_file_security(file: &File) -> anyhow::Result<()> {
-    verify_admin_only_writable(file, "policy file")
+    verify_handle_security(file, "policy file", TrustedWriters::AdminOnly, WRITE_ACCESS_MASK)
 }
 
-/// Verify that `file` may only be written by SYSTEM or built-in Administrators.
+/// A package-manager executable that was verified for elevated execution.
 ///
-/// The check is performed on the already-opened file handle so the verified security
-/// descriptor belongs to the very same file that is subsequently used (no TOCTOU window
-/// via file replacement).
+/// The held file handle was opened without write or delete sharing, so the verified file
+/// object cannot be written, deleted, or renamed while the guard is alive. Callers must
+/// execute [`VerifiedExecutable::path()`] (the final path resolved from the verified
+/// handle) and keep the guard alive until the spawned process — or the script embedding
+/// the path — has finished running, closing the TOCTOU window between verification and
+/// image load.
+#[derive(Debug)]
+pub(crate) struct VerifiedExecutable {
+    _file: File,
+    path: PathBuf,
+}
+
+impl VerifiedExecutable {
+    /// The final path of the verified executable, resolved from the verified handle.
+    ///
+    /// This is the path callers must execute (or embed in generated scripts) so execution
+    /// is bound to the object that was verified rather than to a reparse point that could
+    /// be retargeted after the check.
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Verify that a resolved package-manager executable which will be launched with an
+/// elevated or machine-scope token cannot be tampered with by untrusted principals.
 ///
-/// `subject` is a short human-readable description of the file, used in error messages
-/// (e.g. `"policy file"` or `"elevated package-manager executable"`).
+/// Returns `None` when `requires_elevation` is false, since non-elevated tool installs
+/// (pip venvs, `~/.cargo`, `~/.bun`, etc.) are not expected to live under
+/// admin-only-writable paths. Otherwise, fails closed on any error and returns a
+/// [`VerifiedExecutable`] guard on success:
 ///
-/// Rules (fail-closed):
-/// - The owner must be SYSTEM or the built-in Administrators group.
-/// - A DACL must be present (a NULL DACL grants everyone full control).
-/// - Every access-allowed ACE granting write access must have SYSTEM or the built-in
-///   Administrators group as the trustee.
-/// - Unsupported (object/callback) access-allowed ACE types are rejected.
-pub(crate) fn verify_admin_only_writable(file: &File, subject: &str) -> anyhow::Result<()> {
+/// - The file is opened without write or delete sharing; the open fails if a writer
+///   already has it open, and the guard prevents modification, deletion, and renaming
+///   of the verified object until it is dropped.
+/// - The executable's owner and DACL must only allow writes by SYSTEM, built-in
+///   Administrators, or `NT SERVICE\TrustedInstaller` (see [`verify_policy_file_security`]
+///   for the exact DACL rules).
+/// - Every ancestor directory of the final path (resolved from the verified handle) must
+///   not allow untrusted principals to rename or delete path components, so the name used
+///   for execution cannot be redirected to a different file.
+pub(crate) fn verify_elevated_executable_security(
+    path: &Path,
+    requires_elevation: bool,
+) -> anyhow::Result<Option<VerifiedExecutable>> {
+    if !requires_elevation {
+        return Ok(None);
+    }
+
+    let subject = format!("elevated package-manager executable '{}'", path.display());
+
+    // Share only read access: while this handle is alive the file cannot be opened for
+    // write or delete (rename), and this open fails if such a handle already exists.
+    let file = OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ.0)
+        .open(path)
+        .with_context(|| format!("failed to open {subject}"))?;
+
+    // Resolve the path from the handle itself: if `path` traversed a reparse point
+    // (symlink, junction, ...), this yields the real target, which is the very object
+    // pinned by the guard handle.
+    let final_path =
+        final_path_from_handle(&file).with_context(|| format!("failed to resolve final path of {subject}"))?;
+
+    verify_handle_security(
+        &file,
+        &subject,
+        TrustedWriters::AdminOrTrustedInstaller,
+        WRITE_ACCESS_MASK,
+    )?;
+
+    verify_ancestor_directories(&final_path, &subject)?;
+
+    Ok(Some(VerifiedExecutable {
+        _file: file,
+        path: final_path,
+    }))
+}
+
+/// Verify that every ancestor directory of `path` denies untrusted principals the rights
+/// needed to swap a path component (see [`DIRECTORY_TAMPER_MASK`]).
+///
+/// Without this, a principal with delete/rename rights on an ancestor could replace a
+/// whole directory subtree so the verified name resolves to a different file when the
+/// image is finally loaded.
+fn verify_ancestor_directories(path: &Path, subject: &str) -> anyhow::Result<()> {
+    let mut current = path.parent();
+
+    while let Some(dir) = current {
+        let dir_subject = format!("{subject} ancestor directory '{}'", dir.display());
+
+        let handle = OpenOptions::new()
+            .access_mode(FILE_READ_ATTRIBUTES.0 | READ_CONTROL.0)
+            .share_mode(FILE_SHARE_READ.0 | FILE_SHARE_WRITE.0 | FILE_SHARE_DELETE.0)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS.0)
+            .open(dir)
+            .with_context(|| format!("failed to open {dir_subject}"))?;
+
+        verify_handle_security(
+            &handle,
+            &dir_subject,
+            TrustedWriters::AdminOrTrustedInstaller,
+            DIRECTORY_TAMPER_MASK,
+        )?;
+
+        current = dir.parent();
+    }
+
+    Ok(())
+}
+
+/// Resolve the normalized final path of an open file from its handle.
+fn final_path_from_handle(file: &File) -> anyhow::Result<PathBuf> {
+    let handle = HANDLE(file.as_raw_handle());
+    let mut buffer = vec![0u16; 512];
+
+    loop {
+        // SAFETY: `handle` is a valid open file handle and `buffer` is a live mutable slice.
+        let len = unsafe { GetFinalPathNameByHandleW(handle, &mut buffer, FILE_NAME_NORMALIZED) };
+
+        if len == 0 {
+            return Err(windows::core::Error::from_win32()).context("GetFinalPathNameByHandleW failed");
+        }
+
+        let len = usize::try_from(len).expect("u32 fits in usize on Windows");
+
+        // A return value smaller than the buffer is the number of characters written;
+        // otherwise it is the required buffer size (including the null terminator).
+        if len < buffer.len() {
+            buffer.truncate(len);
+            return Ok(dos_path_from_wide(&buffer));
+        }
+
+        buffer.resize(len, 0);
+    }
+}
+
+/// Convert a possibly `\\?\`-prefixed wide path to its plain Win32 form.
+///
+/// The resolved path is embedded into generated batch scripts and passed to
+/// `CreateProcessAsUserW`, and `cmd.exe` does not understand extended-length paths.
+fn dos_path_from_wide(wide: &[u16]) -> PathBuf {
+    let verbatim: Vec<u16> = r"\\?\".encode_utf16().collect();
+    let verbatim_unc: Vec<u16> = r"\\?\UNC\".encode_utf16().collect();
+
+    if wide.starts_with(&verbatim_unc) {
+        // `\\?\UNC\server\share\...` → `\\server\share\...`.
+        let mut path: Vec<u16> = r"\\".encode_utf16().collect();
+        path.extend_from_slice(&wide[verbatim_unc.len()..]);
+        PathBuf::from(OsString::from_wide(&path))
+    } else if wide.starts_with(&verbatim) {
+        // `\\?\C:\...` → `C:\...`.
+        PathBuf::from(OsString::from_wide(&wide[verbatim.len()..]))
+    } else {
+        PathBuf::from(OsString::from_wide(wide))
+    }
+}
+
+/// Verify that `file` may only be written (per `tamper_mask`) by `trusted_writers` principals.
+///
+/// The check is performed on the already-opened handle so the verified security
+/// descriptor belongs to the very same object that is subsequently used.
+fn verify_handle_security(
+    file: &File,
+    subject: &str,
+    trusted_writers: TrustedWriters,
+    tamper_mask: u32,
+) -> anyhow::Result<()> {
     let handle = HANDLE(file.as_raw_handle());
 
     let mut owner = PSID::default();
@@ -115,54 +319,34 @@ pub(crate) fn verify_admin_only_writable(file: &File, subject: &str) -> anyhow::
 
     // SAFETY: On success, `owner` and `dacl` point into `descriptor` (or are null), which
     // outlives this call.
-    unsafe { verify_owner_and_dacl(subject, owner, dacl) }
+    unsafe { verify_owner_and_dacl(subject, owner, dacl, trusted_writers, tamper_mask) }
 }
 
-/// Opens `path` and verifies that it may only be written by SYSTEM or built-in Administrators.
+/// Verify that `owner` is trusted and that `dacl` grants `tamper_mask` rights to
+/// `trusted_writers` SIDs only.
 ///
-/// Convenience wrapper for callers that only have a path (not an already-open file handle),
-/// such as the executor verifying a resolved package-manager executable before running it
-/// with an elevated or machine-scope token. See [`verify_admin_only_writable`] for the exact
-/// rules. Fails closed (including when the file cannot be opened at all).
-pub(crate) fn verify_admin_only_writable_path(path: &Path, subject: &str) -> anyhow::Result<()> {
-    let file = File::open(path).with_context(|| format!("failed to open {subject} at {}", path.display()))?;
-    verify_admin_only_writable(&file, subject)
-}
-
-/// Verify that a resolved package-manager executable which will be launched with an
-/// elevated or machine-scope token is only writable by SYSTEM or built-in Administrators.
-///
-/// No-op when `requires_elevation` is false, since non-elevated tool installs (pip venvs,
-/// `~/.cargo`, `~/.bun`, etc.) are not expected to live under admin-only-writable paths.
-/// Fails closed on any error (including when the file cannot be opened), so a resolution
-/// or permission issue never silently allows an untrusted binary to run elevated.
-pub(crate) fn verify_elevated_executable_security(path: &Path, requires_elevation: bool) -> anyhow::Result<()> {
-    if !requires_elevation {
-        return Ok(());
-    }
-
-    let subject = format!("elevated package-manager executable '{}'", path.display());
-    verify_admin_only_writable_path(path, &subject)
-}
-
-/// Verify that `owner` is trusted and that `dacl` grants write access to trusted SIDs only.
-///
-/// See [`verify_admin_only_writable`] for the exact rules.
+/// See [`verify_policy_file_security`] for the exact rules.
 ///
 /// # Safety
 ///
 /// - `owner` must be null or point to a valid SID.
 /// - `dacl` must be null or point to a valid, initialized ACL.
-unsafe fn verify_owner_and_dacl(subject: &str, owner: PSID, dacl: *const ACL) -> anyhow::Result<()> {
+unsafe fn verify_owner_and_dacl(
+    subject: &str,
+    owner: PSID,
+    dacl: *const ACL,
+    trusted_writers: TrustedWriters,
+    tamper_mask: u32,
+) -> anyhow::Result<()> {
     if owner.0.is_null() {
         bail!("{subject} has no owner information");
     }
 
     // SAFETY: Per function contract, `owner` points to a valid SID.
-    if !unsafe { is_trusted_sid(owner) } {
+    if !unsafe { is_trusted_sid(owner, trusted_writers) } {
         // SAFETY: Per function contract, `owner` points to a valid SID.
         let owner_string = unsafe { sid_to_string(owner) };
-        bail!("{subject} owner {owner_string} is not SYSTEM or built-in Administrators");
+        bail!("{subject} owner {owner_string} is not a trusted principal");
     }
 
     if dacl.is_null() {
@@ -181,6 +365,12 @@ unsafe fn verify_owner_and_dacl(subject: &str, owner: PSID, dacl: *const ACL) ->
         // SAFETY: GetAce succeeded, so `ace_ptr` points to an ACE starting with an ACE_HEADER.
         let header = unsafe { &*ace_ptr.cast::<ACE_HEADER>() };
 
+        // Inherit-only ACEs do not apply to the object itself, only to its children
+        // (e.g. the `CREATOR OWNER` full-control template ACE on `Program Files`).
+        if u32::from(header.AceFlags) & INHERIT_ONLY_ACE.0 != 0 {
+            continue;
+        }
+
         match header.AceType {
             // Deny and audit ACEs never grant access.
             ACCESS_DENIED_ACE_TYPE | SYSTEM_AUDIT_ACE_TYPE | SYSTEM_ALARM_ACE_TYPE => {}
@@ -188,18 +378,18 @@ unsafe fn verify_owner_and_dacl(subject: &str, owner: PSID, dacl: *const ACL) ->
                 // SAFETY: The ACE type is ACCESS_ALLOWED_ACE_TYPE, so it has the ACCESS_ALLOWED_ACE layout.
                 let ace = unsafe { &*ace_ptr.cast::<ACCESS_ALLOWED_ACE>() };
 
-                if ace.Mask & WRITE_ACCESS_MASK == 0 {
+                if ace.Mask & tamper_mask == 0 {
                     continue;
                 }
 
                 let trustee = PSID(std::ptr::from_ref(&ace.SidStart).cast_mut().cast());
 
                 // SAFETY: `SidStart` is the first DWORD of the trustee SID stored inline in the ACE.
-                if !unsafe { is_trusted_sid(trustee) } {
+                if !unsafe { is_trusted_sid(trustee, trusted_writers) } {
                     // SAFETY: `trustee` points to a valid SID inside the ACE.
                     let trustee_string = unsafe { sid_to_string(trustee) };
                     bail!(
-                        "{subject} DACL grants write access to {trustee_string}; only SYSTEM and built-in Administrators may be able to write it"
+                        "{subject} DACL grants write access to {trustee_string}; only trusted principals may be able to write it"
                     );
                 }
             }
@@ -211,19 +401,25 @@ unsafe fn verify_owner_and_dacl(subject: &str, owner: PSID, dacl: *const ACL) ->
     Ok(())
 }
 
-/// Returns `true` when the SID is SYSTEM or the built-in Administrators group.
+/// Returns `true` when the SID is one of the `trusted_writers` principals.
 ///
 /// # Safety
 ///
 /// `sid` must point to a valid SID.
-unsafe fn is_trusted_sid(sid: PSID) -> bool {
+unsafe fn is_trusted_sid(sid: PSID, trusted_writers: TrustedWriters) -> bool {
     // SAFETY: Per function contract, `sid` points to a valid SID.
-    let is_system = unsafe { IsWellKnownSid(sid, WinLocalSystemSid) }.as_bool();
+    if unsafe { IsWellKnownSid(sid, WinLocalSystemSid) }.as_bool() {
+        return true;
+    }
 
     // SAFETY: Per function contract, `sid` points to a valid SID.
-    let is_admins = unsafe { IsWellKnownSid(sid, WinBuiltinAdministratorsSid) }.as_bool();
+    if unsafe { IsWellKnownSid(sid, WinBuiltinAdministratorsSid) }.as_bool() {
+        return true;
+    }
 
-    is_system || is_admins
+    // SAFETY: Per function contract, `sid` points to a valid SID.
+    trusted_writers == TrustedWriters::AdminOrTrustedInstaller
+        && unsafe { sid_to_string(sid) }.eq_ignore_ascii_case(TRUSTED_INSTALLER_SID)
 }
 
 /// Best-effort conversion of a SID to its string form for diagnostics.
@@ -317,7 +513,29 @@ mod tests {
         fn verify(&self) -> anyhow::Result<()> {
             // SAFETY: `owner` and `dacl` point into the owned security descriptor, which outlives
             // this call.
-            unsafe { verify_owner_and_dacl("test file", self.owner, self.dacl) }
+            unsafe {
+                verify_owner_and_dacl(
+                    "test file",
+                    self.owner,
+                    self.dacl,
+                    TrustedWriters::AdminOnly,
+                    WRITE_ACCESS_MASK,
+                )
+            }
+        }
+
+        fn verify_as_executable(&self) -> anyhow::Result<()> {
+            // SAFETY: `owner` and `dacl` point into the owned security descriptor, which outlives
+            // this call.
+            unsafe {
+                verify_owner_and_dacl(
+                    "test executable",
+                    self.owner,
+                    self.dacl,
+                    TrustedWriters::AdminOrTrustedInstaller,
+                    WRITE_ACCESS_MASK,
+                )
+            }
         }
     }
 
@@ -386,6 +604,34 @@ mod tests {
         // A deny ACE never grants access, so it must not trigger a rejection.
         let sd = SddlDescriptor::parse("O:SYD:(D;;FA;;;WD)(A;;FA;;;SY)(A;;FA;;;BA)");
         sd.verify().expect("deny ACEs must be ignored");
+    }
+
+    #[test]
+    fn inherit_only_write_ace_is_ignored() {
+        // Inherit-only ACEs (e.g. the CREATOR OWNER template on Program Files) do not
+        // apply to the object itself.
+        let sd = SddlDescriptor::parse("O:SYD:(A;;FA;;;SY)(A;OICIIO;GA;;;WD)");
+        sd.verify().expect("inherit-only ACEs must be ignored");
+    }
+
+    #[test]
+    fn trusted_installer_owner_and_write_ace_are_accepted_for_executables() {
+        // Windows-protected binaries (System32, WindowsApps, ...) are owned by and
+        // writable by NT SERVICE\TrustedInstaller.
+        let sddl = format!("O:{TRUSTED_INSTALLER_SID}D:(A;;FA;;;{TRUSTED_INSTALLER_SID})(A;;FR;;;BU)");
+        let sd = SddlDescriptor::parse(&sddl);
+        sd.verify_as_executable()
+            .expect("TrustedInstaller must be trusted for executables");
+    }
+
+    #[test]
+    fn trusted_installer_owner_is_rejected_for_policy_files() {
+        // The policy file is never serviced by the Windows Modules Installer, so
+        // TrustedInstaller stays untrusted there.
+        let sddl = format!("O:{TRUSTED_INSTALLER_SID}D:(A;;FA;;;SY)(A;;FA;;;BA)");
+        let sd = SddlDescriptor::parse(&sddl);
+        let error = sd.verify().unwrap_err();
+        assert!(error.to_string().contains("owner"), "unexpected error: {error}");
     }
 
     #[test]
@@ -472,12 +718,14 @@ mod tests {
 
     #[test]
     fn everyone_writable_executable_path_is_rejected() {
-        let temp = tempfile::NamedTempFile::new().unwrap();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let exe = temp_dir.path().join("fake.exe");
+        std::fs::write(&exe, b"").unwrap();
 
         let everyone = Sid::from_well_known(WinWorldSid, None).unwrap();
-        set_security(temp.path(), None, &[grant(GENERIC_ALL.0, everyone)]).unwrap();
+        set_security(&exe, None, &[grant(GENERIC_ALL.0, everyone)]).unwrap();
 
-        let error = verify_admin_only_writable_path(temp.path(), "elevated package-manager executable").unwrap_err();
+        let error = verify_elevated_executable_security(&exe, true).unwrap_err();
         assert!(
             error.to_string().contains("elevated package-manager executable"),
             "unexpected error: {error}"
@@ -489,10 +737,45 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let missing = temp.path().join("does-not-exist.exe");
 
-        let error = verify_admin_only_writable_path(&missing, "elevated package-manager executable").unwrap_err();
+        let error = verify_elevated_executable_security(&missing, true).unwrap_err();
         assert!(
             error.to_string().contains("failed to open"),
             "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn non_elevated_executable_is_not_verified() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let exe = temp_dir.path().join("fake.exe");
+        std::fs::write(&exe, b"").unwrap();
+
+        let guard = verify_elevated_executable_security(&exe, false).unwrap();
+        assert!(guard.is_none(), "no guard is produced for non-elevated executions");
+    }
+
+    #[test]
+    fn protected_system32_executable_is_accepted_for_elevated_execution() {
+        // Exercises the full chain on a real Windows-protected binary: TrustedInstaller
+        // ownership and write ACEs on the file, plus the ancestor-directory walk over
+        // System32, Windows, and the drive root.
+        let system_root = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_owned());
+        let cmd = Path::new(&system_root).join("System32").join("cmd.exe");
+
+        let guard = verify_elevated_executable_security(&cmd, true)
+            .expect("a protected System32 executable must be accepted")
+            .expect("a guard must be produced for elevated executions");
+
+        assert!(guard.path().is_absolute());
+        assert!(
+            guard.path().ends_with("cmd.exe"),
+            "unexpected final path: {}",
+            guard.path().display()
+        );
+        assert!(
+            !guard.path().to_string_lossy().starts_with(r"\\?\"),
+            "final path must be in plain Win32 form: {}",
+            guard.path().display()
         );
     }
 }

--- a/devolutions-agent/src/broker/policy_security.rs
+++ b/devolutions-agent/src/broker/policy_security.rs
@@ -1,17 +1,23 @@
-//! Policy file security validation.
+//! Admin-only-writable file security validation.
 //!
-//! The policy file is the entire authorization control for the package broker.
-//! `C:\ProgramData` subtrees are a known spot for over-permissive inherited ACEs:
-//! if a standard user can write the policy file, they can self-authorize arbitrary
-//! elevated installs.
+//! Shared by two trust boundaries in the package broker:
+//! - The policy file, which is the entire authorization control for the broker.
+//! - Package-manager executables resolved for elevated/machine-scope execution
+//!   (e.g. `winget.exe`, `choco.exe`).
 //!
-//! As defense-in-depth, before trusting a loaded policy, we verify that the file is
-//! owned by SYSTEM or the built-in Administrators group and that its DACL does not
-//! grant write access to any other principal.
-//! The broker fails closed (pauses) when this check fails.
+//! `C:\ProgramData` subtrees (and similar install roots) are a known spot for
+//! over-permissive inherited ACEs: if a standard user can write the policy file, they
+//! can self-authorize arbitrary elevated installs; if they can write (or replace) the
+//! executable the broker launches with an elevated token, they can run arbitrary code
+//! as SYSTEM/Administrator.
+//!
+//! As defense-in-depth, before trusting such a file, we verify that it is owned by
+//! SYSTEM or the built-in Administrators group and that its DACL does not grant write
+//! access to any other principal. Callers fail closed when this check fails.
 
 use std::fs::File;
 use std::os::windows::io::AsRawHandle as _;
+use std::path::Path;
 
 use anyhow::{Context as _, bail};
 use windows::Win32::Foundation::{ERROR_SUCCESS, GENERIC_ALL, GENERIC_WRITE, HANDLE, HLOCAL, LocalFree};
@@ -61,13 +67,27 @@ impl Drop for OwnedSecurityDescriptor {
 /// descriptor belongs to the very same file that is subsequently read (no TOCTOU window
 /// via file replacement).
 ///
+/// See [`verify_admin_only_writable`] for the exact rules.
+pub(crate) fn verify_policy_file_security(file: &File) -> anyhow::Result<()> {
+    verify_admin_only_writable(file, "policy file")
+}
+
+/// Verify that `file` may only be written by SYSTEM or built-in Administrators.
+///
+/// The check is performed on the already-opened file handle so the verified security
+/// descriptor belongs to the very same file that is subsequently used (no TOCTOU window
+/// via file replacement).
+///
+/// `subject` is a short human-readable description of the file, used in error messages
+/// (e.g. `"policy file"` or `"elevated package-manager executable"`).
+///
 /// Rules (fail-closed):
 /// - The owner must be SYSTEM or the built-in Administrators group.
 /// - A DACL must be present (a NULL DACL grants everyone full control).
 /// - Every access-allowed ACE granting write access must have SYSTEM or the built-in
 ///   Administrators group as the trustee.
 /// - Unsupported (object/callback) access-allowed ACE types are rejected.
-pub(crate) fn verify_policy_file_security(file: &File) -> anyhow::Result<()> {
+pub(crate) fn verify_admin_only_writable(file: &File, subject: &str) -> anyhow::Result<()> {
     let handle = HANDLE(file.as_raw_handle());
 
     let mut owner = PSID::default();
@@ -90,36 +110,63 @@ pub(crate) fn verify_policy_file_security(file: &File) -> anyhow::Result<()> {
     };
 
     if ret != ERROR_SUCCESS {
-        bail!("failed to read policy file security information: error {}", ret.0);
+        bail!("failed to read {subject} security information: error {}", ret.0);
     }
 
     // SAFETY: On success, `owner` and `dacl` point into `descriptor` (or are null), which
     // outlives this call.
-    unsafe { verify_owner_and_dacl(owner, dacl) }
+    unsafe { verify_owner_and_dacl(subject, owner, dacl) }
+}
+
+/// Opens `path` and verifies that it may only be written by SYSTEM or built-in Administrators.
+///
+/// Convenience wrapper for callers that only have a path (not an already-open file handle),
+/// such as the executor verifying a resolved package-manager executable before running it
+/// with an elevated or machine-scope token. See [`verify_admin_only_writable`] for the exact
+/// rules. Fails closed (including when the file cannot be opened at all).
+pub(crate) fn verify_admin_only_writable_path(path: &Path, subject: &str) -> anyhow::Result<()> {
+    let file = File::open(path).with_context(|| format!("failed to open {subject} at {}", path.display()))?;
+    verify_admin_only_writable(&file, subject)
+}
+
+/// Verify that a resolved package-manager executable which will be launched with an
+/// elevated or machine-scope token is only writable by SYSTEM or built-in Administrators.
+///
+/// No-op when `requires_elevation` is false, since non-elevated tool installs (pip venvs,
+/// `~/.cargo`, `~/.bun`, etc.) are not expected to live under admin-only-writable paths.
+/// Fails closed on any error (including when the file cannot be opened), so a resolution
+/// or permission issue never silently allows an untrusted binary to run elevated.
+pub(crate) fn verify_elevated_executable_security(path: &Path, requires_elevation: bool) -> anyhow::Result<()> {
+    if !requires_elevation {
+        return Ok(());
+    }
+
+    let subject = format!("elevated package-manager executable '{}'", path.display());
+    verify_admin_only_writable_path(path, &subject)
 }
 
 /// Verify that `owner` is trusted and that `dacl` grants write access to trusted SIDs only.
 ///
-/// See [`verify_policy_file_security`] for the exact rules.
+/// See [`verify_admin_only_writable`] for the exact rules.
 ///
 /// # Safety
 ///
 /// - `owner` must be null or point to a valid SID.
 /// - `dacl` must be null or point to a valid, initialized ACL.
-unsafe fn verify_owner_and_dacl(owner: PSID, dacl: *const ACL) -> anyhow::Result<()> {
+unsafe fn verify_owner_and_dacl(subject: &str, owner: PSID, dacl: *const ACL) -> anyhow::Result<()> {
     if owner.0.is_null() {
-        bail!("policy file has no owner information");
+        bail!("{subject} has no owner information");
     }
 
     // SAFETY: Per function contract, `owner` points to a valid SID.
     if !unsafe { is_trusted_sid(owner) } {
         // SAFETY: Per function contract, `owner` points to a valid SID.
         let owner_string = unsafe { sid_to_string(owner) };
-        bail!("policy file owner {owner_string} is not SYSTEM or built-in Administrators");
+        bail!("{subject} owner {owner_string} is not SYSTEM or built-in Administrators");
     }
 
     if dacl.is_null() {
-        bail!("policy file has a NULL DACL granting full control to everyone");
+        bail!("{subject} has a NULL DACL granting full control to everyone");
     }
 
     // SAFETY: Per function contract, `dacl` is a valid, non-null pointer to an initialized ACL.
@@ -129,7 +176,7 @@ unsafe fn verify_owner_and_dacl(owner: PSID, dacl: *const ACL) -> anyhow::Result
         let mut ace_ptr: *mut core::ffi::c_void = std::ptr::null_mut();
 
         // SAFETY: `dacl` is a valid ACL pointer and `idx` is within `AceCount`.
-        unsafe { GetAce(dacl, idx, &mut ace_ptr) }.context("failed to read policy file DACL entry")?;
+        unsafe { GetAce(dacl, idx, &mut ace_ptr) }.with_context(|| format!("failed to read {subject} DACL entry"))?;
 
         // SAFETY: GetAce succeeded, so `ace_ptr` points to an ACE starting with an ACE_HEADER.
         let header = unsafe { &*ace_ptr.cast::<ACE_HEADER>() };
@@ -152,12 +199,12 @@ unsafe fn verify_owner_and_dacl(owner: PSID, dacl: *const ACL) -> anyhow::Result
                     // SAFETY: `trustee` points to a valid SID inside the ACE.
                     let trustee_string = unsafe { sid_to_string(trustee) };
                     bail!(
-                        "policy file DACL grants write access to {trustee_string}; only SYSTEM and built-in Administrators may be able to write the policy"
+                        "{subject} DACL grants write access to {trustee_string}; only SYSTEM and built-in Administrators may be able to write it"
                     );
                 }
             }
             // Fail closed on object/callback and other exotic allow ACE types.
-            other => bail!("policy file DACL contains unsupported ACE type {other}"),
+            other => bail!("{subject} DACL contains unsupported ACE type {other}"),
         }
     }
 
@@ -270,7 +317,7 @@ mod tests {
         fn verify(&self) -> anyhow::Result<()> {
             // SAFETY: `owner` and `dacl` point into the owned security descriptor, which outlives
             // this call.
-            unsafe { verify_owner_and_dacl(self.owner, self.dacl) }
+            unsafe { verify_owner_and_dacl("test file", self.owner, self.dacl) }
         }
     }
 
@@ -369,7 +416,7 @@ mod tests {
         }
     }
 
-    fn set_security(path: &std::path::Path, owner: Option<&Sid>, entries: &[ExplicitAccess]) -> anyhow::Result<()> {
+    fn set_security(path: &Path, owner: Option<&Sid>, entries: &[ExplicitAccess]) -> anyhow::Result<()> {
         let dacl = InheritableAcl {
             kind: InheritableAclKind::Protected,
             acl: Acl::new()?.set_entries(entries)?,
@@ -421,5 +468,31 @@ mod tests {
         let file = File::open(temp.path()).unwrap();
 
         verify_policy_file_security(&file).expect("SYSTEM/Administrators-only policy file must be accepted");
+    }
+
+    #[test]
+    fn everyone_writable_executable_path_is_rejected() {
+        let temp = tempfile::NamedTempFile::new().unwrap();
+
+        let everyone = Sid::from_well_known(WinWorldSid, None).unwrap();
+        set_security(temp.path(), None, &[grant(GENERIC_ALL.0, everyone)]).unwrap();
+
+        let error = verify_admin_only_writable_path(temp.path(), "elevated package-manager executable").unwrap_err();
+        assert!(
+            error.to_string().contains("elevated package-manager executable"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn missing_executable_path_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("does-not-exist.exe");
+
+        let error = verify_admin_only_writable_path(&missing, "elevated package-manager executable").unwrap_err();
+        assert!(
+            error.to_string().contains("failed to open"),
+            "unexpected error: {error}"
+        );
     }
 }


### PR DESCRIPTION
Before running a package-manager executable with an elevated (SYSTEM) token, the Agent package broker now verifies that the binary is owned by SYSTEM or the built-in Administrators group and that its DACL does not grant write access to non-admin users. Without this check, a standard user could plant or overwrite a package-manager binary (for example via a user-writable PATH entry) and have it executed with elevated rights, resulting in local privilege escalation.

The verification is fail-closed and enforced at every elevated executable resolution point: directly spawned binaries (dotnet.exe, trusted PowerShell hosts) as well as winget and Chocolatey binaries that are embedded into generated batch scripts. Non-elevated per-user executions are unaffected, so user-scope installs (pip virtualenvs, ~/.cargo, ~/.bun, and so on) keep working as before.

Issue: DGW-434