### PR TITLE
feat(installer): configure Agent Tunnel during setup

### DIFF
--- a/package/WindowsManaged/Actions/CustomActions.cs
+++ b/package/WindowsManaged/Actions/CustomActions.cs
@@ -329,6 +329,25 @@ namespace DevolutionsGateway.Actions
         }
 
         [CustomAction]
+        public static ActionResult ConfigureAgentTunnel(Session session)
+        {
+            string command;
+
+            try
+            {
+                command = $"$AgentTunnel = New-DGatewayAgentTunnelConfig -Enabled -ListenPort {session.Get(GatewayProperties.agentTunnelPort)}; Set-DGatewayConfig -AgentTunnel $AgentTunnel";
+                command = FormatPowerShellCommand(session, command);
+            }
+            catch (Exception e)
+            {
+                session.Log($"command {nameof(ConfigureAgentTunnel)} execution failure: {e}");
+                return ActionResult.Failure;
+            }
+
+            return ExecuteCommand(session, command);
+        }
+
+        [CustomAction]
         public static ActionResult ConfigurePublicKey(Session session)
         {
             string command;

--- a/package/WindowsManaged/Actions/GatewayActions.cs
+++ b/package/WindowsManaged/Actions/GatewayActions.cs
@@ -327,13 +327,27 @@ internal static class GatewayActions
         },
         new[] { GatewayProperties.configureNgrok.Equal(true) });
 
+    private static readonly ElevatedManagedAction configureAgentTunnel = BuildConfigureAction(
+        $"CA.{nameof(configureAgentTunnel)}",
+        CustomActions.ConfigureAgentTunnel,
+        When.After, new Step(configureNgrokListeners.Id),
+        new IWixProperty[]
+        {
+            GatewayProperties.agentTunnelPort,
+        },
+        new[]
+        {
+            GatewayProperties.firstInstall.Equal(true),
+            GatewayProperties.enableAgentTunnel.Equal(true)
+        });
+
     /// <summary>
     /// Configure the certificate using PowerShell
     /// </summary>
     private static readonly ElevatedManagedAction configureCertificate = BuildConfigureAction(
         $"CA.{nameof(configureCertificate)}",
         CustomActions.ConfigureCertificate,
-        When.After, new Step(configureNgrokListeners.Id),
+        When.After, new Step(configureAgentTunnel.Id),
         new IWixProperty[]
         {
             GatewayProperties.certificateMode,
@@ -534,9 +548,10 @@ internal static class GatewayActions
         configureInit,
         configureAccessUri,
         configureListeners,
+        configureNgrokListeners,
+        configureAgentTunnel,
         configureCertificate,
         setCertificatePrivateKeyPermissions,
-        configureNgrokListeners,
         configurePublicKey,
         configureWebApp,
         configureWebAppUser,

--- a/package/WindowsManaged/Dialogs/CustomizeDialog.Designer.cs
+++ b/package/WindowsManaged/Dialogs/CustomizeDialog.Designer.cs
@@ -38,6 +38,10 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.gbConfigure = new System.Windows.Forms.GroupBox();
             this.tableLayoutPanel3 = new System.Windows.Forms.TableLayoutPanel();
+            this.chkEnableAgentTunnel = new System.Windows.Forms.CheckBox();
+            this.flowAgentTunnelPort = new System.Windows.Forms.FlowLayoutPanel();
+            this.lblAgentTunnelPort = new System.Windows.Forms.Label();
+            this.txtAgentTunnelPort = new System.Windows.Forms.TextBox();
             this.chkWebApp = new System.Windows.Forms.CheckBox();
             this.chkGenerateCertificate = new System.Windows.Forms.CheckBox();
             this.chkGenerateKeyPair = new System.Windows.Forms.CheckBox();
@@ -62,6 +66,7 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel2.SuspendLayout();
             this.gbConfigure.SuspendLayout();
             this.tableLayoutPanel3.SuspendLayout();
+            this.flowAgentTunnelPort.SuspendLayout();
             this.topPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).BeginInit();
             this.bottomPanel.SuspendLayout();
@@ -130,15 +135,18 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel3.ColumnCount = 2;
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tableLayoutPanel3.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel3.Controls.Add(this.chkWebApp, 0, 2);
-            this.tableLayoutPanel3.Controls.Add(this.chkGenerateCertificate, 0, 3);
-            this.tableLayoutPanel3.Controls.Add(this.chkGenerateKeyPair, 0, 4);
+            this.tableLayoutPanel3.Controls.Add(this.chkEnableAgentTunnel, 0, 1);
+            this.tableLayoutPanel3.Controls.Add(this.flowAgentTunnelPort, 0, 2);
+            this.tableLayoutPanel3.Controls.Add(this.chkWebApp, 0, 3);
+            this.tableLayoutPanel3.Controls.Add(this.chkGenerateCertificate, 0, 4);
+            this.tableLayoutPanel3.Controls.Add(this.chkGenerateKeyPair, 0, 5);
             this.tableLayoutPanel3.Controls.Add(this.chkConfigureNgrok, 0, 0);
             this.tableLayoutPanel3.Controls.Add(this.lnkNgrok, 1, 0);
             this.tableLayoutPanel3.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel3.Location = new System.Drawing.Point(3, 16);
             this.tableLayoutPanel3.Name = "tableLayoutPanel3";
-            this.tableLayoutPanel3.RowCount = 6;
+            this.tableLayoutPanel3.RowCount = 7;
+            this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -147,6 +155,53 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel3.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel3.Size = new System.Drawing.Size(458, 146);
             this.tableLayoutPanel3.TabIndex = 0;
+            //
+            // chkEnableAgentTunnel
+            //
+            this.chkEnableAgentTunnel.AutoSize = true;
+            this.tableLayoutPanel3.SetColumnSpan(this.chkEnableAgentTunnel, 2);
+            this.chkEnableAgentTunnel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.chkEnableAgentTunnel.Enabled = false;
+            this.chkEnableAgentTunnel.Location = new System.Drawing.Point(10, 26);
+            this.chkEnableAgentTunnel.Margin = new System.Windows.Forms.Padding(10, 3, 3, 3);
+            this.chkEnableAgentTunnel.Name = "chkEnableAgentTunnel";
+            this.chkEnableAgentTunnel.Size = new System.Drawing.Size(445, 17);
+            this.chkEnableAgentTunnel.TabIndex = 2;
+            this.chkEnableAgentTunnel.Text = "[EnableAgentTunnel]";
+            this.chkEnableAgentTunnel.UseVisualStyleBackColor = true;
+            this.chkEnableAgentTunnel.CheckedChanged += new System.EventHandler(this.chkEnableAgentTunnel_CheckedChanged);
+            //
+            // flowAgentTunnelPort
+            //
+            this.flowAgentTunnelPort.AutoSize = true;
+            this.tableLayoutPanel3.SetColumnSpan(this.flowAgentTunnelPort, 2);
+            this.flowAgentTunnelPort.Controls.Add(this.lblAgentTunnelPort);
+            this.flowAgentTunnelPort.Controls.Add(this.txtAgentTunnelPort);
+            this.flowAgentTunnelPort.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.flowAgentTunnelPort.Location = new System.Drawing.Point(30, 46);
+            this.flowAgentTunnelPort.Margin = new System.Windows.Forms.Padding(30, 0, 3, 0);
+            this.flowAgentTunnelPort.Name = "flowAgentTunnelPort";
+            this.flowAgentTunnelPort.Size = new System.Drawing.Size(425, 26);
+            this.flowAgentTunnelPort.TabIndex = 3;
+            this.flowAgentTunnelPort.WrapContents = false;
+            //
+            // lblAgentTunnelPort
+            //
+            this.lblAgentTunnelPort.AutoSize = true;
+            this.lblAgentTunnelPort.Location = new System.Drawing.Point(0, 6);
+            this.lblAgentTunnelPort.Margin = new System.Windows.Forms.Padding(0, 6, 3, 0);
+            this.lblAgentTunnelPort.Name = "lblAgentTunnelPort";
+            this.lblAgentTunnelPort.Size = new System.Drawing.Size(54, 13);
+            this.lblAgentTunnelPort.TabIndex = 0;
+            this.lblAgentTunnelPort.Text = "[AgentTunnelUdpPort]";
+            //
+            // txtAgentTunnelPort
+            //
+            this.txtAgentTunnelPort.Enabled = false;
+            this.txtAgentTunnelPort.Location = new System.Drawing.Point(60, 3);
+            this.txtAgentTunnelPort.Name = "txtAgentTunnelPort";
+            this.txtAgentTunnelPort.Size = new System.Drawing.Size(50, 20);
+            this.txtAgentTunnelPort.TabIndex = 1;
             // 
             // chkWebApp
             // 
@@ -154,11 +209,11 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel3.SetColumnSpan(this.chkWebApp, 2);
             this.chkWebApp.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkWebApp.Enabled = false;
-            this.chkWebApp.Location = new System.Drawing.Point(10, 26);
+            this.chkWebApp.Location = new System.Drawing.Point(10, 75);
             this.chkWebApp.Margin = new System.Windows.Forms.Padding(10, 3, 3, 3);
             this.chkWebApp.Name = "chkWebApp";
             this.chkWebApp.Size = new System.Drawing.Size(445, 17);
-            this.chkWebApp.TabIndex = 2;
+            this.chkWebApp.TabIndex = 4;
             this.chkWebApp.Text = "[EnableTheGatewayWebInterface]";
             this.chkWebApp.UseVisualStyleBackColor = true;
             this.chkWebApp.CheckedChanged += new System.EventHandler(this.chkWebApp_CheckedChanged);
@@ -169,11 +224,11 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel3.SetColumnSpan(this.chkGenerateCertificate, 2);
             this.chkGenerateCertificate.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkGenerateCertificate.Enabled = false;
-            this.chkGenerateCertificate.Location = new System.Drawing.Point(30, 49);
+            this.chkGenerateCertificate.Location = new System.Drawing.Point(30, 98);
             this.chkGenerateCertificate.Margin = new System.Windows.Forms.Padding(30, 3, 3, 3);
             this.chkGenerateCertificate.Name = "chkGenerateCertificate";
             this.chkGenerateCertificate.Size = new System.Drawing.Size(425, 17);
-            this.chkGenerateCertificate.TabIndex = 3;
+            this.chkGenerateCertificate.TabIndex = 5;
             this.chkGenerateCertificate.Text = "[GenerateASelfSignedHttpsCertificate]";
             this.chkGenerateCertificate.UseVisualStyleBackColor = true;
             // 
@@ -183,11 +238,11 @@ namespace WixSharpSetup.Dialogs
             this.tableLayoutPanel3.SetColumnSpan(this.chkGenerateKeyPair, 2);
             this.chkGenerateKeyPair.Dock = System.Windows.Forms.DockStyle.Fill;
             this.chkGenerateKeyPair.Enabled = false;
-            this.chkGenerateKeyPair.Location = new System.Drawing.Point(30, 72);
+            this.chkGenerateKeyPair.Location = new System.Drawing.Point(30, 121);
             this.chkGenerateKeyPair.Margin = new System.Windows.Forms.Padding(30, 3, 3, 3);
             this.chkGenerateKeyPair.Name = "chkGenerateKeyPair";
             this.chkGenerateKeyPair.Size = new System.Drawing.Size(425, 17);
-            this.chkGenerateKeyPair.TabIndex = 4;
+            this.chkGenerateKeyPair.TabIndex = 6;
             this.chkGenerateKeyPair.Text = "[GenerateEncryptionKeys]";
             this.chkGenerateKeyPair.UseVisualStyleBackColor = true;
             // 
@@ -405,6 +460,8 @@ namespace WixSharpSetup.Dialogs
             this.gbConfigure.ResumeLayout(false);
             this.tableLayoutPanel3.ResumeLayout(false);
             this.tableLayoutPanel3.PerformLayout();
+            this.flowAgentTunnelPort.ResumeLayout(false);
+            this.flowAgentTunnelPort.PerformLayout();
             this.topPanel.ResumeLayout(false);
             this.topPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.banner)).EndInit();
@@ -432,6 +489,10 @@ namespace WixSharpSetup.Dialogs
         private System.Windows.Forms.Panel topBorder;
         private System.Windows.Forms.Panel middlePanel;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
+        private System.Windows.Forms.CheckBox chkEnableAgentTunnel;
+        private System.Windows.Forms.FlowLayoutPanel flowAgentTunnelPort;
+        private System.Windows.Forms.Label lblAgentTunnelPort;
+        private System.Windows.Forms.TextBox txtAgentTunnelPort;
         private System.Windows.Forms.CheckBox chkWebApp;
         private System.Windows.Forms.GroupBox gbConfigure;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel3;

--- a/package/WindowsManaged/Dialogs/CustomizeDialog.cs
+++ b/package/WindowsManaged/Dialogs/CustomizeDialog.cs
@@ -25,6 +25,8 @@ public partial class CustomizeDialog : GatewayDialog
     {
         GatewayProperties properties = new(this.Runtime.Session);
         this.cmbConfigure.SelectedIndex = properties.ConfigureGateway ? 0 : 1;
+        this.chkEnableAgentTunnel.Checked = properties.EnableAgentTunnel;
+        this.txtAgentTunnelPort.Text = properties.AgentTunnelPort.ToString();
         this.chkConfigureNgrok.Checked = properties.ConfigureNgrok;
         this.chkWebApp.Checked = properties.ConfigureWebApp;
         this.chkGenerateCertificate.Checked = properties.GenerateCertificate;
@@ -33,12 +35,28 @@ public partial class CustomizeDialog : GatewayDialog
         this.SetControlStates();
     }
 
+    public override bool DoValidate()
+    {
+        if (this.ConfigureNow && this.chkEnableAgentTunnel.Checked &&
+            (string.IsNullOrWhiteSpace(this.txtAgentTunnelPort.Text) || !Validation.IsValidPort(this.txtAgentTunnelPort.Text, out _)))
+        {
+            ShowValidationError(I18n(Strings.YouMustEnterAValidPort));
+            return false;
+        }
+
+        return true;
+    }
+
     public override bool ToProperties()
     {
         new GatewayProperties(this.Runtime.Session)
         {
             ConfigureGateway = this.ConfigureNow,
             ConfigureNgrok = this.ConfigureNow && this.chkConfigureNgrok.Checked,
+            EnableAgentTunnel = this.ConfigureNow && this.chkEnableAgentTunnel.Checked,
+            AgentTunnelPort = Validation.IsValidPort(this.txtAgentTunnelPort.Text, out uint agentTunnelPort)
+                ? agentTunnelPort
+                : GatewayProperties.agentTunnelPort.Default,
             ConfigureWebApp = this.ConfigureNow && this.chkWebApp.Checked,
             GenerateCertificate = this.ConfigureNow && this.chkGenerateCertificate.Checked && !this.chkConfigureNgrok.Checked,
             GenerateKeyPair = this.ConfigureNow && this.chkGenerateKeyPair.Checked,
@@ -73,6 +91,8 @@ public partial class CustomizeDialog : GatewayDialog
     private void SetControlStates()
     {
         this.chkConfigureNgrok.Enabled = this.ConfigureNow;
+        this.chkEnableAgentTunnel.Enabled = this.ConfigureNow;
+        this.txtAgentTunnelPort.Enabled = this.chkEnableAgentTunnel.Checked && this.chkEnableAgentTunnel.Enabled;
         this.chkWebApp.Enabled = this.ConfigureNow;
 
         this.chkGenerateCertificate.Enabled = this.chkWebApp.Checked && this.chkWebApp.Enabled && !this.chkConfigureNgrok.Checked;
@@ -115,6 +135,11 @@ public partial class CustomizeDialog : GatewayDialog
         {
             this.chkGenerateCertificate.Checked = false;
         }
+    }
+
+    private void chkEnableAgentTunnel_CheckedChanged(object sender, EventArgs e)
+    {
+        this.SetControlStates();
     }
 
     private void cmbConfigure_SelectedIndexChanged(object sender, EventArgs e)

--- a/package/WindowsManaged/Dialogs/SummaryDialog.cs
+++ b/package/WindowsManaged/Dialogs/SummaryDialog.cs
@@ -170,6 +170,17 @@ public partial class SummaryDialog : GatewayDialog
 
         new PropertyGroup()
         {
+            Name = Strings.Group_AgentTunnel,
+            If = p => p.EnableAgentTunnel,
+            Properties = new IProperty[]
+            {
+                new InstallerProperty(this.MsiRuntime, GatewayProperties.enableAgentTunnel),
+                new InstallerProperty(this.MsiRuntime, GatewayProperties.agentTunnelPort)
+            }
+        },
+
+        new PropertyGroup()
+        {
             Name = Strings.Group_EncryptionKeys,
             If = Always,
             Properties = new IProperty[]

--- a/package/WindowsManaged/Properties/GatewayProperties.g.cs
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.cs
@@ -518,6 +518,63 @@ namespace DevolutionsGateway.Properties
         }
 
  
+        internal static readonly WixProperty<Boolean> enableAgentTunnel = new()
+        {
+            Id = "P.ENABLEAGENTTUNNEL",
+            Default = false,
+            Name = "EnableAgentTunnel",
+            Secure = true,
+            Hidden = false,
+            Public = true,
+            Encode = false,
+        };
+
+        /// <summary>`true` to enable Agent Tunnel</summary>
+        public Boolean EnableAgentTunnel
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(enableAgentTunnel.Id);
+                return WixProperties.GetPropertyValue<Boolean>(stringValue);
+            }
+            set
+            {
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(enableAgentTunnel, value);
+                }
+            }
+        }
+
+
+        internal static readonly WixProperty<UInt32> agentTunnelPort = new()
+        {
+            Id = "P.AGENTTUNNELPORT",
+            Default = 4433,
+            Name = "AgentTunnelPort",
+            Secure = true,
+            Hidden = false,
+            Public = true,
+            Encode = false,
+        };
+
+        public UInt32 AgentTunnelPort
+        {
+            get
+            {
+                string stringValue = this.FnGetPropValue(agentTunnelPort.Id);
+                return WixProperties.GetPropertyValue<UInt32>(stringValue);
+            }
+            set
+            {
+                if (this.runtimeSession is not null)
+                {
+                    this.runtimeSession.Set(agentTunnelPort, value);
+                }
+            }
+        }
+
+
         internal static readonly WixProperty<Boolean> hasPowerShell = new()
         {
             Id = "P.HasPowerShell",
@@ -1522,6 +1579,12 @@ namespace DevolutionsGateway.Properties
             configureGateway,
  
  
+            enableAgentTunnel,
+
+
+            agentTunnelPort,
+
+
             hasPowerShell,
  
  

--- a/package/WindowsManaged/Properties/GatewayProperties.g.tt
+++ b/package/WindowsManaged/Properties/GatewayProperties.g.tt
@@ -271,6 +271,8 @@ namespace DevolutionsGateway.Properties
     new PropertyDefinition<string>("DevolutionsServerCertificateExceptions", "", isPublic: true, hidden: false, secure: true, encode: true),
 
     new PropertyDefinition<bool>("ConfigureGateway", false, secure: false, comment: "`true` to configure the Gateway interactively"),    
+    new PropertyDefinition<bool>("EnableAgentTunnel", false, comment: "`true` to enable Agent Tunnel"),
+    new PropertyDefinition<uint>("AgentTunnelPort", 4433),
     new PropertyDefinition<bool>("HasPowerShell", false, isPublic: false, secure: false),
 
     new PropertyDefinition<string>("HttpListenerHost", "0.0.0.0"),

--- a/package/WindowsManaged/Resources/DevolutionsGateway_de-de.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_de-de.wxl
@@ -49,6 +49,7 @@
                 <String Id="ViewErrorsButton">Konfigurationsprobleme anzeigen</String>
                 <String Id="ViewLogButton">Protokoll anzeigen</String>
                     <!-- propertyGroups -->
+                <String Id="Group_AgentTunnel">Agent Tunnel</String>
                 <String Id="Group_Certificate">Zertifikat</String>
                 <String Id="Group_EncryptionKeys">Verschlüsselungsschlüssel</String>
                 <String Id="Group_ExternalAccess">Externer Zugriff</String>
@@ -94,6 +95,7 @@
                 <String Id="StoreName_TrustedPublisher">Vertrauenswürdige Herausgeber</String>
                     <!-- properties -->
                 <String Id="Property_AccessUri">Zugriffs-URI</String>
+                <String Id="Property_AgentTunnelPort">UDP-Port</String>
                 <String Id="Property_AuthenticationMode">Authentifizierungsmodus</String>
                 <String Id="Property_CertificateFile">Zertifikatsdatei</String>
                 <String Id="Property_CertificateLocation">Zertifikatort</String>
@@ -104,6 +106,7 @@
                 <String Id="Property_CertificateStore">Zertifikatspeicher</String>
                 <String Id="Property_DevolutionsServerUrl">Devolutions Server-URL</String>
                 <String Id="Property_Directory">Verzeichnis</String>
+                <String Id="Property_EnableAgentTunnel">Aktiviert</String>
                 <String Id="Property_HttpListener">HTTP-Listener</String>
                 <String Id="Property_NewCertificate">Ein neues selbstsigniertes Zertifikat wird generiert</String>
                 <String Id="Property_NewKeyPair">Ein neues Schlüsselpaar wird generiert</String>
@@ -152,12 +155,14 @@ Wenn sie minimiert erscheint, aktivieren Sie sie über die Taskleiste.</String>
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Willkommen beim Setup-Assistenten für [ProductName] 20[ProductVersion]</String>
                     <!-- dialogs.customize -->
+                <String Id="AgentTunnelUdpPort">UDP-Port</String>
                 <String Id="ConfigurationOptions">Konfigurationsoptionen</String>
                 <String Id="ConfigureTheGatewayInstallation">Gateway-Installation konfigurieren</String>
                 <String Id="CustomInstallDlgDescription">Wählen Sie, wie [ProductName] konfiguriert werden soll.</String>
                 <String Id="CustomInstallDlgInfoLabel">Der Setup-Assistent generiert eine Konfiguration, die Sie später aktualisieren können; oder Sie können die Konfigurationsinformationen jetzt angeben.</String>
                 <String Id="CustomInstallDlgTitle">Konfiguration</String>
                 <String Id="EnableAccessOverTheInternetUsingNgrok">Internetzugriff über ngrok aktivieren</String>
+                <String Id="EnableAgentTunnel">Agent Tunnel aktivieren</String>
                 <String Id="EnableTheGatewayWebInterface">Gateway-Weboberfläche aktivieren</String>
                 <String Id="GenerateASelfSignedHttpsCertificate">Selbstsigniertes HTTPS-Zertifikat generieren</String>
                 <String Id="GenerateEncryptionKeys">Verschlüsselungsschlüssel generieren</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_en-us.wxl
@@ -49,6 +49,7 @@
                 <String Id="ViewErrorsButton">View configuration issues</String>
                 <String Id="ViewLogButton">View Log</String>
                     <!-- propertyGroups -->
+                <String Id="Group_AgentTunnel">Agent Tunnel</String>
                 <String Id="Group_Certificate">Certificate</String>
                 <String Id="Group_EncryptionKeys">Encryption Keys</String>
                 <String Id="Group_ExternalAccess">External Access</String>
@@ -94,6 +95,7 @@
                 <String Id="StoreName_TrustedPublisher">Trusted Publishers</String>
                     <!-- properties -->
                 <String Id="Property_AccessUri">Access URI</String>
+                <String Id="Property_AgentTunnelPort">UDP Port</String>
                 <String Id="Property_AuthenticationMode">Authentication Mode</String>
                 <String Id="Property_CertificateFile">Certificate File</String>
                 <String Id="Property_CertificateLocation">Certificate Location</String>
@@ -104,6 +106,7 @@
                 <String Id="Property_CertificateStore">Certificate Store</String>
                 <String Id="Property_DevolutionsServerUrl">Devolutions Server URL</String>
                 <String Id="Property_Directory">Directory</String>
+                <String Id="Property_EnableAgentTunnel">Enabled</String>
                 <String Id="Property_HttpListener">HTTP Listener</String>
                 <String Id="Property_NewCertificate">A new self-signed certificate will be generated</String>
                 <String Id="Property_NewKeyPair">A new key pair will be generated</String>
@@ -152,12 +155,14 @@ If it appears minimized then active it from the taskbar.</String>
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Welcome to the [ProductName] 20[ProductVersion] Setup Wizard</String>
                     <!-- dialogs.customize -->
+                <String Id="AgentTunnelUdpPort">UDP port</String>
                 <String Id="ConfigurationOptions">Configuration Options</String>
                 <String Id="ConfigureTheGatewayInstallation">Configure the Gateway installation</String>
                 <String Id="CustomInstallDlgDescription">Choose how to configure [ProductName].</String>
                 <String Id="CustomInstallDlgInfoLabel">The Setup Wizard will generate a configuration which you can update later; or you can provide configuration information now.</String>
                 <String Id="CustomInstallDlgTitle">Configuration</String>
                 <String Id="EnableAccessOverTheInternetUsingNgrok">Enable access over the internet using ngrok</String>
+                <String Id="EnableAgentTunnel">Enable Agent Tunnel</String>
                 <String Id="EnableTheGatewayWebInterface">Enable the Gateway web interface</String>
                 <String Id="GenerateASelfSignedHttpsCertificate">Generate a self-signed HTTPS certificate</String>
                 <String Id="GenerateEncryptionKeys">Generate encryption keys</String>

--- a/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
+++ b/package/WindowsManaged/Resources/DevolutionsGateway_fr-fr.wxl
@@ -84,6 +84,7 @@
                 <String Id="YouMustProvideAValidHostname">Vous devez fournir un nom d'hôte valide</String>
                 <String Id="YouMustSelectACertificateFromTheSystemCertificateStore">Vous devez sélectionner un certificat dans le magasin de certificats du système</String>
                     <!-- propertyGroups -->
+                <String Id="Group_AgentTunnel">Agent Tunnel</String>
                 <String Id="Group_Certificate">Certificat</String>
                 <String Id="Group_EncryptionKeys">Clés de chiffrement</String>
                 <String Id="Group_ExternalAccess">Accès externe</String>
@@ -94,6 +95,7 @@
                 <String Id="Group_WebApp">Application Web</String>
                     <!-- properties -->
                 <String Id="Property_AccessUri">URI d'accès</String>
+                <String Id="Property_AgentTunnelPort">Port UDP</String>
                 <String Id="Property_AuthenticationMode">Mode authentification</String>
                 <String Id="Property_CertificateFile">Fichier de certificat</String>
                 <String Id="Property_CertificateLocation">Emplacement du certificat</String>
@@ -104,6 +106,7 @@
                 <String Id="Property_CertificateStore">Magasin de certificats</String>
                 <String Id="Property_DevolutionsServerUrl">URL du Devolutions Server</String>
                 <String Id="Property_Directory">Répertoire</String>
+                <String Id="Property_EnableAgentTunnel">Activé</String>
                 <String Id="Property_HttpListener">Écouteur HTTP</String>
                 <String Id="Property_NewCertificate">Un nouveau certificat autosigné sera généré</String>
                 <String Id="Property_NewKeyPair">Une nouvelle paire de clés sera générée</String>
@@ -170,12 +173,14 @@ Si elle apparaît en mode réduit, alors vous devez l'activer à partir de la ba
                     <!-- dialogs.welcome -->
                 <String Id="WelcomeDlgTitle">Bienvenue dans l'assistant d'installation de [ProductName] 20[ProductVersion]</String>
                     <!-- dialogs.customize -->
+                <String Id="AgentTunnelUdpPort">Port UDP</String>
                 <String Id="ConfigurationOptions">Options de configuration</String>
                 <String Id="ConfigureTheGatewayInstallation">Configurer l'installation de Gateway</String>
                 <String Id="CustomInstallDlgDescription">Veuillez choisir comment configurer [ProductName].</String>
                 <String Id="CustomInstallDlgInfoLabel">L'assistant d'installation va générer une configuration minimale à finaliser plus tard, ou vous pouvez compléter la configuration maintenant.</String>
                 <String Id="CustomInstallDlgTitle">Configuration</String>
                 <String Id="EnableAccessOverTheInternetUsingNgrok">Autoriser l'accès Web via ngrok.</String>
+                <String Id="EnableAgentTunnel">Activer Agent Tunnel</String>
                 <String Id="EnableTheGatewayWebInterface">Activer l'interface Web de Gateway</String>
                 <String Id="GenerateASelfSignedHttpsCertificate">Générer un certificat HTTPS autosigné</String>
                 <String Id="GenerateEncryptionKeys">Générer des clés de chiffrement</String>

--- a/package/WindowsManaged/Resources/Strings.g.cs
+++ b/package/WindowsManaged/Resources/Strings.g.cs
@@ -197,6 +197,10 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string Group_Ngrok = "Group_Ngrok";		
 		/// <summary>
+		/// Agent Tunnel
+		/// </summary>
+		public const string Group_AgentTunnel = "Group_AgentTunnel";
+		/// <summary>
 		/// External Access
 		/// </summary>
 		public const string Group_ExternalAccess = "Group_ExternalAccess";		
@@ -417,6 +421,14 @@ namespace DevolutionsGateway.Resources
 		/// </summary>
 		public const string Property_NgrokRemoteAddress = "Property_NgrokRemoteAddress";		
 		/// <summary>
+		/// Enabled
+		/// </summary>
+		public const string Property_EnableAgentTunnel = "Property_EnableAgentTunnel";
+		/// <summary>
+		/// UDP Port
+		/// </summary>
+		public const string Property_AgentTunnelPort = "Property_AgentTunnelPort";
+		/// <summary>
 		/// Directory
 		/// </summary>
 		public const string Property_Directory = "Property_Directory";		
@@ -576,6 +588,14 @@ namespace DevolutionsGateway.Resources
 		/// Enable access over the internet using ngrok
 		/// </summary>
 		public const string EnableAccessOverTheInternetUsingNgrok = "EnableAccessOverTheInternetUsingNgrok";		
+		/// <summary>
+		/// Enable Agent Tunnel
+		/// </summary>
+		public const string EnableAgentTunnel = "EnableAgentTunnel";
+		/// <summary>
+		/// UDP port
+		/// </summary>
+		public const string AgentTunnelUdpPort = "AgentTunnelUdpPort";
 		/// <summary>
 		/// Enable the Gateway web interface
 		/// </summary>

--- a/package/WindowsManaged/Resources/Strings_de-DE.json
+++ b/package/WindowsManaged/Resources/Strings_de-DE.json
@@ -199,6 +199,10 @@
           "text": "ngrok"
         },
         {
+          "id": "Group_AgentTunnel",
+          "text": "Agent Tunnel"
+        },
+        {
           "id": "Group_ExternalAccess",
           "text": "Externer Zugriff"
         },
@@ -423,6 +427,14 @@
           "text": "TCP-Adresse"
         },
         {
+          "id": "Property_EnableAgentTunnel",
+          "text": "Aktiviert"
+        },
+        {
+          "id": "Property_AgentTunnelPort",
+          "text": "UDP-Port"
+        },
+        {
           "id": "Property_Directory",
           "text": "Verzeichnis"
         },
@@ -601,6 +613,14 @@
           {
             "id": "EnableAccessOverTheInternetUsingNgrok",
             "text": "Internetzugriff über ngrok aktivieren"
+          },
+          {
+            "id": "EnableAgentTunnel",
+            "text": "Agent Tunnel aktivieren"
+          },
+          {
+            "id": "AgentTunnelUdpPort",
+            "text": "UDP-Port"
           },
           {
             "id": "EnableTheGatewayWebInterface",

--- a/package/WindowsManaged/Resources/Strings_en-US.json
+++ b/package/WindowsManaged/Resources/Strings_en-US.json
@@ -199,6 +199,10 @@
           "text": "ngrok"
         },
         {
+          "id": "Group_AgentTunnel",
+          "text": "Agent Tunnel"
+        },
+        {
           "id": "Group_ExternalAccess",
           "text": "External Access"
         },
@@ -423,6 +427,14 @@
           "text": "TCP Address"
         },
         {
+          "id": "Property_EnableAgentTunnel",
+          "text": "Enabled"
+        },
+        {
+          "id": "Property_AgentTunnelPort",
+          "text": "UDP Port"
+        },
+        {
           "id": "Property_Directory",
           "text": "Directory"
         },
@@ -601,6 +613,14 @@
           {
             "id": "EnableAccessOverTheInternetUsingNgrok",
             "text": "Enable access over the internet using ngrok"
+          },
+          {
+            "id": "EnableAgentTunnel",
+            "text": "Enable Agent Tunnel"
+          },
+          {
+            "id": "AgentTunnelUdpPort",
+            "text": "UDP port"
           },
           {
             "id": "EnableTheGatewayWebInterface",

--- a/package/WindowsManaged/Resources/Strings_fr-FR.json
+++ b/package/WindowsManaged/Resources/Strings_fr-FR.json
@@ -338,6 +338,10 @@
           "text": "ngrok"
         },
         {
+          "id": "Group_AgentTunnel",
+          "text": "Agent Tunnel"
+        },
+        {
           "id": "Group_ExternalAccess",
           "text": "Accès externe"
         },
@@ -434,6 +438,14 @@
         {
           "id": "Property_NgrokRemoteAddress",
           "text": "Adresse TCP"
+        },
+        {
+          "id": "Property_EnableAgentTunnel",
+          "text": "Activé"
+        },
+        {
+          "id": "Property_AgentTunnelPort",
+          "text": "Port UDP"
         },
         {
           "id": "Property_Directory",
@@ -662,6 +674,14 @@
           {
             "id": "EnableAccessOverTheInternetUsingNgrok",
             "text": "Autoriser l'accès Web via ngrok."
+          },
+          {
+            "id": "EnableAgentTunnel",
+            "text": "Activer Agent Tunnel"
+          },
+          {
+            "id": "AgentTunnelUdpPort",
+            "text": "Port UDP"
           },
           {
             "id": "EnableTheGatewayWebInterface",


### PR DESCRIPTION
Adds an Agent Tunnel option to the Gateway installer.

Administrators can enable it during initial configuration.
The UDP listening port defaults to 4433 and can be changed.