### PR TITLE
feat(webapp): add option for ARD only input encryption

### DIFF
--- a/webapp/apps/gateway-ui/package.json
+++ b/webapp/apps/gateway-ui/package.json
@@ -29,7 +29,7 @@
     "@devolutions/icons": "^5.0.10",
     "@devolutions/iron-remote-desktop": "^0.11.0",
     "@devolutions/iron-remote-desktop-rdp": "^0.7.0",
-    "@devolutions/iron-remote-desktop-vnc": "../IronVNC/web-client/iron-remote-desktop-vnc/dist",
+    "@devolutions/iron-remote-desktop-vnc": "^0.7.0",
     "@devolutions/ldap-wasm-js": "^0.3.4",
     "@devolutions/terminal-shared": "^1.4.1",
     "@devolutions/web-active-directory-gui": "0.0.13",

--- a/webapp/apps/gateway-ui/package.json
+++ b/webapp/apps/gateway-ui/package.json
@@ -29,7 +29,7 @@
     "@devolutions/icons": "^5.0.10",
     "@devolutions/iron-remote-desktop": "^0.11.0",
     "@devolutions/iron-remote-desktop-rdp": "^0.7.0",
-    "@devolutions/iron-remote-desktop-vnc": "0.7.0",
+    "@devolutions/iron-remote-desktop-vnc": "../IronVNC/web-client/iron-remote-desktop-vnc/dist",
     "@devolutions/ldap-wasm-js": "^0.3.4",
     "@devolutions/terminal-shared": "^1.4.1",
     "@devolutions/web-active-directory-gui": "0.0.13",

--- a/webapp/apps/gateway-ui/package.json
+++ b/webapp/apps/gateway-ui/package.json
@@ -29,7 +29,7 @@
     "@devolutions/icons": "^5.0.10",
     "@devolutions/iron-remote-desktop": "^0.11.0",
     "@devolutions/iron-remote-desktop-rdp": "^0.7.0",
-    "@devolutions/iron-remote-desktop-vnc": "^0.7.0",
+    "@devolutions/iron-remote-desktop-vnc": "^0.7.2",
     "@devolutions/ldap-wasm-js": "^0.3.4",
     "@devolutions/terminal-shared": "^1.4.1",
     "@devolutions/web-active-directory-gui": "0.0.13",

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/ard/web-client-ard.component.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/ard/web-client-ard.component.ts
@@ -11,7 +11,13 @@ import { MessageService } from 'primeng/api';
 import { EMPTY, from, Observable, of } from 'rxjs';
 import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import '@devolutions/iron-remote-desktop/iron-remote-desktop.js';
-import { ardQualityMode, Backend, resolutionQuality, wheelSpeedFactor } from '@devolutions/iron-remote-desktop-vnc';
+import {
+  ardQualityMode,
+  Backend,
+  resolutionQuality,
+  wheelSpeedFactor,
+  ardOnlyInputEncryption,
+} from '@devolutions/iron-remote-desktop-vnc';
 import { DVL_ARD_ICON, JET_ARD_URL } from '@gateway/app.constants';
 import { AnalyticService, ProtocolString } from '@gateway/shared/services/analytic.service';
 import { WheelSpeedControl } from '@shared/components/floating-session-toolbar/models/floating-session-toolbar-config.model';
@@ -113,7 +119,15 @@ export class WebClientArdComponent
   }
 
   private fetchParameters(formData: ArdFormDataInput): Observable<IronARDConnectionParameters> {
-    const { hostname, username, password, resolutionQuality, ardQualityMode, wheelSpeedFactor = 1 } = formData;
+    const {
+      hostname,
+      username,
+      password,
+      resolutionQuality,
+      ardQualityMode,
+      wheelSpeedFactor = 1,
+      ardOnlyInputEncryption,
+    } = formData;
     const extractedData: ExtractedHostnamePort = this.utils.string.extractHostnameAndPort(hostname, DefaultArdPort);
 
     const sessionId: string = uuidv4();
@@ -132,6 +146,7 @@ export class WebClientArdComponent
       ardQualityMode,
       wheelSpeedFactor,
       sessionId,
+      ardOnlyInputEncryption,
     };
     return of(connectionParameters);
   }
@@ -157,6 +172,7 @@ export class WebClientArdComponent
       configBuilder.withExtension(ardQualityMode(connectionParameters.ardQualityMode));
     }
 
+    configBuilder.withExtension(ardOnlyInputEncryption(connectionParameters.ardOnlyInputEncryption));
     configBuilder.withExtension(wheelSpeedFactor(connectionParameters.wheelSpeedFactor));
 
     const config = configBuilder.build();

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/ard/web-client-ard.component.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/ard/web-client-ard.component.ts
@@ -12,11 +12,11 @@ import { EMPTY, from, Observable, of } from 'rxjs';
 import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import '@devolutions/iron-remote-desktop/iron-remote-desktop.js';
 import {
+  ardOnlyInputEncryption,
   ardQualityMode,
   Backend,
   resolutionQuality,
   wheelSpeedFactor,
-  ardOnlyInputEncryption,
 } from '@devolutions/iron-remote-desktop-vnc';
 import { DVL_ARD_ICON, JET_ARD_URL } from '@gateway/app.constants';
 import { AnalyticService, ProtocolString } from '@gateway/shared/services/analytic.service';

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/ard/ard-form.component.html
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-components/ard/ard-form.component.html
@@ -39,6 +39,11 @@
         </div>
       }
 
+      <div class="col-12 gateway-form-group">
+         <web-client-ard-only-input-encryption-control [parentForm]="form"
+                                          [inputFormData]="inputFormData"></web-client-ard-only-input-encryption-control>
+      </div>
+
   </div>
 
 </div>

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-controls/ard-only-input-encryption/ard-only-input-encryption-control.component.html
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-controls/ard-only-input-encryption/ard-only-input-encryption-control.component.html
@@ -1,0 +1,15 @@
+<div [formGroup]="parentForm">
+  <div class="gateway-form-input">
+    <p-checkbox
+      formControlName="ardOnlyInputEncryption"
+      inputId="ardOnlyInputEncryption"
+      [binary]="true"
+    ></p-checkbox>
+    <label
+      for="ardOnlyInputEncryption"
+      pTooltip="By default, we enable full ARD session encryption. This option forces only input encryption which improves performance."
+    >
+      ARD only Input Encryption
+    </label>
+  </div>
+</div>

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-controls/ard-only-input-encryption/ard-only-input-encryption.component.scss
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-controls/ard-only-input-encryption/ard-only-input-encryption.component.scss
@@ -1,0 +1,9 @@
+@use '../../../../../../../assets/css/style/mixins' as *;
+@use "../../../../../../../assets/css/style/variables" as *;
+@use "../../../../../../../assets/css/theme/theme-mode-variables" as *;
+
+.gateway-form-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-controls/ard-only-input-encryption/ard-only-input-encryption.component.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/form/form-controls/ard-only-input-encryption/ard-only-input-encryption.component.ts
@@ -1,0 +1,30 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+import { BaseComponent } from '@shared/bases/base.component';
+import { WebFormService } from '@shared/services/web-form.service';
+
+@Component({
+  standalone: false,
+  selector: 'web-client-ard-only-input-encryption-control',
+  templateUrl: 'ard-only-input-encryption-control.component.html',
+  styleUrls: ['ard-only-input-encryption.component.scss'],
+})
+export class ArdOnlyInputEncryptionComponent extends BaseComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+  @Input() inputFormData;
+
+  constructor(private formService: WebFormService) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.formService.addControlToForm({
+      formGroup: this.parentForm,
+      controlName: 'ardOnlyInputEncryption',
+      inputFormData: this.inputFormData,
+      isRequired: false,
+      defaultValue: false,
+    });
+  }
+}

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/web-client.module.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/web-client.module.ts
@@ -34,8 +34,8 @@ import { SharedModule } from '@shared/shared.module';
 import { CheckboxModule } from 'primeng/checkbox';
 import { KeyFilterModule } from 'primeng/keyfilter';
 import { WebClientActiveDirectoryComponent } from './active-directory/web-client-active-directory.component';
-import { ArdQualityModeControlComponent } from './form/form-controls/ard-quality-mode-control/ard-quality-mode-control.component';
 import { ArdOnlyInputEncryptionComponent } from './form/form-controls/ard-only-input-encryption/ard-only-input-encryption.component';
+import { ArdQualityModeControlComponent } from './form/form-controls/ard-quality-mode-control/ard-quality-mode-control.component';
 import { AutoClipboardControlComponent } from './form/form-controls/auto-clipboard-control/auto-clipboard-control.component';
 import { ColorFormatControlComponent } from './form/form-controls/color-format-control/color-format-control.component';
 // TODO: uncomment when adding support for iDRAC and VMWare

--- a/webapp/apps/gateway-ui/src/client/app/modules/web-client/web-client.module.ts
+++ b/webapp/apps/gateway-ui/src/client/app/modules/web-client/web-client.module.ts
@@ -35,6 +35,7 @@ import { CheckboxModule } from 'primeng/checkbox';
 import { KeyFilterModule } from 'primeng/keyfilter';
 import { WebClientActiveDirectoryComponent } from './active-directory/web-client-active-directory.component';
 import { ArdQualityModeControlComponent } from './form/form-controls/ard-quality-mode-control/ard-quality-mode-control.component';
+import { ArdOnlyInputEncryptionComponent } from './form/form-controls/ard-only-input-encryption/ard-only-input-encryption.component';
 import { AutoClipboardControlComponent } from './form/form-controls/auto-clipboard-control/auto-clipboard-control.component';
 import { ColorFormatControlComponent } from './form/form-controls/color-format-control/color-format-control.component';
 // TODO: uncomment when adding support for iDRAC and VMWare
@@ -114,6 +115,7 @@ const routes: Routes = [
     UltraVirtualDisplayControlComponent,
     ResolutionQualityControlComponent,
     ArdQualityModeControlComponent,
+    ArdOnlyInputEncryptionComponent,
     TabViewComponent,
     DynamicTabComponent,
     FileControlComponent,

--- a/webapp/apps/gateway-ui/src/client/app/shared/interfaces/connection-params.interfaces.ts
+++ b/webapp/apps/gateway-ui/src/client/app/shared/interfaces/connection-params.interfaces.ts
@@ -56,6 +56,7 @@ export interface IronARDConnectionParameters {
   ardQualityMode?: string;
   wheelSpeedFactor: number;
   sessionId?: string;
+  ardOnlyInputEncryption: boolean;
 }
 
 export interface TelnetConnectionParameters {

--- a/webapp/apps/gateway-ui/src/client/app/shared/interfaces/forms.interfaces.ts
+++ b/webapp/apps/gateway-ui/src/client/app/shared/interfaces/forms.interfaces.ts
@@ -68,6 +68,7 @@ export interface ArdFormDataInput {
   resolutionQuality: ResolutionQuality;
   ardQualityMode: ArdQualityMode;
   autoClipboard?: boolean;
+  ardOnlyInputEncryption: boolean;
 }
 
 export interface TelnetFormDataInput {

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@devolutions/iron-remote-desktop-vnc':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.7.2
+        version: 0.7.2
       '@devolutions/ldap-wasm-js':
         specifier: ^0.3.4
         version: 0.3.4
@@ -1360,8 +1360,8 @@ packages:
   '@devolutions/iron-remote-desktop-rdp@0.7.0':
     resolution: {integrity: sha512-CclAh4OS9aBoPJT0l7bih7ETOHPnB9KjT0drB0a6r5+Qh95pTEuQCx7uFN/XA2AlkFlrqx+DBAMDGYXmgsjHAQ==}
 
-  '@devolutions/iron-remote-desktop-vnc@0.7.0':
-    resolution: {integrity: sha512-fdxwJuBytLTdxrm6GrJ4po5ZI0bWP+yKNo4TZhKNRqkbRsUNOoqEK+9U1VwPYRlrTkrDryR57xeHRpxg/tDbOQ==, tarball: https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-vnc/-/@devolutions/iron-remote-desktop-vnc-0.7.0.tgz}
+  '@devolutions/iron-remote-desktop-vnc@0.7.2':
+    resolution: {integrity: sha512-gP2Bh/THC1y1Pe5jYdQ+YMx9MdarOugZ9H/xVhWNskTqfotdpw4pPhh9bROh60frbZX6EnQ92Y61/uZt/fUjKQ==, tarball: https://devolutions.jfrog.io/devolutions/api/npm/npm/@devolutions/iron-remote-desktop-vnc/-/@devolutions/iron-remote-desktop-vnc-0.7.2.tgz}
 
   '@devolutions/iron-remote-desktop@0.11.0':
     resolution: {integrity: sha512-ZH8xfabDA+6rAXkW2V3XgRdj0LHOsHoXAzars/H22DmKsHM39LdMfheKFUR3qLaFDM8mjf6DTFngzjgr+Byx0Q==}
@@ -8435,7 +8435,7 @@ snapshots:
 
   '@devolutions/iron-remote-desktop-rdp@0.7.0': {}
 
-  '@devolutions/iron-remote-desktop-vnc@0.7.0': {}
+  '@devolutions/iron-remote-desktop-vnc@0.7.2': {}
 
   '@devolutions/iron-remote-desktop@0.11.0': {}
 

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -67,7 +67,7 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@devolutions/iron-remote-desktop-vnc':
-        specifier: 0.7.0
+        specifier: ^0.7.0
         version: 0.7.0
       '@devolutions/ldap-wasm-js':
         specifier: ^0.3.4
@@ -4273,6 +4273,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'


### PR DESCRIPTION
The way it looks
<img width="1479" height="985" alt="image" src="https://github.com/user-attachments/assets/8ccf751c-bb93-49a9-b3bd-44edd9efdba0" />
