### PR TITLE
fix(agent): enforce client identity for user-scope execution when broker is not SYSTEM

### DIFF
--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -168,7 +168,11 @@ fn execute_as_system(
     Ok(output)
 }
 
-/// Execute a command as the current user (development mode).
+/// Execute a command as the current user (non-SYSTEM mode).
+///
+/// This path is taken whenever the broker does not run as SYSTEM, regardless of build
+/// profile — e.g. when the agent binary is launched manually as a regular user instead
+/// of as the Windows service.
 ///
 /// Opens the current process token and uses the same `create_process_as_user`
 /// code path as SYSTEM mode, ensuring consistent behavior (environment, desktop, flags).
@@ -183,7 +187,7 @@ fn execute_as_current_user(
 ) -> anyhow::Result<ExecutionOutput> {
     info!(
         effective_user = %ctx.effective_user,
-        "Executing command as current user (dev mode)"
+        "Executing command as current user (non-SYSTEM mode)"
     );
 
     let token = Process::current_process()
@@ -197,8 +201,8 @@ fn execute_as_current_user(
     if process_user_sid != ctx.user_sid {
         bail!(
             "pipe client user SID '{}' does not match broker process user SID '{}'; \
-             user-scope execution in development mode is only supported when the client \
-             and the broker run as the same user",
+             user-scope execution is only supported when the client \
+             and the broker run as the same user (broker is not running as SYSTEM)",
             ctx.user_sid,
             process_user_sid,
         );
@@ -1647,7 +1651,7 @@ mod tests {
     }
 
     #[test]
-    fn dev_mode_rejects_client_user_different_from_broker_user() {
+    fn non_system_mode_rejects_client_user_different_from_broker_user() {
         let ctx = ExecutionContext {
             kill_processes: Vec::new(),
             pre_command: None,

--- a/devolutions-agent/src/broker/executor/windows/mod.rs
+++ b/devolutions-agent/src/broker/executor/windows/mod.rs
@@ -124,8 +124,10 @@ fn execute_as_system(
 
     debug!("All privileges enabled, finding user session");
 
-    let (session_id, user_token) =
-        find_user_session(&ctx.user_sid).context("failed to find active session for user")?;
+    let (session_id, user_token) = find_user_session(&ctx.user_sid).context(
+        "failed to find an active logon session for the target user; \
+         user-scope and interactive operations require the user to be logged on",
+    )?;
 
     info!(
         effective_user = %ctx.effective_user,
@@ -170,6 +172,11 @@ fn execute_as_system(
 ///
 /// Opens the current process token and uses the same `create_process_as_user`
 /// code path as SYSTEM mode, ensuring consistent behavior (environment, desktop, flags).
+///
+/// The client identity must match the broker process user: the process token defines
+/// the target profile (`%LOCALAPPDATA%`, HKCU) and desktop session, so executing on
+/// behalf of a different pipe client would put user-scope installs into the wrong
+/// profile and interactive UIs on the wrong desktop.
 fn execute_as_current_user(
     ctx: &ExecutionContext,
     process_started: Option<ProcessStartedCallback>,
@@ -182,6 +189,20 @@ fn execute_as_current_user(
     let token = Process::current_process()
         .token(TOKEN_ALL_ACCESS)
         .context("failed to open current process token")?;
+
+    let process_user_sid = token
+        .sid_and_attributes()
+        .context("failed to query current process token user SID")?
+        .sid;
+    if process_user_sid != ctx.user_sid {
+        bail!(
+            "pipe client user SID '{}' does not match broker process user SID '{}'; \
+             user-scope execution in development mode is only supported when the client \
+             and the broker run as the same user",
+            ctx.user_sid,
+            process_user_sid,
+        );
+    }
 
     let session_id = token.session_id().context("failed to query token session ID")?;
 
@@ -1116,8 +1137,9 @@ mod tests {
     use win_api_wrappers::identity::sid::Sid;
 
     use super::{
-        POWERSHELL_UTF8_ENCODING_PREAMBLE, prepare_chocolatey_script_in_with_default_install_root,
-        prepare_main_command_in, prepare_shell_command_in, reject_unsupported_vcpkg_elevation,
+        POWERSHELL_UTF8_ENCODING_PREAMBLE, execute_as_current_user,
+        prepare_chocolatey_script_in_with_default_install_root, prepare_main_command_in, prepare_shell_command_in,
+        reject_unsupported_vcpkg_elevation,
     };
     use crate::broker::executor::ExecutionContext;
 
@@ -1622,6 +1644,30 @@ mod tests {
         ctx.scope = Some(Scope::Machine);
         let error = reject_unsupported_vcpkg_elevation(&ctx).expect_err("machine-scope vcpkg should fail");
         assert!(error.to_string().contains("machine-scope"));
+    }
+
+    #[test]
+    fn dev_mode_rejects_client_user_different_from_broker_user() {
+        let ctx = ExecutionContext {
+            kill_processes: Vec::new(),
+            pre_command: None,
+            command: vec![
+                r"C:\Windows\System32\cmd.exe".to_owned(),
+                "/C".to_owned(),
+                "exit".to_owned(),
+            ],
+            post_command: None,
+            effective_user: "DOMAIN\\other".to_owned(),
+            // The Everyone (World) SID never matches the test process user SID.
+            user_sid: Sid::from_well_known(windows::Win32::Security::WinWorldSid, None)
+                .expect("well-known Everyone SID"),
+            elevation: Elevation::Standard,
+            scope: Some(Scope::User),
+            capture_output: false,
+        };
+
+        let error = execute_as_current_user(&ctx, None).expect_err("mismatched client SID should fail");
+        assert!(error.to_string().contains("does not match broker process user SID"));
     }
 
     #[test]


### PR DESCRIPTION
Ensures package operations always run in the requesting user's own context.

In service (SYSTEM) mode the broker already launches operations with the client user's real session token, so user-scope installs land in the correct profile (`%LOCALAPPDATA%`, HKCU) and interactive installer UIs appear on the user's desktop rather than in session 0.

This change closes a gap in the non-SYSTEM execution path, which is selected at runtime whenever the broker process does not run as SYSTEM (e.g. the agent binary launched manually as a regular user instead of as the Windows service — in any build profile, release included): the executor ran commands under the broker process token regardless of which user connected to the pipe, so a user-scope install requested by a different user would silently land in the broker user's profile. Such requests are now rejected with a clear error.

The error reported when the target user has no active logon session is also clarified, since user-scope and interactive operations require the user to be logged on.

Issue: DGW-436