### PR TITLE
toolchain: install matching rust-analyzer

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.90.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Keep rust-analyzer aligned with each repository toolchain

The current rust-analyzer extension bundles a server that requires Rust 1.94 or newer. This minimum was [raised from 1.78 to 1.94](https://github.com/rust-lang/rust-analyzer/commit/f0d63081622929ed3ec29a2d3448d261053769c3), and the released code sets it to 1.94 at [`MINIMUM_SUPPORTED_TOOLCHAIN_VERSION`](https://github.com/rust-lang/rust-analyzer/blob/f0d63081622929ed3ec29a2d3448d261053769c3/crates/rust-analyzer/src/lib.rs#L24-L27).

These repositories intentionally pin older toolchains:

| Repository | Rust toolchain |
|---|---:|
| Gateway | 1.90.0 |
| picky-rs | 1.88.0 |

Opening either repository now triggers an incompatible-toolchain warning. This adds the official `rust-analyzer` component next to `rustfmt` and `clippy`:

```toml
components = ["rustfmt", "clippy", "rust-analyzer"]
```

The VS Code extension has an explicit [toolchain-server selection path](https://github.com/rust-lang/rust-analyzer/blob/12c3381f0b17b8eec21075d1c72fd010996a9bda/editors/code/src/bootstrap.ts#L58-L108). It calls `rustup which rust-analyzer` only when [`rust-analyzer` is declared in the repository toolchain file](https://github.com/rust-lang/rust-analyzer/blob/12c3381f0b17b8eec21075d1c72fd010996a9bda/editors/code/src/bootstrap.ts#L181-L192). Otherwise, it falls back to its newer bundled server.

### Why not install rust-analyzer locally?

Installing it is not enough. I already had the Rust 1.90 component installed for Gateway, but the extension did not select it because the repository did not declare it. The alternative is a machine-specific `rust-analyzer.server.path`, which every developer and editor would need to maintain separately.

### Why not downgrade the extension?

The extension version is global, but these Rust versions are repository-specific. Downgrading it for these repositories would also downgrade it for newer Rust workspaces. The extension also updates automatically, so this workaround requires disabling updates or repeatedly downgrading it.

### Why not upgrade the Rust toolchains?

That changes the compiler used by each repository and is much broader than fixing editor compatibility. Using the matching analyzer component preserves the existing compiler pins.

### Why should an editor tool be declared by the repository?

These toolchain files already declare the repository's development tools through `rustfmt` and `clippy`. `rust-analyzer` is also an official Rust component. Declaring it keeps the compiler/analyzer pairing in the same place instead of duplicating it in local editor settings.

### What is the tradeoff?

Rustup installs one additional development component in environments that honor the toolchain file. In return, contributors get a compatible analyzer automatically, without global extension downgrades or per-machine server configuration.

---

> **LLM Wrote, Irving Audited.**
