### PR TITLE
fix(agent)!: remove PSU hub registration

### DIFF
--- a/devolutions-agent/docker/devolutions-agent-entrypoint.sh
+++ b/devolutions-agent/docker/devolutions-agent-entrypoint.sh
@@ -8,21 +8,6 @@ json_escape() {
 }
 
 if [ -n "${PSU_SERVER_URL:-}" ] && [ -n "${PSU_APP_TOKEN:-}" ]; then
-    IFS=',' read -r -a hubs <<< "${PSU_HUBS:-}"
-    hubs_json=""
-    for hub in "${hubs[@]}"; do
-        hub="${hub#${hub%%[![:space:]]*}}"
-        hub="${hub%${hub##*[![:space:]]}}"
-        if [ -z "${hub}" ]; then
-            continue
-        fi
-
-        if [ -n "${hubs_json}" ]; then
-            hubs_json="${hubs_json}, "
-        fi
-        hubs_json="${hubs_json}\"$(json_escape "${hub}")\""
-    done
-
     psu_agent_config=$(cat <<EOF
   "PsuAgent": {
     "Enabled": true,
@@ -30,7 +15,6 @@ if [ -n "${PSU_SERVER_URL:-}" ] && [ -n "${PSU_APP_TOKEN:-}" ]; then
     "AgentId": "$(json_escape "${PSU_AGENT_ID:-devo-agent-linux}")",
     "DisplayName": "$(json_escape "${PSU_DISPLAY_NAME:-Devolutions Agent Linux}")",
     "AppToken": "$(json_escape "${PSU_APP_TOKEN}")",
-    "Hubs": [ ${hubs_json} ],
     "PowerShell": {
       "ExecutablePath": "$(json_escape "${PSU_POWERSHELL_EXECUTABLE:-${POWERSHELL_EXECUTABLE:-pwsh}}")"
     }

--- a/devolutions-agent/proto/psu_agent.proto
+++ b/devolutions-agent/proto/psu_agent.proto
@@ -51,14 +51,12 @@ message RegisterAgent {
   string architecture = 6;
   string agent_version = 7;
   string protocol_version = 8;
-  repeated string hubs = 9;
-  repeated AgentCapability capabilities = 10;
-  repeated PowerShellRuntime powershell_runtimes = 11;
+  repeated AgentCapability capabilities = 9;
+  repeated PowerShellRuntime powershell_runtimes = 10;
 }
 
 message RegisterAccepted {
   string connection_id = 1;
-  repeated string accepted_hubs = 2;
 }
 
 message AgentCapability {

--- a/devolutions-agent/src/config.rs
+++ b/devolutions-agent/src/config.rs
@@ -112,7 +112,6 @@ pub struct PsuConf {
     pub agent_id: Option<String>,
     pub display_name: Option<String>,
     pub app_token: String,
-    pub hubs: Vec<String>,
     pub powershell: dto::PsuPowerShellConf,
 }
 
@@ -139,7 +138,6 @@ impl TryFrom<dto::PsuConf> for Option<PsuConf> {
             agent_id: conf.agent_id,
             display_name: conf.display_name,
             app_token,
-            hubs: conf.hubs,
             powershell: conf.powershell,
         }))
     }
@@ -608,10 +606,6 @@ pub mod dto {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         pub app_token: Option<String>,
 
-        /// Hubs/queues advertised during registration.
-        #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        pub hubs: Vec<String>,
-
         /// PowerShell child process configuration.
         #[serde(
             default,
@@ -969,7 +963,6 @@ mod tests {
                 "AgentId": "agent-01",
                 "DisplayName": "Agent 01",
                 "AppToken": "app-token",
-                "Hubs": ["default"],
                 "PowerShell": {
                     "VersionSelector": "7.5"
                 }

--- a/devolutions-agent/src/psu_agent/mod.rs
+++ b/devolutions-agent/src/psu_agent/mod.rs
@@ -293,7 +293,6 @@ impl PsuAgent {
                 architecture: std::env::consts::ARCH.to_owned(),
                 agent_version: env!("CARGO_PKG_VERSION").to_owned(),
                 protocol_version: PROTOCOL_VERSION.to_owned(),
-                hubs: self.conf.hubs.clone(),
                 capabilities: vec![
                     AgentCapability {
                         name: CAPABILITY_JOB_EXECUTION.to_owned(),
@@ -464,7 +463,6 @@ mod tests {
             agent_id: Some("agent-01".to_owned()),
             display_name: None,
             app_token: "literal-token".to_owned(),
-            hubs: Vec::new(),
             powershell: dto::PsuPowerShellConf {
                 executable_path: Some("missing-pwsh".into()),
                 ..dto::PsuPowerShellConf::default()

--- a/package/AgentLinux/README.md
+++ b/package/AgentLinux/README.md
@@ -29,7 +29,6 @@ docker run --rm `
 | `PSU_APP_TOKEN` | Empty |
 | `PSU_AGENT_ID` | `devolutions-agent-linux` |
 | `PSU_DISPLAY_NAME` | `Devolutions Agent Linux` |
-| `PSU_HUBS` | Empty |
 | `PSU_POWERSHELL_EXECUTABLE` | `/var/lib/devolutions-agent/.pwsh/bin/pwsh` |
 
 Build one image locally:


### PR DESCRIPTION
Remove obsolete hub fields from the pre-release PSU gRPC protocol.
Drop the corresponding container configuration and documentation.

Computer groups now provide this targeting behavior.
Compact the remaining RegisterAgent fields.
Mixed old and new peers are intentionally incompatible.

Changelog: ignore

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>