### PR TITLE
fix(webapp): restore hostname suggestion contrast

### DIFF
--- a/webapp/apps/gateway-ui/src/assets/css/override/_p-autocomplete.scss
+++ b/webapp/apps/gateway-ui/src/assets/css/override/_p-autocomplete.scss
@@ -9,7 +9,9 @@
     width: 100%;
   }
 
-  &.p-autocomplete-dd {
+  /* The dropdown button floats over the input, so the input keeps its
+     rounded corners instead of butting up against the button. */
+  &:has(.p-autocomplete-dropdown) {
     .p-autocomplete-input {
       padding-right: 2em;
       border-top-right-radius: $borderRadius;
@@ -21,18 +23,12 @@
         color: $input-txt-border-focus-color;
       }
     }
-
-    &.p-autocomplete-multiple {
-      .p-autocomplete-multiple-container {
-        padding-right: 2em;
-      }
-    }
   }
 
   .p-autocomplete-dropdown {
     width: 2em;
     background: transparent !important;
-    color: var(--p-select-dropdown-color);
+    color: var(--p-autocomplete-dropdown-color);
     border: 0 none;
     position: absolute;
     right: 0;
@@ -44,185 +40,63 @@
       color: $input-txt-border-focus-color;
     }
   }
-
-  &.p-autocomplete-multiple {
-    .p-autocomplete-multiple-container:not(.p-disabled).p-focus + .p-autocomplete-dropdown {
-      .pi {
-        color: $input-txt-border-focus-color;
-      }
-    }
-
-    .p-autocomplete-multiple-container {
-      padding: .429em;
-
-      &:not(.p-disabled):hover {
-        border-color: $input-txt-border-focus-color;
-      }
-
-      &:not(.p-disabled).p-focus {
-        border-color: $input-txt-border-focus-color;
-      }
-
-      .p-autocomplete-input-token {
-        padding: 0 .25em 0 0;
-        vertical-align: top;
-
-        input {
-          border: none;
-          color: $default-text-color;
-          font-family: $fontFamily;
-          font-size: $fontSize;
-          padding: 0;
-          margin: 0;
-        }
-      }
-
-      .p-autocomplete-token {
-        font-size: $fontSize;
-        padding-right: 8px;
-        line-height: 24px;
-        background: var(--input-chips-bg-color);
-        color: var(--input-chips-txt-color);
-        margin-right: 4px;
-        border-radius: 4px;
-        max-height: 24px;
-
-        & > div {
-          display: flex;
-          align-items: center;
-          padding: 3px;
-        }
-      }
-    }
-  }
 }
 
-.p-autocomplete-panel {
-  background-color: var(--main-body-bg);
+.p-autocomplete-overlay {
+  background: var(--main-body-bg);
   color: $dropdown-item-txt-color;
-  border: 1px solid $dropdown-overlay-border-color;
+  border: 1px solid $input-txt-border-focus-color;
   box-shadow: $defaultBoxShadow;
   margin-top: -1px; /* hack to simulate a thin line */
   border-radius: 0 0 $borderRadius $borderRadius;
 
   @include custom-scrollbar();
 
-  .p-autocomplete-items {
-    padding: 0;
-
-    .p-autocomplete-empty-message {
-      align-items: center;
-      display: flex;
-      height: 36px;
-      justify-content: flex-start;
-      padding-left: 10px;
-    }
-
-    .p-autocomplete-item {
-      align-items: center;
-      background: var(--main-body-bg);
-      display: flex;
-      margin: 0;
-      padding: $listItemPadding;
-      color: $default-text-color;
-      @include border-radius(0);
-
-      .user-or-group-container {
-        display: flex;
-        align-items: center;
-        padding: 5px 0;
-
-        label {
-          @include text-ellipsis();
-          width: 100%;
-          margin-left: 10px;
-          line-height: 1.6;
-          color: $grid-txt-color;
-        }
-      }
-    }
-
-    .p-autocomplete-item:hover, .p-autocomplete-item.p-highlight {
-      background-color: $dropdown-user-group-selected-bg-hover-color;
-      color: $default-text-color;
-    }
-  }
-}
-
-.p-fluid {
-  .p-autocomplete {
-    &.p-autocomplete-multiple.p-autocomplete-dd {
-      .p-autocomplete-multiple-container {
-        width: 100%;
-      }
-    }
-
-    &.p-autocomplete-dd {
-      .p-inputtext {
-        width: 100%;
-      }
-    }
-  }
-}
-
-.p-autocomplete.p-autocomplete-multiple {
-  display: block;
-
-  .p-inputtext {
-
-    input:hover,
-    input:active,
-    input:focus,
-    input:active:focus {
-      border: none !important;
-      transition: none !important;
-      box-shadow: none !important;
-    }
-  }
-
-  .p-autocomplete-token {
-    margin: 2px;
-
-    @include transition(ease-in-out background-color .15s, ease-in-out color .15s);
-
-    > div {
-      margin-right: 5px;
-    }
-
-    .p-autocomplete-token-icon {
-      font-size: 16px;
-      right: 3px;
-      vertical-align: middle;
-      color: var(--input-chips-icon-color);
-
-      @include transition(ease-in-out color .15s);
-    }
-
-    &:hover:not(:disabled) {
-      background-color: var(--input-chips-bg-hover-color);
-      color: var(--input-chips-txt-hover-color);
-
-      .p-autocomplete-token-icon {
-        color: var(--input-chips-icon-hover-color);
-      }
-    }
-
-    &:active:not(:disabled) {
-      background-color: var(--input-chips-bg-pressed-color);
-      color: var(--input-chips-txt-color);
-
-      .p-autocomplete-token-icon {
-        color: var(--input-chips-icon-color);
-      }
-    }
-  }
-
-  .p-autocomplete-multiple-container {
-    padding: 5px 0 5px 8px;
-    width: 100%;
-    max-height: 160px;
+  .p-autocomplete-list-container {
+    border-radius: 0 0 $borderRadius $borderRadius;
 
     @include custom-scrollbar();
+  }
+}
+
+.p-autocomplete-list {
+  background: var(--main-body-bg);
+  color: $dropdown-item-txt-color;
+  padding: 0;
+
+  .p-autocomplete-option {
+    align-items: center;
+    background: var(--main-body-bg);
+    color: $dropdown-item-txt-color;
+    display: flex;
+    margin: 0;
+    padding: $listItemPadding;
+
+    @include border-radius(0);
+
+    &.p-autocomplete-option-selected {
+      font-weight: 600;
+      background-color: $dropdown-item-selected-bg-color;
+      color: $dropdown-item-selected-txt-color;
+    }
+
+    &[data-p-focused='true'],
+    &.p-focus {
+      background-color: $dropdown-item-selected-bg-hover-color;
+      color: $dropdown-item-txt-color;
+    }
+
+    &:not(.p-autocomplete-option-selected):not(.p-disabled):hover {
+      background-color: $dropdown-item-selected-bg-hover-color;
+    }
+  }
+
+  .p-autocomplete-empty-message {
+    align-items: center;
+    display: flex;
+    height: 36px;
+    justify-content: flex-start;
+    padding-left: 10px;
   }
 }
 
@@ -232,29 +106,7 @@
     border-bottom-left-radius: 0 !important;
   }
 
-  .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
-  }
-
   .p-autocomplete-dropdown {
     border-color: $default-btn-bg-pressed-color;
   }
-}
-
-.p-autocomplete-option-selected {
-  background: $dropdown-item-selected-bg-color;
-  color: $dropdown-item-selected-txt-color;
-}
-
-.p-autocomplete-list {
-  background: var(--main-body-bg);
-  color: $dropdown-item-txt-color;
-}
-
-.p-autocomplete-overlay {
-  background: var(--main-body-bg);
-  color: $dropdown-item-txt-color;
-  border-radius: 0 0 $borderRadius $borderRadius;
-  border: 1px solid $input-txt-border-focus-color;
 }

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/web-client-form.component.html
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/web-client-form.component.html
@@ -54,15 +54,11 @@
                 <p-autoComplete
                   formControlName="autoComplete"
                   id="hostname"
-                  field="hostname"
                   optionLabel="hostname"
                   placeholder="Enter hostname"
                   [suggestions]="filteredHostnames"
                   [dropdown]="isHostnamesExists()"
                   (completeMethod)="filterHostname($event)"
-                  [overlayOptions]="{
-                    styleClass: 'dv-autocomplete-panel-open'
-                  }"
                   [appendTo]="'body'"
                   required
                 ></p-autoComplete>

--- a/webapp/apps/gateway-ui/src/client/app/styles/dvl.preset.ts
+++ b/webapp/apps/gateway-ui/src/client/app/styles/dvl.preset.ts
@@ -409,6 +409,73 @@ const DvlPreset = definePreset(Aura, {
       },
     },
 
+    autocomplete: {
+      root: {
+        background: 'var(--bg-100)',
+        disabledBackground: 'var(--bg-300)',
+        color: 'var(--text-400)',
+        disabledColor: 'var(--text-100)',
+        borderColor: 'var(--border-200)',
+        hoverBorderColor: 'var(--accent-brand-400)',
+        focusBorderColor: 'var(--accent-brand-300)',
+        invalidBorderColor: 'var(--accent-danger-400)',
+        borderRadius: '4px',
+        paddingX: '0.5rem',
+        paddingY: '0.375rem',
+        shadow: 'none',
+        transitionDuration: '0.2s',
+        placeholderColor: 'var(--text-100)',
+      },
+
+      dropdown: {
+        width: '2.5rem',
+        color: 'var(--text-200)',
+        hoverColor: 'var(--text-300)',
+        activeColor: 'var(--text-400)',
+        borderColor: 'var(--border-200)',
+        borderRadius: '4px',
+      },
+
+      overlay: {
+        background: 'var(--bg-200)',
+        color: 'var(--text-300)',
+        borderColor: 'var(--accent-brand-300)',
+        borderRadius: '4px',
+        shadow: '0 4px 6px var(--alt-600)',
+      },
+
+      list: {
+        padding: '0',
+        gap: '0',
+      },
+
+      option: {
+        color: 'var(--text-300)',
+        focusBackground: 'var(--border-contrast-brand-100)',
+        focusColor: 'var(--text-300)',
+        selectedBackground: 'var(--border-contrast-brand-200)',
+        selectedColor: 'var(--text-300)',
+        selectedFocusBackground: 'var(--border-contrast-brand-200)',
+        selectedFocusColor: 'var(--text-300)',
+        padding: '0.5rem 0.75rem',
+        borderRadius: '0',
+      },
+
+      optionGroup: {
+        background: 'var(--bg-200)',
+        color: 'var(--text-300)',
+        padding: '0.5rem 0.75rem',
+      },
+
+      chip: {
+        borderRadius: '4px',
+      },
+
+      emptyMessage: {
+        padding: '0.5rem 0.75rem',
+      },
+    },
+
     //
     // CARD / DIALOG
     //


### PR DESCRIPTION
The hostname suggestion list did not set its own text colour, so options were painted with whatever colour the PrimeNG theme supplied. When that colour was close to the panel background the suggestions were invisible until the pointer moved over them.

The styles meant to prevent this had been written against PrimeNG 18 class names and stopped matching anything when the app moved to PrimeNG 20. They are now ported to the current class names and the suggestion list is themed like every other dropdown, so options stay readable in both light and dark themes.

Issue: DGW-337