### PR TITLE
ci: build npm libraries without the full webapp

### DIFF
--- a/.github/workflows/publish-libraries.yml
+++ b/.github/workflows/publish-libraries.yml
@@ -121,8 +121,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          cache: 'pnpm'
-          cache-dependency-path: 'webapp/pnpm-lock.yaml'
 
       - name: Build
         run: |

--- a/webapp/packages/multi-video-player/build.ps1
+++ b/webapp/packages/multi-video-player/build.ps1
@@ -8,6 +8,11 @@ try
 {
 	pnpm install --frozen-lockfile --filter "@devolutions/multi-video-player..."
 
+	if ($LASTEXITCODE -ne 0)
+	{
+		throw "pnpm install failed with exit code $LASTEXITCODE"
+	}
+
 	pnpm --filter @devolutions/multi-video-player... build
 
 	Set-Location -Path ./dist/

--- a/webapp/packages/multi-video-player/build.ps1
+++ b/webapp/packages/multi-video-player/build.ps1
@@ -6,7 +6,7 @@ Push-Location -Path $PSScriptRoot
 
 try
 {
-	pnpm install
+	pnpm install --frozen-lockfile --filter "@devolutions/multi-video-player..."
 
 	pnpm --filter @devolutions/multi-video-player... build
 

--- a/webapp/packages/session-recording-log/build.ps1
+++ b/webapp/packages/session-recording-log/build.ps1
@@ -8,6 +8,11 @@ try
 {
 	pnpm install --frozen-lockfile --filter "@devolutions/session-recording-log..."
 
+	if ($LASTEXITCODE -ne 0)
+	{
+		throw "pnpm install failed with exit code $LASTEXITCODE"
+	}
+
 	pnpm --filter @devolutions/session-recording-log... build
 
 	Set-Location -Path ./dist/

--- a/webapp/packages/session-recording-log/build.ps1
+++ b/webapp/packages/session-recording-log/build.ps1
@@ -6,7 +6,7 @@ Push-Location -Path $PSScriptRoot
 
 try
 {
-	pnpm install
+	pnpm install --frozen-lockfile --filter "@devolutions/session-recording-log..."
 
 	pnpm --filter @devolutions/session-recording-log... build
 

--- a/webapp/packages/shadow-player/build.ps1
+++ b/webapp/packages/shadow-player/build.ps1
@@ -6,7 +6,7 @@ Push-Location -Path $PSScriptRoot
 
 try
 {
-	pnpm install
+	pnpm install --frozen-lockfile --filter "@devolutions/shadow-player..."
 
 	pnpm --filter @devolutions/shadow-player... build
 

--- a/webapp/packages/shadow-player/build.ps1
+++ b/webapp/packages/shadow-player/build.ps1
@@ -8,6 +8,11 @@ try
 {
 	pnpm install --frozen-lockfile --filter "@devolutions/shadow-player..."
 
+	if ($LASTEXITCODE -ne 0)
+	{
+		throw "pnpm install failed with exit code $LASTEXITCODE"
+	}
+
 	pnpm --filter @devolutions/shadow-player... build
 
 	Set-Location -Path ./dist/

--- a/webapp/packages/web-recorder/build.ps1
+++ b/webapp/packages/web-recorder/build.ps1
@@ -8,6 +8,11 @@ try
 {
 	pnpm install --frozen-lockfile --filter "@devolutions/web-recorder..."
 
+	if ($LASTEXITCODE -ne 0)
+	{
+		throw "pnpm install failed with exit code $LASTEXITCODE"
+	}
+
 	pnpm --filter @devolutions/web-recorder... build
 
 	Set-Location -Path ./dist/

--- a/webapp/packages/web-recorder/build.ps1
+++ b/webapp/packages/web-recorder/build.ps1
@@ -6,7 +6,7 @@ Push-Location -Path $PSScriptRoot
 
 try
 {
-	pnpm install
+	pnpm install --frozen-lockfile --filter "@devolutions/web-recorder..."
 
 	pnpm --filter @devolutions/web-recorder... build
 


### PR DESCRIPTION
The npm library jobs installed the full webapp workspace, which pulled in the private `@devolutions/icons` package even though the published libraries do not use it. This made releases depend on a warm pnpm cache.

Install only each library and its workspace dependencies, remove the shared pnpm cache configuration, and stop immediately when installation fails.