### PR TITLE
fix(webapp): fix type error in VNC form when the app run in non-secure context

### DIFF
--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
@@ -91,7 +91,7 @@ export class VncFormComponent extends BaseComponent implements OnInit {
       });
 
     // Enable the extended clipboard option only if the modern Clipboard API is available (`read` and `write` methods).
-    // But when running in no secure contexts, `navigator.clipboard` is undefined, so we need to check the secure context first.
+    // But when running in non-secure contexts, `navigator.clipboard` is undefined, so we need to check the secure context first.
     this.showExtendedClipboardCheckbox = window.isSecureContext && !!(navigator.clipboard.read && navigator.clipboard.write);
     // Enable the auto clipboard option only for Blink-based browsers (e.g., Chrome, Edge) running in secure context.
     this.showAutoClipboardCheckbox = new UAParser().getEngine().name === 'Blink' && window.isSecureContext;

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
@@ -90,8 +90,10 @@ export class VncFormComponent extends BaseComponent implements OnInit {
         error: (error) => console.error('Error fetching dropdown options', error),
       });
 
-    this.showExtendedClipboardCheckbox =
-      !!(navigator.clipboard.read && navigator.clipboard.write) && window.isSecureContext;
+    // Enable the extended clipboard option only if the modern Clipboard API is available (`read` and `write` methods).
+    // But when running in no secure contexts, `navigator.clipboard` is undefined, so we need to check the secure context first.
+    this.showExtendedClipboardCheckbox = window.isSecureContext && !!(navigator.clipboard.read && navigator.clipboard.write);
+    // Enable the auto clipboard option only for Blink-based browsers (e.g., Chrome, Edge) running in secure context.
     this.showAutoClipboardCheckbox = new UAParser().getEngine().name === 'Blink' && window.isSecureContext;
   }
 

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/vnc/vnc-form.component.ts
@@ -92,7 +92,8 @@ export class VncFormComponent extends BaseComponent implements OnInit {
 
     // Enable the extended clipboard option only if the modern Clipboard API is available (`read` and `write` methods).
     // But when running in non-secure contexts, `navigator.clipboard` is undefined, so we need to check the secure context first.
-    this.showExtendedClipboardCheckbox = window.isSecureContext && !!(navigator.clipboard.read && navigator.clipboard.write);
+    this.showExtendedClipboardCheckbox =
+      window.isSecureContext && !!(navigator.clipboard.read && navigator.clipboard.write);
     // Enable the auto clipboard option only for Blink-based browsers (e.g., Chrome, Edge) running in secure context.
     this.showAutoClipboardCheckbox = new UAParser().getEngine().name === 'Blink' && window.isSecureContext;
   }


### PR DESCRIPTION
I was able to hit this error when running the WebApp in a non-secure context.
<img width="438" height="382" alt="image" src="https://github.com/user-attachments/assets/14fa3802-99cf-460f-8a3b-3be41d869ebe" />
This PR fixes it. 

