### PR TITLE
chore(skills): add local Tessl skill linting

### DIFF
--- a/.agents/skills/tessl-skill-linting/SKILL.md
+++ b/.agents/skills/tessl-skill-linting/SKILL.md
@@ -10,7 +10,8 @@ Keep repository-local agent skills correct, focused, and inexpensive to load.
 ## Workflow
 
 1. Identify the relevant skill directories under `.agents\skills`.
-   Read each target `SKILL.md` before changing it and preserve its intended behavior and scope.
+   For an existing skill, read its `SKILL.md` before editing and preserve its intended behavior and scope.
+   For a new skill, inspect neighboring skills for conventions, then create the target directory and initial `SKILL.md` from the requested scope.
 2. Inspect the frontmatter and instructions for valid structure, clear trigger conditions, focused scope, missing prerequisites, accurate and safe tooling steps, ambiguity, brittleness, redundancy, and likely failure cases.
 3. Run local structural validation for every relevant skill:
 

--- a/.agents/skills/tessl-skill-linting/SKILL.md
+++ b/.agents/skills/tessl-skill-linting/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: tessl-skill-linting
+description: Review, lint, create, edit, refine, optimize, compress, or validate any agent skill in this repository, including any SKILL.md. Use this skill whenever a user asks to author or change a skill, improve its instructions or trigger coverage, assess skill quality, or reduce its context usage, even when Tessl is not mentioned. Keep skills small and split distinct workflows into focused micro-skills when that reduces context and trigger overlap. Do not use it for ordinary application code, documentation, or workflow changes that are not agent skills.
+---
+
+# Tessl Skill Linting
+
+Keep repository-local agent skills correct, focused, and inexpensive to load.
+
+## Workflow
+
+1. Identify the relevant skill directories under `.agents\skills`.
+   Read each target `SKILL.md` before changing it and preserve its intended behavior and scope.
+2. Inspect the frontmatter and instructions for valid structure, clear trigger conditions, focused scope, missing prerequisites, accurate and safe tooling steps, ambiguity, brittleness, redundancy, and likely failure cases.
+3. Run local structural validation for every relevant skill:
+
+   ```powershell
+   pwsh <this-skill-directory>\scripts\Test-TesslSkill.ps1 -SkillDirectory <skill-directory>
+   ```
+
+   The helper stages the skill in a temporary directory, creates Tessl's required local metadata there, runs `tessl skill lint <temporary-skill-directory>`, and removes the staging directory.
+   Treat lint findings as input to fix when appropriate.
+   Tessl lint validates structure, not whether the workflow is semantically complete.
+4. Make only clearly justified edits inside the relevant skill and directly related local eval artifacts.
+   Do not change application code, unrelated skills, or repository configuration.
+5. Perform a deliberate compression pass.
+   Remove filler, repetition, ceremonial headings, generic advice, redundant rules, needless examples, and details better suited to a progressive-disclosure reference.
+   Prefer concise imperative language.
+   Keep the initial `SKILL.md` minimal; add a reference only when specialized material is substantial and needed conditionally.
+   Prefer focused micro-skills over one broad skill when distinct workflows can trigger or load independently.
+6. Re-run the local lint helper after edits and inspect the final diff.
+
+## Report
+
+State:
+
+- Tessl lint findings and their resolution.
+- Meaningful edits and the behavior they preserve or improve.
+- Two or three recommended future local test prompts that exercise triggering and instructions.
+
+Use Tessl only for temporary local import and structural linting.
+Cloud features, including `tessl skill review`, managed evals, scenarios, project creation or linking, publishing, and credentials, are out of scope.

--- a/.agents/skills/tessl-skill-linting/scripts/Test-TesslSkill.ps1
+++ b/.agents/skills/tessl-skill-linting/scripts/Test-TesslSkill.ps1
@@ -1,0 +1,52 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [ValidateNotNullOrEmpty()]
+    [string[]] $SkillDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$Tessl = (Get-Command tessl -ErrorAction Stop).Source
+$Failed = $false
+
+foreach ($Directory in $SkillDirectory) {
+    $ResolvedDirectory = (Resolve-Path -LiteralPath $Directory).Path
+    $SkillFile = Join-Path $ResolvedDirectory 'SKILL.md'
+    if (-not (Test-Path -LiteralPath $SkillFile -PathType Leaf)) {
+        Write-Error "SKILL.md not found in $ResolvedDirectory" -ErrorAction Continue
+        $Failed = $true
+        continue
+    }
+
+    $SkillsRoot = Split-Path $ResolvedDirectory -Parent
+    $StagingRoot = Split-Path $SkillsRoot -Parent
+    $TemporaryRoot = Join-Path $StagingRoot ".tessl-skill-lint-$([guid]::NewGuid())"
+    $StagedDirectory = Join-Path $TemporaryRoot (Split-Path $ResolvedDirectory -Leaf)
+
+    try {
+        New-Item -ItemType Directory -Path $StagedDirectory -Force | Out-Null
+        Get-ChildItem -LiteralPath $ResolvedDirectory -Force |
+            Where-Object Name -ne '.tessl-plugin' |
+            Copy-Item -Destination $StagedDirectory -Recurse -Force
+
+        & $Tessl skill import --workspace local $StagedDirectory | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Tessl local import failed for $ResolvedDirectory" -ErrorAction Continue
+            $Failed = $true
+            continue
+        }
+
+        & $Tessl skill lint $StagedDirectory
+        if ($LASTEXITCODE -ne 0) {
+            $Failed = $true
+        }
+    } finally {
+        if (Test-Path -LiteralPath $TemporaryRoot) {
+            Remove-Item -LiteralPath $TemporaryRoot -Recurse -Force
+        }
+    }
+}
+
+if ($Failed) {
+    exit 1
+}

--- a/.agents/skills/tessl-skill-linting/scripts/Test-TesslSkill.ps1
+++ b/.agents/skills/tessl-skill-linting/scripts/Test-TesslSkill.ps1
@@ -10,6 +10,12 @@ $Tessl = (Get-Command tessl -ErrorAction Stop).Source
 $Failed = $false
 
 foreach ($Directory in $SkillDirectory) {
+    if (-not (Test-Path -LiteralPath $Directory -PathType Container)) {
+        Write-Error "Skill directory not found: $Directory" -ErrorAction Continue
+        $Failed = $true
+        continue
+    }
+
     $ResolvedDirectory = (Resolve-Path -LiteralPath $Directory).Path
     $SkillFile = Join-Path $ResolvedDirectory 'SKILL.md'
     if (-not (Test-Path -LiteralPath $SkillFile -PathType Leaf)) {


### PR DESCRIPTION
Add a repository-local skill for reviewing and compressing agent skills.
Use temporary local Tessl metadata so bare SKILL.md directories can be structurally linted without cloud features or persistent plugin files.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>