### PR TITLE
build(deps): bump cadeau and webm-iterable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "cadeau"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc663bd17ad2e21ad335c0d2c3fd51b341113c4165b8b5cc078dd15b97f3f9"
+checksum = "02884456f32df770744a0342e2c71aa06dadf62f383d03f89c08911f0d36dfaf"
 dependencies = [
  "xmf-sys",
 ]
@@ -2189,10 +2189,11 @@ dependencies = [
 
 [[package]]
 name = "ebml-iterable"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5173ac3752f08b526a6991509615e1a345b221ec3c58c7633433e8c9582312"
+checksum = "255f697fda61d9a3ea24ec21aa4a443d2380660e2cb138e7167d18891abb4daa"
 dependencies = [
+ "bytes 1.12.1",
  "ebml-iterable-specification",
  "ebml-iterable-specification-derive",
  "futures",
@@ -8800,9 +8801,9 @@ dependencies = [
 
 [[package]]
 name = "webm-iterable"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fbf173b4b38f2f8bbb0082a0d4cb21f263a70811f5fccb1663c421c66d9f9"
+checksum = "a2ebdc6faab4925edc7737bd0a04f9784f8b8e2cbb174aa523e94689575cd152"
 dependencies = [
  "ebml-iterable",
 ]
@@ -9562,9 +9563,9 @@ dependencies = [
 
 [[package]]
 name = "xmf-sys"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe719e326e963b00276c45c7d8a10567330106f48ea56ad25976b4be0e6caebc"
+checksum = "046fee6c2b1b7e4ae631265485f27436ebee39ff5229d532da08065bc8de9821"
 dependencies = [
  "dlib",
 ]

--- a/ci/download-cadeau.ps1
+++ b/ci/download-cadeau.ps1
@@ -9,7 +9,7 @@ param(
 	[ValidateSet('x64', 'arm64')]
 	[string] $Architecture,
 
-	[string] $VersionTag = "v2026.3.13.0"
+	[string] $VersionTag = "v2026.8.21.0"
 )
 
 $ErrorActionPreference = "Stop"

--- a/crates/video-streamer/Cargo.toml
+++ b/crates/video-streamer/Cargo.toml
@@ -24,11 +24,11 @@ tokio = { version = "1.52", features = [
 ] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing = "0.1"
-cadeau = { version = "0.5", features = ["dlopen"] }
+cadeau = { version = "0.5.2", features = ["dlopen"] }
 thiserror = "2"
 num_cpus = "1.17"
-ebml-iterable = "0.6"
-webm-iterable = "0.6"
+ebml-iterable = "0.7"
+webm-iterable = "0.7"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/devolutions-gateway/Cargo.toml
+++ b/devolutions-gateway/Cargo.toml
@@ -123,7 +123,7 @@ dlopen = "0.1"
 dlopen_derive = "0.1"
 
 # Video processing for session recording
-cadeau = { version = "0.5", features = ["dlopen"] }
+cadeau = { version = "0.5.2", features = ["dlopen"] }
 
 # Dependencies required for PCAP support
 # QUESTION: should we keep that built-in?


### PR DESCRIPTION
cadeau 0.5.2 ships VpxImage dimensions and xmf-sys 0.4.1.
webm-iterable 0.7.0 pulls crates.io ebml-iterable 0.7.0, which includes the incremental TagDecoder.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>