### PR TITLE
fix(dgw): reject null event source handles

### DIFF
--- a/crates/sysevent-winevent/src/lib.rs
+++ b/crates/sysevent-winevent/src/lib.rs
@@ -25,7 +25,7 @@ impl WinEvent {
         // SAFETY: Proper UTF-16, null-terminated string.
         let handle = unsafe { EventLog::RegisterEventSourceW(std::ptr::null(), source_name_utf16.as_ptr()) };
 
-        if handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+        if event_source_registration_failed(handle) {
             return Err(SysEventError::Platform(format!(
                 "failed to register event source '{source_name}'"
             )));
@@ -141,6 +141,10 @@ impl Drop for WinEvent {
     }
 }
 
+fn event_source_registration_failed(handle: windows_sys::Win32::Foundation::HANDLE) -> bool {
+    handle.is_null()
+}
+
 fn severity_to_event_type(severity: Severity) -> u16 {
     match severity {
         Severity::Critical => EventLog::EVENTLOG_ERROR_TYPE,
@@ -158,6 +162,14 @@ fn to_null_terminated_utf16(input: &str) -> Vec<u16> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn event_source_registration_failure_sentinel() {
+        assert!(event_source_registration_failed(std::ptr::null_mut()));
+        assert!(!event_source_registration_failed(
+            windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
+        ));
+    }
 
     #[test]
     fn severity_to_event_type_mapping() {

--- a/crates/sysevent-winevent/src/lib.rs
+++ b/crates/sysevent-winevent/src/lib.rs
@@ -25,7 +25,7 @@ impl WinEvent {
         // SAFETY: Proper UTF-16, null-terminated string.
         let handle = unsafe { EventLog::RegisterEventSourceW(std::ptr::null(), source_name_utf16.as_ptr()) };
 
-        if event_source_registration_failed(handle) {
+        if handle.is_null() {
             return Err(SysEventError::Platform(format!(
                 "failed to register event source '{source_name}'"
             )));

--- a/crates/sysevent-winevent/src/lib.rs
+++ b/crates/sysevent-winevent/src/lib.rs
@@ -164,14 +164,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn event_source_registration_failure_sentinel() {
-        assert!(event_source_registration_failed(std::ptr::null_mut()));
-        assert!(!event_source_registration_failed(
-            windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE
-        ));
-    }
-
-    #[test]
     fn severity_to_event_type_mapping() {
         assert_eq!(
             severity_to_event_type(Severity::Critical),

--- a/crates/sysevent-winevent/src/lib.rs
+++ b/crates/sysevent-winevent/src/lib.rs
@@ -141,10 +141,6 @@ impl Drop for WinEvent {
     }
 }
 
-fn event_source_registration_failed(handle: windows_sys::Win32::Foundation::HANDLE) -> bool {
-    handle.is_null()
-}
-
 fn severity_to_event_type(severity: Severity) -> u16 {
     match severity {
         Severity::Critical => EventLog::EVENTLOG_ERROR_TYPE,


### PR DESCRIPTION
Treats the null handle returned by RegisterEventSourceW as a registration failure, preventing invalid event source handles from being retained and used for Windows Event Log writes.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>