### PR TITLE
chore(npm): bump shadow-player to v0.1.2

### DIFF
--- a/webapp/packages/multi-video-player/package.dist.json
+++ b/webapp/packages/multi-video-player/package.dist.json
@@ -1,6 +1,6 @@
 {
   "name": "@devolutions/multi-video-player",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Multi-segment video player with live streaming support",
   "type": "module",
   "main": "./index.js",
@@ -14,7 +14,7 @@
     "./index.css": "./index.css"
   },
   "dependencies": {
-    "@devolutions/shadow-player": "^0.1.1",
+    "@devolutions/shadow-player": "^0.1.2",
     "video.js": "^8.0.0"
   },
   "repository": {

--- a/webapp/packages/multi-video-player/package.dist.json
+++ b/webapp/packages/multi-video-player/package.dist.json
@@ -1,6 +1,6 @@
 {
   "name": "@devolutions/multi-video-player",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Multi-segment video player with live streaming support",
   "type": "module",
   "main": "./index.js",
@@ -14,7 +14,7 @@
     "./index.css": "./index.css"
   },
   "dependencies": {
-    "@devolutions/shadow-player": "^0.1.2",
+    "@devolutions/shadow-player": "^0.1.1",
     "video.js": "^8.0.0"
   },
   "repository": {

--- a/webapp/packages/shadow-player/package.dist.json
+++ b/webapp/packages/shadow-player/package.dist.json
@@ -1,6 +1,6 @@
 {
   "name": "@devolutions/shadow-player",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "WebM stream player web component for real-time video streaming",
   "type": "module",
   "main": "./index.js",


### PR DESCRIPTION
Bumps `@devolutions/shadow-player` to `0.1.2` to publish the playback recovery fix from #1916.

`multi-video-player` stays at `0.1.1`; its `^0.1.1` dependency already accepts this release.