### PR TITLE
chore(agents): clarify commit conventions

### DIFF
--- a/.agents/skills/commit-and-pr-conventions/SKILL.md
+++ b/.agents/skills/commit-and-pr-conventions/SKILL.md
@@ -16,7 +16,10 @@ Treat the PR title and initial body as the exact commit message that squash-and-
 - For standalone commits, wrap body lines at 72 characters. Explain why the change was needed, how it solves it, and material side effects.
 - Put an existing ticket key or link in a footer, not the subject: `Issue: PROJECT-123`. Follow repository-specific footer format when an issue exists. When none exists, omit the footer rather than fabricating `Issue: N/A`.
 - Add applicable Conventional Commit footers and `Co-authored-by: Name <email>` trailers for collaborators.
-- Use `fix` for bugs, `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `ci` for automation, `docs` for documentation only, `style` for non-semantic edits, `refactor` for restructuring, `test` for tests, and `perf` for performance.
+- Choose the type by the affected surface, not by whether the change fixes a defect.
+- Use `ci` for CI, workflow, and automation changes, including fixes to that automation, and reserve `fix` for product or runtime bugs.
+- Use `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `docs` for documentation only, `style` for non-semantic edits, `refactor` for non-breaking restructuring, `test` for tests, and `perf` for performance.
+- Use `fix`, not `refactor`, for breaking restructuring and mark the change with `!` or a `BREAKING CHANGE` footer.
 - Keep every non-squashed development commit coherent and conventional.
 
 ```text

--- a/.agents/skills/commit-and-pr-conventions/SKILL.md
+++ b/.agents/skills/commit-and-pr-conventions/SKILL.md
@@ -17,8 +17,9 @@ Treat the PR title and initial body as the exact commit message that squash-and-
 - Put an existing ticket key or link in a footer, not the subject: `Issue: PROJECT-123`. Follow repository-specific footer format when an issue exists. When none exists, omit the footer rather than fabricating `Issue: N/A`.
 - Add applicable Conventional Commit footers and `Co-authored-by: Name <email>` trailers for collaborators.
 - Choose the type by the affected surface, not by whether the change fixes a defect.
-- Use `ci` for CI, workflow, and automation changes, including fixes to that automation, and reserve `fix` for product or runtime bugs.
-- Use `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `docs` for documentation only, `style` for non-semantic edits, `refactor` for restructuring, `test` for tests, and `perf` for performance.
+- Use `ci` for CI, workflow, and automation changes, including fixes to that automation.
+- Use `fix` for product or runtime bugs and non-feature changes to externally consumed public API boundaries.
+- Use `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `docs` for documentation only, `style` for non-semantic edits, `refactor` for internal restructuring, `test` for tests, and `perf` for performance.
 - Mark breaking changes with `!` or a `BREAKING CHANGE` footer without changing an otherwise accurate type.
 - Keep every non-squashed development commit coherent and conventional.
 

--- a/.agents/skills/commit-and-pr-conventions/SKILL.md
+++ b/.agents/skills/commit-and-pr-conventions/SKILL.md
@@ -18,8 +18,8 @@ Treat the PR title and initial body as the exact commit message that squash-and-
 - Add applicable Conventional Commit footers and `Co-authored-by: Name <email>` trailers for collaborators.
 - Choose the type by the affected surface, not by whether the change fixes a defect.
 - Use `ci` for CI, workflow, and automation changes, including fixes to that automation, and reserve `fix` for product or runtime bugs.
-- Use `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `docs` for documentation only, `style` for non-semantic edits, `refactor` for non-breaking restructuring, `test` for tests, and `perf` for performance.
-- Use `fix`, not `refactor`, for breaking restructuring and mark the change with `!` or a `BREAKING CHANGE` footer.
+- Use `feat` for features, `build` for build or dependencies, `chore` for non-product tools or configuration, `docs` for documentation only, `style` for non-semantic edits, `refactor` for restructuring, `test` for tests, and `perf` for performance.
+- Mark breaking changes with `!` or a `BREAKING CHANGE` footer without changing an otherwise accurate type.
 - Keep every non-squashed development commit coherent and conventional.
 
 ```text

--- a/.agents/skills/commit-scope/SKILL.md
+++ b/.agents/skills/commit-scope/SKILL.md
@@ -25,7 +25,8 @@ A shared component receives each product scope whose behavior changes. Merely bu
 
 For included commits, use only product scopes. Scopes containing `openapi`, `npm`, `nuget`, `dotnet-*`, or `ts-*` cause git-cliff to suppress the entry. The `deps` scope suppresses only exact `chore(deps)` and `build(deps)` subjects; do not use it with other included types or as part of a broader scope.
 
-Scopes are more flexible when git-cliff excludes the commit, whether by type, scope, or `Changelog: ignore`. Keep the semantic type: an npm package feature may use `feat(npm): ...` because the scope suppresses it. For `chore`, `ci`, `style`, `refactor`, and `test`, use a concise target when useful, such as `openapi`, `deps`, `toolchain`, `package`, `skills`, `dependabot`, `miri`, `tokengen`, or `dotnet-utils`; omit the scope if none helps. Prefer a precise current name over generic `tools` or `dotnet`.
+Scopes are more flexible when git-cliff excludes the commit, whether by type, scope, or `Changelog: ignore`. Keep the semantic type: an npm package feature may use `feat(npm): ...` because the scope suppresses it. For `chore`, `ci`, `style`, `refactor`, and `test`, use a concise target when useful, such as `openapi`, `deps`, `toolchain`, `package`, `agents`, `dependabot`, `miri`, `tokengen`, or `dotnet-utils`; omit the scope if none helps. Prefer a precise current name over generic `tools` or `dotnet`.
+Use `agents` for agent instructions and reusable skills.
 
 Use the established `chore(release): prepare for <version>` pattern when cutting a release.
 


### PR DESCRIPTION
Classify Conventional Commit types by affected surface so automation fixes remain `ci` and non-feature public API boundary changes use `fix`.

Standardize `agents` as the scope for agent instructions and reusable skills.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>