### PR TITLE
chore(skills): add commit conventions

### DIFF
--- a/.agents/skills/commit-and-pr-conventions/SKILL.md
+++ b/.agents/skills/commit-and-pr-conventions/SKILL.md
@@ -11,10 +11,10 @@ Treat the PR title and initial body as the exact commit message that squash-and-
 
 - Read repository instructions first. Derive scopes with the repository-local `commit-scope` skill. If unavailable, use explicit repository rules or omit the scope rather than inventing one.
 - Follow Conventional Commits: `<type>[optional scope][!]: <description>`.
-- Limit the subject to 50 characters and describe the resulting behavior.
+- Target 50 characters and describe the resulting behavior. Do not drop repository-required scopes to meet that target; when they make it impossible, keep the remaining description as concise as practical.
 - Separate subject, body, and footers with blank lines.
 - For standalone commits, wrap body lines at 72 characters. Explain why the change was needed, how it solves it, and material side effects.
-- Put an existing ticket key or link in a footer, not the subject: `Issue: PROJECT-123`. Omit the footer when no issue exists; never write `Issue: N/A`.
+- Put an existing ticket key or link in a footer, not the subject: `Issue: PROJECT-123`. Follow repository-specific footer format when an issue exists. When none exists, omit the footer rather than fabricating `Issue: N/A`.
 - Add applicable Conventional Commit footers and `Co-authored-by: Name <email>` trailers for collaborators.
 - Use `fix` for bugs, `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `ci` for automation, `docs` for documentation only, `style` for non-semantic edits, `refactor` for restructuring, `test` for tests, and `perf` for performance.
 - Keep every non-squashed development commit coherent and conventional.

--- a/.agents/skills/commit-and-pr-conventions/SKILL.md
+++ b/.agents/skills/commit-and-pr-conventions/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: commit-and-pr-conventions
+description: Follow the adopted commit and pull-request conventions. Use whenever creating a commit or opening, editing, reviewing, or preparing to squash-merge a PR, including requests to commit, push, or open a PR.
+---
+
+# Commit and PR conventions
+
+Treat the PR title and initial body as the exact commit message that squash-and-merge will land.
+
+## Commit message
+
+- Read repository instructions first. Derive scopes with the repository-local `commit-scope` skill. If unavailable, use explicit repository rules or omit the scope rather than inventing one.
+- Follow Conventional Commits: `<type>[optional scope][!]: <description>`.
+- Limit the subject to 50 characters and describe the resulting behavior.
+- Separate subject, body, and footers with blank lines.
+- For standalone commits, wrap body lines at 72 characters. Explain why the change was needed, how it solves it, and material side effects.
+- Put an existing ticket key or link in a footer, not the subject: `Issue: PROJECT-123`. Omit the footer when no issue exists; never write `Issue: N/A`.
+- Add applicable Conventional Commit footers and `Co-authored-by: Name <email>` trailers for collaborators.
+- Use `fix` for bugs, `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `ci` for automation, `docs` for documentation only, `style` for non-semantic edits, `refactor` for restructuring, `test` for tests, and `perf` for performance.
+- Keep every non-squashed development commit coherent and conventional.
+
+```text
+fix(storage): preserve collated indexes
+
+Normalize server-expanded collations before comparing index definitions.
+
+Issue: PROJECT-123
+```
+
+## Pull request
+
+- Set the title to the intended squash commit subject exactly.
+- Set the initial body to the intended squash commit body and footers exactly. Exclude PR-only preambles, checklists, and implementation journals.
+- Do not manually wrap the PR body; GitHub handles display wrapping.
+- Keep permanent history concise: record motivation, material behavior, and side effects.
+- Put experiments, alternatives, extensive validation, and implementation chronology in follow-up comments.
+- Update the title and initial body as the implementation evolves.
+- Before opening, updating, or merging, read `title + blank line + body` as one commit message and correct any mismatch.

--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: commit-scope
+description: Select commit and PR scopes in the Devolutions Gateway repository. Use whenever composing or reviewing a Conventional Commit subject, especially for shared libraries, packaging, tests, documentation, CI, or changes spanning products.
+---
+
+# Devolutions Gateway commit scope
+
+Choose scopes by affected deliverable, not file location or internal component.
+
+1. Inspect the diff and repository instructions.
+2. Read the ordered parsers in `cliff.toml`; the completed subject and footers determine whether git-cliff includes the commit.
+3. For an included commit, trace shared-code and packaging dependencies to every affected product. For Rust crates, inspect reverse dependencies. Count shipped normal dependencies; ignore dev-only use unless tests or developer behavior are the change.
+4. Add every applicable product scope:
+
+| Scope | Area |
+|---|---|
+| `dgw` | Devolutions Gateway service, runtime, API, configuration, or product-specific tests/docs/build logic |
+| `installer` | Devolutions Gateway installers, packages, installation behavior, or installer-specific tests/docs/build logic |
+| `agent` | Devolutions Agent services, updater, runtime, or product-specific tests/docs/build logic |
+| `agent-installer` | Devolutions Agent installers, packages, installation behavior, or installer-specific tests/docs/build logic |
+| `jetsocat` | Jetsocat runtime, packages, or product-specific tests/docs/build logic |
+| `webapp` | Anything affecting the standalone Gateway web application |
+
+A shared component receives each product scope whose behavior changes. Merely bundling an updated runtime does not add `installer` or `agent-installer`; add those scopes only when installation or packaging behavior changes. Do not use internal component names such as `jmux` or `pedm`: JMUX changes commonly affect `dgw,jetsocat`; PEDM changes commonly affect `agent` and sometimes `agent-installer`.
+
+For included commits, use only product scopes. Scopes containing `openapi`, `deps`, `npm`, `nuget`, `dotnet-*`, or `ts-*` cause git-cliff to suppress the entry.
+
+Scopes are more flexible when git-cliff excludes the commit, whether by type, scope, or `Changelog: ignore`. Keep the semantic type: an npm package feature may use `feat(npm): ...` because the scope suppresses it. For `chore`, `ci`, `style`, `refactor`, and `test`, use a concise target when useful, such as `openapi`, `deps`, `toolchain`, `package`, `skills`, `dependabot`, `miri`, `tokengen`, or `dotnet-utils`; omit the scope if none helps. Prefer a precise current name over generic `tools` or `dotnet`.
+
+Use the established `chore(release): prepare for <version>` pattern when cutting a release.
+
+For multiple products, separate scopes with commas and no spaces in this order: `dgw,installer,agent,agent-installer,jetsocat,webapp`.
+
+Examples:
+
+- Shared code shipped by Gateway and Agent: `fix(dgw,agent): ...`
+- JMUX code shared by Gateway and Jetsocat: `perf(dgw,jetsocat): ...`
+- Standalone web application change: `feat(webapp): ...`
+- Gateway contract plus generated clients: `feat(dgw): ...`
+- Standalone npm package feature: `feat(npm): ...`
+- Generated clients only: `chore(openapi): ...`
+- Release preparation: `chore(release): prepare for 2026.3.0`

--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -23,7 +23,7 @@ Choose scopes by affected deliverable, not file location or internal component.
 
 A shared component receives each product scope whose behavior changes. Merely bundling an updated runtime does not add `installer` or `agent-installer`; add those scopes only when installation or packaging behavior changes. Do not use internal component names such as `jmux` or `pedm`: JMUX changes commonly affect `dgw,jetsocat`; PEDM changes commonly affect `agent` and sometimes `agent-installer`.
 
-For included commits, use only product scopes. Scopes containing `openapi`, `deps`, `npm`, `nuget`, `dotnet-*`, or `ts-*` cause git-cliff to suppress the entry.
+For included commits, use only product scopes. Scopes containing `openapi`, `npm`, `nuget`, `dotnet-*`, or `ts-*` cause git-cliff to suppress the entry. The `deps` scope suppresses only exact `chore(deps)` and `build(deps)` subjects; do not use it with other included types or as part of a broader scope.
 
 Scopes are more flexible when git-cliff excludes the commit, whether by type, scope, or `Changelog: ignore`. Keep the semantic type: an npm package feature may use `feat(npm): ...` because the scope suppresses it. For `chore`, `ci`, `style`, `refactor`, and `test`, use a concise target when useful, such as `openapi`, `deps`, `toolchain`, `package`, `skills`, `dependabot`, `miri`, `tokengen`, or `dotnet-utils`; omit the scope if none helps. Prefer a precise current name over generic `tools` or `dotnet`.
 


### PR DESCRIPTION
Document reusable commit and pull-request rules while keeping Gateway-specific scope selection in a separate local skill.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>